### PR TITLE
feat: Cloud Run deployment configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.next
+.git
+.gitignore
+*.md
+.env*
+.vscode
+.idea
+.vercel
+.DS_Store

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Build-time (NEXT_PUBLIC_* — baked into JS bundle)
+NEXT_PUBLIC_API_BASE=https://app-api.sparkonomy.com
+NEXT_PUBLIC_META_PIXEL_ID=
+NEXT_PUBLIC_GA_MEASUREMENT_ID=
+NEXT_PUBLIC_CLARITY_PROJECT_ID=
+
+# Runtime (server-side only — injected via Secret Manager)
+WORDPRESS_USERNAME=
+WORDPRESS_APP_PASSWORD=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM node:20-alpine AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+# ---
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG NEXT_PUBLIC_API_BASE
+ARG NEXT_PUBLIC_META_PIXEL_ID
+ARG NEXT_PUBLIC_GA_MEASUREMENT_ID
+ARG NEXT_PUBLIC_CLARITY_PROJECT_ID
+
+ENV NEXT_PUBLIC_API_BASE=$NEXT_PUBLIC_API_BASE
+ENV NEXT_PUBLIC_META_PIXEL_ID=$NEXT_PUBLIC_META_PIXEL_ID
+ENV NEXT_PUBLIC_GA_MEASUREMENT_ID=$NEXT_PUBLIC_GA_MEASUREMENT_ID
+ENV NEXT_PUBLIC_CLARITY_PROJECT_ID=$NEXT_PUBLIC_CLARITY_PROJECT_ID
+
+RUN yarn build
+
+# ---
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,69 @@
+substitutions:
+  _SERVICE_NAME: spark-landing-frontend
+  _REGION: asia-south1
+  _MIN_INSTANCES: '1'
+  _MAX_INSTANCES: '2'
+  _ENV: prod
+  _AR_REPO: us-central1-docker.pkg.dev/sparkonomy/spark-landing
+
+steps:
+  # Build Docker image with build-time secrets
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        docker build \
+          --build-arg NEXT_PUBLIC_API_BASE=$$NEXT_PUBLIC_API_BASE \
+          --build-arg NEXT_PUBLIC_META_PIXEL_ID=$$NEXT_PUBLIC_META_PIXEL_ID \
+          --build-arg NEXT_PUBLIC_GA_MEASUREMENT_ID=$$NEXT_PUBLIC_GA_MEASUREMENT_ID \
+          --build-arg NEXT_PUBLIC_CLARITY_PROJECT_ID=$$NEXT_PUBLIC_CLARITY_PROJECT_ID \
+          -t ${_AR_REPO}/${_SERVICE_NAME}:${COMMIT_SHA} \
+          -t ${_AR_REPO}/${_SERVICE_NAME}:latest \
+          .
+    secretEnv:
+      - 'NEXT_PUBLIC_API_BASE'
+      - 'NEXT_PUBLIC_META_PIXEL_ID'
+      - 'NEXT_PUBLIC_GA_MEASUREMENT_ID'
+      - 'NEXT_PUBLIC_CLARITY_PROJECT_ID'
+
+  # Push image to Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', '${_AR_REPO}/${_SERVICE_NAME}']
+
+  # Deploy to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - '${_SERVICE_NAME}'
+      - '--image=${_AR_REPO}/${_SERVICE_NAME}:${COMMIT_SHA}'
+      - '--region=${_REGION}'
+      - '--port=3000'
+      - '--memory=512Mi'
+      - '--cpu=1'
+      - '--min-instances=${_MIN_INSTANCES}'
+      - '--max-instances=${_MAX_INSTANCES}'
+      - '--allow-unauthenticated'
+      - '--update-secrets=WORDPRESS_USERNAME=WORDPRESS_USERNAME:latest,WORDPRESS_APP_PASSWORD=WORDPRESS_APP_PASSWORD:latest'
+
+availableSecrets:
+  secretManager:
+    - versionName: projects/sparkonomy/secrets/${_ENV}_NEXT_PUBLIC_API_BASE/versions/latest
+      env: 'NEXT_PUBLIC_API_BASE'
+    - versionName: projects/sparkonomy/secrets/${_ENV}_NEXT_PUBLIC_META_PIXEL_ID/versions/latest
+      env: 'NEXT_PUBLIC_META_PIXEL_ID'
+    - versionName: projects/sparkonomy/secrets/${_ENV}_NEXT_PUBLIC_GA_MEASUREMENT_ID/versions/latest
+      env: 'NEXT_PUBLIC_GA_MEASUREMENT_ID'
+    - versionName: projects/sparkonomy/secrets/${_ENV}_NEXT_PUBLIC_CLARITY_PROJECT_ID/versions/latest
+      env: 'NEXT_PUBLIC_CLARITY_PROJECT_ID'
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: '1200s'
+
+images:
+  - '${_AR_REPO}/${_SERVICE_NAME}:${COMMIT_SHA}'
+  - '${_AR_REPO}/${_SERVICE_NAME}:latest'

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type {NextConfig} from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+    output: "standalone",
     experimental: {
         // NOTE: experimental.optimizeCss is intentionally NOT set here.
         // In Next 16 it is wired only into the Pages Router post-process


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfile with standalone Next.js output for minimal container images
- Add `cloudbuild.yaml` with Secret Manager integration and dual-environment support (prod/dev)
- Add `output: "standalone"` to `next.config.ts`
- Add `.dockerignore` and `.env.example`

## Environment Setup
- **Prod trigger** (`main`): `_ENV=prod`, `_MIN_INSTANCES=1`, `_MAX_INSTANCES=2`
- **Dev trigger** (`dev`): `_ENV=dev`, `_MIN_INSTANCES=0`, `_MAX_INSTANCES=1`

## Secrets Required in Secret Manager
| Secret | Environment |
|---|---|
| `prod_NEXT_PUBLIC_API_BASE` | Build-time |
| `prod_NEXT_PUBLIC_META_PIXEL_ID` | Build-time |
| `prod_NEXT_PUBLIC_GA_MEASUREMENT_ID` | Build-time |
| `prod_NEXT_PUBLIC_CLARITY_PROJECT_ID` | Build-time |
| `dev_NEXT_PUBLIC_API_BASE` | Build-time |
| `dev_NEXT_PUBLIC_META_PIXEL_ID` | Build-time |
| `dev_NEXT_PUBLIC_GA_MEASUREMENT_ID` | Build-time |
| `dev_NEXT_PUBLIC_CLARITY_PROJECT_ID` | Build-time |
| `WORDPRESS_USERNAME` | Runtime (shared) |
| `WORDPRESS_APP_PASSWORD` | Runtime (shared) |

## Test plan
- [ ] Verify `yarn build` succeeds with `output: "standalone"`
- [ ] Test local Docker build and run
- [ ] Create Artifact Registry repo in `us-central1`
- [ ] Create secrets in Secret Manager
- [ ] Run manual Cloud Build submission
- [ ] Verify Cloud Run service is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)