### PR TITLE
fix(blog): open LinkedIn app on mobile share with prefilled clipboard

### DIFF
--- a/components/blog/MetaShareButton.tsx
+++ b/components/blog/MetaShareButton.tsx
@@ -51,35 +51,50 @@ export default function MetaShareButton({
     );
   };
 
-  const handleLinkedIn = () => {
+  const handleLinkedIn = async () => {
     track("blog_share_click", { platform: "linkedin", slug });
     const webUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`;
+    const caption = `${title} ${url}`;
 
     if (typeof navigator === "undefined") {
       openShareUrl(webUrl);
       return;
     }
 
-    const ua = navigator.userAgent;
-    const isAndroid = /Android/i.test(ua);
-    const isIOS = /iPhone|iPad|iPod/i.test(ua);
+    const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 
-    if (isAndroid) {
-      const intentUrl =
-        `intent://shareArticle?mini=true&url=${encodeURIComponent(url)}` +
-        `&title=${encodeURIComponent(title)}` +
-        `#Intent;scheme=linkedin;package=com.linkedin.android;` +
-        `S.browser_fallback_url=${encodeURIComponent(webUrl)};end`;
-      window.location.href = intentUrl;
+    if (!isMobile) {
+      openShareUrl(webUrl);
       return;
     }
 
-    if (isIOS) {
-      const appUrl =
-        `linkedin://shareArticle?mini=true` +
-        `&url=${encodeURIComponent(url)}` +
-        `&title=${encodeURIComponent(title)}`;
+    let copied = false;
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(caption);
+        copied = true;
+      } else {
+        const textarea = document.createElement("textarea");
+        textarea.value = caption;
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        copied = document.execCommand("copy");
+        document.body.removeChild(textarea);
+      }
+    } catch {
+      copied = false;
+    }
 
+    if (copied) {
+      toast.success("Link copied! Paste it in your LinkedIn post.");
+    } else {
+      toast.error("Couldn't copy link");
+    }
+
+    window.setTimeout(() => {
+      const appUrl = "linkedin://";
       let didHide = false;
       const onVisibilityChange = () => {
         if (document.hidden) didHide = true;
@@ -89,18 +104,12 @@ export default function MetaShareButton({
       window.location.href = appUrl;
 
       window.setTimeout(() => {
-        document.removeEventListener(
-          "visibilitychange",
-          onVisibilityChange
-        );
+        document.removeEventListener("visibilitychange", onVisibilityChange);
         if (!didHide && !document.hidden) {
           window.location.href = webUrl;
         }
       }, 1500);
-      return;
-    }
-
-    openShareUrl(webUrl);
+    }, 1500);
   };
 
   const handleX = () => {


### PR DESCRIPTION
## Summary
- LinkedIn share from the blog post share menu was opening the browser on mobile instead of the LinkedIn app, because the handler used `linkedin://shareArticle` (iOS) and a `shareArticle` Android intent — neither of which the current LinkedIn app honors. Both fell through the visibility-timeout fallback to the web URL.
- Switched the LinkedIn handler in [components/blog/MetaShareButton.tsx](components/blog/MetaShareButton.tsx) to mirror the existing Instagram pattern: copy a WhatsApp-style `${title} ${url}` template to the clipboard, show a toast, then deep-link to `linkedin://` (which the app reliably handles on both iOS and Android). Falls back to the share-offsite web URL if the app isn't installed.
- Desktop behavior is unchanged — opens `https://www.linkedin.com/sharing/share-offsite/?url=...` in a new tab.

## Why this approach
LinkedIn deliberately blocks prefilled commentary text in their share dialog (the `?text=` / `?summary=` params were removed in 2018, and the `linkedin://shareArticle` deep link no longer prefills on the current mobile app). Clipboard + open-app is the most reliable way to give users a one-tap "open the LinkedIn app, paste the template" flow without a download or native integration.

## Test plan
- [ ] On Android: open a blog post → tap share → tap LinkedIn → confirm toast appears, LinkedIn app opens, long-press in composer pastes `<title> <url>`
- [ ] On iOS: same as above
- [ ] On desktop: confirm LinkedIn opens `share-offsite` in a new tab (unchanged)
- [ ] On a device without LinkedIn installed: confirm fallback to `https://www.linkedin.com/sharing/share-offsite/?url=...` after ~1.5s
- [ ] Verify `blog_share_click` analytics still fires with `platform: "linkedin"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)