### PR TITLE
feat: defer CookieYes banner by 15s

### DIFF
--- a/components/CookieConsentScript.tsx
+++ b/components/CookieConsentScript.tsx
@@ -1,8 +1,18 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Script from "next/script";
 
 export default function CookieConsentScript() {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setReady(true), 15_000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!ready) return null;
+
   return (
     <Script
       async


### PR DESCRIPTION
## Summary
- Delays rendering the CookieYes consent script by 15 seconds after page mount to reduce main-thread contention during initial load
- GA, GTM, and Clarity are unaffected — they load independently with consent defaults already granted inline

## Test plan
- [ ] Verify CookieYes banner appears ~15s after page load
- [ ] Confirm GA/GTM events fire immediately on page load (check Network tab)
- [ ] Confirm Clarity session recording starts as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)