### PR TITLE
feat(creator/earn): 50/50 A/B test for bunny stories intro

### DIFF
--- a/app/creator/earn/CreatorEarnPage.tsx
+++ b/app/creator/earn/CreatorEarnPage.tsx
@@ -11,6 +11,7 @@ import HeroSection from "@/components/creator/earn/HeroSection";
 import StoriesContainer from "@/components/creator/earn/stories/StoriesContainer";
 import ReferralBanner from "@/components/creator/earn/ReferralBanner";
 import {PROMO_CONFIG, isPromoActiveAt} from "@/lib/promo/config";
+import {track} from "@/lib/analytics/track";
 
 const ValueProposition = dynamic(() => import("@/components/creator/earn/ValueProposition"));
 const BenefitsSection = dynamic(() => import("@/components/creator/earn/BenefitsSection"));
@@ -38,18 +39,27 @@ function CreatorEarnPageContent() {
     }
     // Don't force English - let the user's selection persist
 
-    // Check if user has already viewed stories
     const storiesViewed = sessionStorage.getItem("storiesViewed");
     const referralCode = searchParams.get("ref");
 
-    if (storiesViewed === "true" || referralCode) {
-      // Skip stories for returning visitors OR referral visitors
+    if (referralCode || storiesViewed === "true") {
       setShowLandingPage(true);
       setShowStories(false);
     } else {
-      // Show stories for first-time visitors
-      setShowStories(true);
-      setShowLandingPage(false);
+      const variant = Math.random() < 0.5 ? "show_stories" : "no_stories";
+      track("earn_stories_ab_exposure", {
+        test_name: "earn_stories_50_50",
+        variant,
+      });
+
+      if (variant === "show_stories") {
+        setShowStories(true);
+        setShowLandingPage(false);
+      } else {
+        sessionStorage.setItem("storiesViewed", "true");
+        setShowLandingPage(true);
+        setShowStories(false);
+      }
     }
 
     setIsLoading(false);


### PR DESCRIPTION
## Summary
- Adds a 50/50 coin flip on `/creator/earn` so half of organic visitors see the 4-story bunny intro and half go straight to the landing page.
- Fires a single `earn_stories_ab_exposure` event to GA4 (via `dataLayer` → GTM) with `{ test_name: "earn_stories_50_50", variant: "show_stories" | "no_stories" }` for downstream funnel analysis.
- Referral visitors (`?ref=...`) and returning-session users still bypass entirely and are excluded from the test population so variant-level conversion math stays clean.
- Within a single session the bucket is locked (we set `sessionStorage.storiesViewed = "true"` on the `no_stories` arm) so a refresh doesn't reroll and surprise the user with stories.

Single file changed: `app/creator/earn/CreatorEarnPage.tsx`. No new helpers, no env vars, no GTM/GA dashboard plumbing in this PR — the event will appear in GA4 DebugView automatically once deployed.

## Test plan
- [ ] `yarn dev` and open `http://localhost:3000/creator/earn` in fresh incognito windows; stories appear ~50% of the time, landing page directly the rest of the time.
- [ ] In a session bucketed to `no_stories`, refreshing the page does **not** flip back to showing stories.
- [ ] On a fresh session, exactly one `earn_stories_ab_exposure` event lands in `window.dataLayer` with the expected `test_name` and `variant` params.
- [ ] `/creator/earn?ref=foo` skips stories and fires **no** `earn_stories_ab_exposure` event (referral visitors stay out of the test).
- [ ] Refreshing within the same session fires **no** additional `earn_stories_ab_exposure` event (sessionStorage gate short-circuits before the coin flip).
- [ ] Post-deploy: confirm `earn_stories_ab_exposure` shows up in GA4 DebugView with both variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)