### PR TITLE
feat(creator): founder-invite referral landing page

### DIFF
--- a/app/creator/[founderFriend]/CreatorFounderInvitePage.tsx
+++ b/app/creator/[founderFriend]/CreatorFounderInvitePage.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Suspense, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import dynamic from "next/dynamic";
+import "@/lib/i18n";
+import Navigation from "@/components/creator/earn/Navigation";
+import ReferralBanner from "@/components/creator/earn/ReferralBanner";
+import FounderInviteHero from "@/components/creator/founder-invite/FounderInviteHero";
+import FounderInviteBackdrop from "@/components/creator/founder-invite/FounderInviteBackdrop";
+import InvitationOnlyBanner from "@/components/creator/founder-invite/InvitationOnlyBanner";
+import { SignupProvider } from "@/components/creator/promo/SignupContext";
+import type { FounderReferral } from "@/lib/data/founder-referrals";
+
+// Below-the-fold sections are code-split. Mirrors /creator/promo so the
+// founder-invite page reuses the same JS chunks once the user navigates
+// between funnels.
+const ThreeStepSection = dynamic(() => import("@/components/creator/promo/ThreeStepSection"));
+const PhoneMockupSection = dynamic(() => import("@/components/creator/promo/PhoneMockupSection"));
+const TestimonialsSection = dynamic(() => import("@/components/creator/earn/TestimonialsSection"));
+const AdvantageSection = dynamic(() => import("@/components/creator/earn/AdvantageSection"));
+const FAQSection = dynamic(() => import("@/components/creator/earn/FAQSection"));
+const EarnFooter = dynamic(() => import("@/components/creator/earn/EarnFooter"));
+
+interface Props {
+  data: FounderReferral;
+}
+
+export default function CreatorFounderInvitePage({ data }: Props) {
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    // Founder-invite copy is Hinglish across both locales (per the project
+    // memory rule). Force hi-Latn at mount so the blogs/earn detector chain
+    // doesn't bounce back to en mid-render.
+    if (i18n.language !== "hi-Latn") {
+      i18n.changeLanguage("hi-Latn");
+    }
+  }, [i18n]);
+
+  return (
+    <SignupProvider>
+      <main className="relative min-h-screen bg-black overflow-hidden">
+        <FounderInviteBackdrop />
+
+        <div className="relative z-10">
+          <Navigation
+            showLanguageSwitcher
+            showCTA={false}
+            namespace="creatorPromo"
+          />
+          <InvitationOnlyBanner />
+          <Suspense fallback={null}>
+            <ReferralBanner namespace="creatorPromo" />
+          </Suspense>
+          <FounderInviteHero data={data} />
+          <ThreeStepSection />
+          <PhoneMockupSection />
+          <TestimonialsSection
+            namespace="creatorPromo"
+            trackingId="founder_invite_testimonials"
+            disableSlideEntryAnimation
+          />
+          <AdvantageSection
+            variant="promo"
+            namespace="creatorPromo"
+            trackingId="founder_invite_advantage"
+          />
+          {/* Marker picked up by FounderInviteBackdrop — once this wrapper
+              enters the viewport, the backdrop fades in a black overlay so
+              the FAQ + footer area sits on a solid black ground. */}
+          <div data-backdrop-fade-trigger>
+            <FAQSection
+              namespace="creatorPromo"
+              trackingId="founder_invite_faq"
+              analyticsEvent="founder_invite_faq_toggle"
+              expandInline
+            />
+          </div>
+          <EarnFooter />
+        </div>
+      </main>
+    </SignupProvider>
+  );
+}

--- a/app/creator/[founderFriend]/loading.tsx
+++ b/app/creator/[founderFriend]/loading.tsx
@@ -1,0 +1,40 @@
+// Skeleton mirrors the FounderInviteHero layout: friend avatar, divider,
+// headline, founder quote card, "WHAT IS SPARKONOMY?" intro, signup card.
+// Tone-matched to the black backdrop (subtle white shimmer instead of the
+// slate shimmer used on the blog skeleton).
+export default function Loading() {
+  const shimmer =
+    "animate-shimmer bg-gradient-to-r from-white/5 via-white/15 to-white/5 bg-[length:200%_100%]";
+
+  return (
+    <main className="relative min-h-screen bg-black overflow-hidden">
+      <div className="relative z-10 max-w-[440px] mx-auto px-5 pt-10 pb-16 space-y-6">
+        {/* friend avatar pill */}
+        <div className="flex flex-col items-center gap-3">
+          <div className={`w-[72px] h-[72px] rounded-full ${shimmer}`} />
+          <div className={`h-6 w-44 rounded-full ${shimmer}`} />
+        </div>
+        {/* divider */}
+        <div className={`h-3 w-56 mx-auto rounded ${shimmer}`} />
+        {/* headline */}
+        <div className="space-y-2">
+          <div className={`h-7 w-full rounded ${shimmer}`} />
+          <div className={`h-7 w-5/6 mx-auto rounded ${shimmer}`} />
+          <div className={`h-7 w-2/3 mx-auto rounded ${shimmer}`} />
+        </div>
+        {/* quote card */}
+        <div className={`h-[112px] w-full rounded-[20px] ${shimmer}`} />
+        {/* what-is heading + body */}
+        <div className="space-y-2">
+          <div className={`h-3 w-44 rounded ${shimmer}`} />
+          <div className={`h-6 w-2/3 rounded ${shimmer}`} />
+          <div className={`h-4 w-full rounded ${shimmer}`} />
+          <div className={`h-4 w-full rounded ${shimmer}`} />
+          <div className={`h-4 w-3/4 rounded ${shimmer}`} />
+        </div>
+        {/* signup card */}
+        <div className={`h-[420px] w-full rounded-[24px] ${shimmer}`} />
+      </div>
+    </main>
+  );
+}

--- a/app/creator/[founderFriend]/page.tsx
+++ b/app/creator/[founderFriend]/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import {
+  getAllFounderReferralSlugs,
+  getFounderReferral,
+} from "@/lib/data/founder-referrals";
+import CreatorFounderInvitePage from "./CreatorFounderInvitePage";
+
+type Props = {
+  params: Promise<{ founderFriend: string }>;
+};
+
+export function generateStaticParams() {
+  return getAllFounderReferralSlugs().map((founderFriend) => ({ founderFriend }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { founderFriend } = await params;
+  const data = getFounderReferral(founderFriend);
+  if (!data) return {};
+
+  const title = `${data.friend.name}, ${data.founder.name} from Sparkonomy has a gift for you`;
+  const description = `Exclusively for ${data.friend.name}'s referrals — first year free.`;
+  const url = `https://www.sparkonomy.com/creator/${data.slug}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: { title, description, url },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+export default async function Page({ params }: Props) {
+  const { founderFriend } = await params;
+  const data = getFounderReferral(founderFriend);
+  if (!data) notFound();
+  return <CreatorFounderInvitePage data={data} />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -85,6 +85,30 @@ body {
     }
 }
 
+/* Founder-invite backdrop — paint hints for the 390-px-wide stage and the
+   absolutely-positioned blobs inside it. Coordinates and gradients are set
+   inline from FounderInviteBackdrop.tsx (ported from Figma); these classes
+   only carry the GPU-promotion + ellipse hints. */
+.founder-bg-stage {
+    will-change: transform;
+    transform: translate3d(0, 0, 0);
+    -webkit-backface-visibility: hidden;
+}
+.founder-bg-blob {
+    position: absolute;
+    border-radius: 50%;
+    will-change: transform;
+    transform: translate3d(0, 0, 0);
+    -webkit-backface-visibility: hidden;
+}
+@media (max-width: 768px) {
+    /* Cap the largest blurs on mobile so painting stays cheap on lower-end
+       GPUs. The selectors target the inline filter strings emitted by the
+       BLOBS array — see FounderInviteBackdrop.tsx for the source values. */
+    .founder-bg-blob[style*="blur(150px)"] { filter: blur(80px) !important; }
+    .founder-bg-blob[style*="blur(100px)"] { filter: blur(60px) !important; }
+}
+
 .cta-button-gradient {
     background: linear-gradient(162deg, rgba(221, 42, 123, 0.4) 0%, rgba(151, 71, 255, 0.4) 64%);
 }

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -24,7 +24,20 @@ export const LanguageSwitcher = ({ className }: LanguageSwitcherProps) => {
     { code: "hi-Latn", label: "Hinglish" },
   ];
 
-  const currentLang = i18n.language?.startsWith("hi") ? "hi-Latn" : "en";
+  // Hydration gate: i18n on the server is locked to lng="en" (see lib/i18n.ts),
+  // but on the client the LanguageDetector may have already flipped the
+  // language to hi-Latn from localStorage before the first React render.
+  // Reading i18n.language during hydration would then produce "Hinglish"
+  // against an "English" SSR HTML and trigger a hydration mismatch. We hold
+  // the rendered label at the SSR default until after mount, then let the
+  // real language take over on the next render.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const currentLang =
+    mounted && i18n.language?.startsWith("hi") ? "hi-Latn" : "en";
   const currentLanguage =
     languages.find((lang) => lang.code === currentLang) || languages[0];
 

--- a/components/creator/founder-invite/FounderInviteBackdrop.tsx
+++ b/components/creator/founder-invite/FounderInviteBackdrop.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Backdrop for the founder-invite page. Two stacked fixed layers pinned to
+// the viewport:
+//
+//   1. Base — the designer's HTML mockup gradient (5 radials + linear),
+//      shown for the whole page.
+//   2. Black fade overlay — opacity-transitions in once the FAQ section
+//      enters the viewport, painting the bottom band of the viewport black
+//      so the FAQ + footer area sits on a solid ground (matches the
+//      bg-black + top-only-gradient pattern used on /creator/earn).
+//
+// The page marks its FAQ wrapper with data-backdrop-fade-trigger; this
+// component finds it on mount and observes its intersection.
+
+const GRADIENT_BG = [
+  "radial-gradient(ellipse 500px 380px at 10% 4%, rgba(139,75,230,0.42), transparent 65%)",
+  "radial-gradient(ellipse 440px 340px at 92% 12%, rgba(214,58,142,0.48), transparent 60%)",
+  "radial-gradient(ellipse 480px 380px at 50% 45%, rgba(232,80,150,0.52), transparent 65%)",
+  "radial-gradient(ellipse 380px 280px at 6% 80%, rgba(168,37,158,0.42), transparent 70%)",
+  "radial-gradient(ellipse 420px 320px at 94% 90%, rgba(90,30,120,0.35), transparent 65%)",
+  "linear-gradient(180deg, #2A0A3A 0%, #5B1F7A 30%, #A8259E 58%, #D63A8E 75%, #5B1F7A 88%, #2A0A3A 100%)",
+].join(", ");
+
+// Black fade overlay. Transparent in the top half of the viewport so the
+// underlying gradient is fully visible up there; ramps to solid black over
+// the bottom ~55% so the FAQ + footer feel grounded.
+const BLACK_FADE_OVERLAY =
+  "linear-gradient(180deg, transparent 0%, transparent 35%, rgba(0,0,0,0.4) 60%, rgba(0,0,0,0.85) 80%, #000 100%)";
+
+const STAGE_WIDTH = 390;
+
+export default function FounderInviteBackdrop() {
+  // True once the element marked [data-backdrop-fade-trigger] is in view.
+  // Until then the black overlay stays at opacity: 0.
+  const [showBlack, setShowBlack] = useState(false);
+
+  useEffect(() => {
+    const target = document.querySelector("[data-backdrop-fade-trigger]");
+    if (!target) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setShowBlack(entry.isIntersecting),
+      // rootMargin negative-bottom delays the trigger so the fade only
+      // kicks in when the section is meaningfully visible, not when its
+      // top edge first peeks into the viewport.
+      { threshold: 0, rootMargin: "0px 0px -20% 0px" }
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      aria-hidden
+      className="fixed inset-0 z-0 pointer-events-none overflow-hidden"
+    >
+      {/* Base gradient — always rendered. */}
+      <div
+        className="absolute left-1/2 top-0 h-full"
+        style={{
+          width: STAGE_WIDTH,
+          // Inline transform composes the centering shift with GPU-promotion
+          // in a single value so nothing in globals.css can override it.
+          transform: "translate3d(-50%, 0, 0)",
+          backgroundImage: GRADIENT_BG,
+        }}
+      />
+
+      {/* Black-fade overlay — fades in once FAQ is visible. */}
+      <div
+        className="absolute left-1/2 top-0 h-full"
+        style={{
+          width: STAGE_WIDTH,
+          transform: "translate3d(-50%, 0, 0)",
+          backgroundImage: BLACK_FADE_OVERLAY,
+          opacity: showBlack ? 1 : 0,
+          transition: "opacity 600ms ease-out",
+        }}
+      />
+    </div>
+  );
+}

--- a/components/creator/founder-invite/FounderInviteHero.tsx
+++ b/components/creator/founder-invite/FounderInviteHero.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import Image from "next/image";
+import { Trans, useTranslation } from "react-i18next";
+import type { FounderReferral } from "@/lib/data/founder-referrals";
+import FounderInviteSignupCard from "@/components/creator/promo/FounderInviteSignupCard";
+
+// Yellow-highlight style — same trick as the promo HeroSection so the
+// "gift for you" run keeps a consistent visual treatment across the funnel.
+// boxDecorationBreak: clone keeps the highlight intact across line wraps.
+const HIGHLIGHT_STYLE: React.CSSProperties = {
+  backgroundImage:
+    "linear-gradient(100deg, transparent 0, transparent 0.2em, #FFCC00 0.35em, #FFCC00 calc(100% - 0.35em), transparent calc(100% - 0.2em), transparent 100%)",
+  padding: "0.05em 0.4em",
+  boxDecorationBreak: "clone",
+  WebkitBoxDecorationBreak: "clone",
+  color: "#000",
+};
+
+const CREATORS_HIGHLIGHT_STYLE: React.CSSProperties = {
+  backgroundImage:
+    "linear-gradient(162.34deg, #DD2A7B 4.78%, #9747FF 89.95%)",
+  WebkitBackgroundClip: "text",
+  backgroundClip: "text",
+  color: "transparent",
+};
+
+interface Props {
+  data: FounderReferral;
+}
+
+export default function FounderInviteHero({ data }: Props) {
+  const { t } = useTranslation("creatorFounderInvite");
+
+  return (
+    <section className="px-5 pt-4 pb-8 max-w-[440px] mx-auto">
+      {/* Friend avatar — circular pill above the "Invited you" line */}
+      <div className="flex flex-col items-center">
+        <div className="relative h-[72px] w-[72px] rounded-full overflow-hidden ring-2 ring-white/30">
+          <Image
+            src={data.friend.image}
+            alt={data.friend.name}
+            fill
+            sizes="72px"
+            className="object-cover"
+            priority
+            fetchPriority="high"
+          />
+        </div>
+        <p className="mt-3 inline-flex items-center rounded-full bg-white/8 px-4 py-1 text-sm text-white">
+          <span className="font-semibold">{data.friend.name}</span>
+          <span className="ml-1 font-light">{t("hero.invitedYou")}</span>
+        </p>
+      </div>
+
+      {/* Divider — gradient hairlines on either side of the small caps label */}
+      <div className="mt-5 flex items-center gap-3 text-[10px] tracking-[0.22em] text-white/85">
+        <span
+          className="h-px flex-1"
+          style={{
+            background:
+              "linear-gradient(90deg, transparent 0%, #DD2A7B 60%, #9747FF 100%)",
+          }}
+        />
+        <span className="font-semibold whitespace-nowrap">
+          {t("hero.exclusiveDivider")}
+        </span>
+        <span
+          className="h-px flex-1"
+          style={{
+            background:
+              "linear-gradient(90deg, #9747FF 0%, #DD2A7B 40%, transparent 100%)",
+          }}
+        />
+      </div>
+
+      {/* Headline — yellow highlight on the "gift for you" run */}
+      <h1 className="mt-5 text-[32px] font-bold text-white text-center leading-tight tracking-[-0.01em]">
+        <Trans
+          i18nKey="hero.headline"
+          t={t}
+          components={[<mark key="hl" style={HIGHLIGHT_STYLE} />]}
+        />
+      </h1>
+
+      {/* Founder quote card */}
+      <div
+        className="mt-6 rounded-[20px] border border-white/10 px-4 py-4 backdrop-blur-sm"
+        style={{
+          background:
+            "linear-gradient(145deg, rgba(255,255,255,0.07) 0%, rgba(255,255,255,0.03) 100%)",
+        }}
+      >
+        <div className="flex items-start gap-3">
+          <div className="relative h-[44px] w-[44px] flex-shrink-0 rounded-full overflow-hidden ring-1 ring-white/30">
+            <Image
+              src={data.founder.image}
+              alt={data.founder.name}
+              fill
+              sizes="44px"
+              className="object-cover"
+            />
+          </div>
+          <div className="flex-1 min-w-0">
+            <blockquote className="text-[14px] italic text-white leading-snug">
+              &ldquo;{data.founder.quote}&rdquo;
+            </blockquote>
+            <p className="mt-2 text-[12px] text-white/80">
+              <span className="font-semibold">{data.founder.name}</span>
+              <span className="mx-1.5">•</span>
+              <span>{t("hero.founderTitle")}</span>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* WHAT IS SPARKONOMY? intro */}
+      <div className="mt-7">
+        <p className="text-[10px] tracking-[0.22em] font-semibold text-white/85">
+          {t("hero.whatIs")}
+        </p>
+        <h2 className="mt-1 text-[22px] font-bold text-white leading-snug">
+          <Trans
+            i18nKey="hero.whatIsHeadline"
+            t={t}
+            components={[<span key="creators" style={CREATORS_HIGHLIGHT_STYLE} />]}
+          />
+        </h2>
+        <p className="mt-3 text-[14px] text-white/90 leading-relaxed">
+          {t("hero.whatIsBody")}
+        </p>
+        <p className="mt-3 text-[12px] text-white/70 leading-relaxed">
+          {t("hero.whatIsFootnote")}
+        </p>
+      </div>
+
+      {/* Signup card */}
+      <div className="mt-6">
+        <FounderInviteSignupCard
+          founderName={data.founder.name}
+          friendName={data.friend.name}
+        />
+      </div>
+    </section>
+  );
+}

--- a/components/creator/founder-invite/InvitationOnlyBanner.tsx
+++ b/components/creator/founder-invite/InvitationOnlyBanner.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+// Thin pink strip that sits between the nav and the hero. The dot separator is
+// a literal middot character so it doesn't depend on a custom font.
+export default function InvitationOnlyBanner() {
+  const { t } = useTranslation("creatorFounderInvite");
+  return (
+    <div
+      className="w-full text-center text-[11px] tracking-[0.18em] font-medium text-[#FFB1D8] py-1.5 px-4"
+      style={{
+        background:
+          "linear-gradient(90deg, rgba(221,42,123,0) 0%, rgba(221,42,123,0.18) 50%, rgba(151,71,255,0) 100%)",
+      }}
+    >
+      <span>{t("banner.left")}</span>
+      <span className="mx-2 text-[#FFB1D8]/70">·</span>
+      <span>{t("banner.right")}</span>
+    </div>
+  );
+}

--- a/components/creator/promo/FounderInviteSignupCard.tsx
+++ b/components/creator/promo/FounderInviteSignupCard.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Trans, useTranslation } from "react-i18next";
+import { ArrowRight, Loader2 } from "lucide-react";
+import { ValidatedPhoneInput } from "@/components/creator/earn/ValidatedPhoneInput";
+import OtpInput from "@/components/creator/otp/OtpInput";
+import TextInput from "@/components/common/TextInput";
+import { useSignup } from "./SignupContext";
+import {
+  CARD_GRADIENT,
+  PartnerFooter,
+  ResendRow,
+  SHEET_TRANSITION,
+  VerifiedBadge,
+  WhatsAppGlyph,
+} from "./signup-card-shared";
+
+interface FounderInviteSignupCardProps {
+  founderName: string;
+  friendName: string;
+}
+
+export default function FounderInviteSignupCard({
+  founderName,
+  friendName,
+}: FounderInviteSignupCardProps) {
+  const { t } = useTranslation(["creatorPromo", "creatorFounderInvite"]);
+  const {
+    phone,
+    setPhone,
+    setCountry,
+    stage,
+    otp,
+    setOtp,
+    verifyStatus,
+    profile,
+    setProfileField,
+    error,
+    fieldErrors,
+    requiresBasicInfo,
+    resendIn,
+    sendOtp,
+    resendOtp,
+    submitProfile,
+    changeNumber,
+  } = useSignup();
+
+  const checks = (() => {
+    const raw = t("creatorFounderInvite:signupCard.checks", {
+      returnObjects: true,
+    });
+    return Array.isArray(raw) ? (raw as string[]) : [];
+  })();
+
+  const otpVisible =
+    stage === "otp" || stage === "profile" || stage === "submitting" || stage === "submitted";
+  // Returning users (requires_basic_info=false) skip the profile sheet entirely;
+  // /verify runs straight from the OTP stage with no name/email payload.
+  const profileVisible =
+    requiresBasicInfo &&
+    (stage === "profile" || stage === "submitting" || stage === "submitted");
+  // Once we move past Stage 1 the phone input is locked. The CTA button
+  // toggles to "Edit" so the user can unlock it and pick a new number.
+  const phoneLocked = stage !== "phone";
+
+  const isFirstNameValid = profile.firstName.trim().length > 0;
+  const isLastNameValid = profile.lastName.trim().length > 0;
+  const emailTrimmed = profile.email.trim();
+  const isEmailValid = emailTrimmed === "" || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailTrimmed);
+  const canSubmitProfile = isFirstNameValid && isLastNameValid && isEmailValid;
+
+  const submitButtonLabel =
+    stage === "submitting"
+      ? t("signupCard.creating")
+      : stage === "submitted"
+        ? t("signupCard.done")
+        : t("creatorFounderInvite:signupCard.ctaCreateAccount");
+
+  // Forward-only progressive reveal in Stage 3: lastName appears once
+  // firstName has any non-whitespace text, email + submit appear once
+  // lastName does. Once revealed, fields stay revealed even if the user
+  // clears the field — collapsing mid-edit would be jarring.
+  const [hasTypedFirstName, setHasTypedFirstName] = useState(false);
+  const [hasTypedLastName, setHasTypedLastName] = useState(false);
+  useEffect(() => {
+    if (!hasTypedFirstName && profile.firstName.trim().length > 0) {
+      setHasTypedFirstName(true);
+    }
+  }, [profile.firstName, hasTypedFirstName]);
+  useEffect(() => {
+    if (!hasTypedLastName && profile.lastName.trim().length > 0) {
+      setHasTypedLastName(true);
+    }
+  }, [profile.lastName, hasTypedLastName]);
+
+  return (
+    <motion.div
+      id="founder-hero-card"
+      layout
+      style={{ background: CARD_GRADIENT }}
+      transition={{
+        layout: { duration: 0.4, ease: [0.4, 0, 0.2, 1] },
+      }}
+      className="relative mx-auto w-full max-w-[420px] rounded-[24px] border-[3px] border-[#DD2A7B] px-3 py-4 shadow-[0_18px_40px_rgba(245,166,35,0.25),0_8px_20px_rgba(0,0,0,0.25)]"
+    >
+      {/* Voucher / VIP INVITE row */}
+      <div className="flex items-start gap-3">
+        <VipInviteTicket label={t("creatorFounderInvite:signupCard.ribbon")} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2">
+            <h2 className="text-[20px] font-semibold tracking-[-0.02em] text-primary leading-tight">
+              {t("creatorFounderInvite:signupCard.headline")}
+            </h2>
+            <s className="text-xs text-primary/60 font-normal">
+              {t("creatorFounderInvite:signupCard.originalPrice")}
+            </s>
+          </div>
+          <ul className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] font-normal text-primary">
+            {checks.map((label, i) => (
+              <li key={i} className="flex items-center gap-1">
+                <span aria-hidden="true">•</span>
+                <span>{label}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-1 text-[12px] font-medium text-primary leading-snug">
+            {t("creatorFounderInvite:signupCard.topTierLine", {
+              founder: founderName,
+            })}
+          </p>
+          <p className="text-[11px] font-normal text-primary/85 leading-snug">
+            {t("creatorFounderInvite:signupCard.exclusiveLine", {
+              friend: friendName,
+            })}
+          </p>
+        </div>
+      </div>
+
+      {/* Phone input + Claim Now. Once we leave stage 'phone' the input is
+          locked and the button flips to "Edit", which calls changeNumber
+          to unlock the field. */}
+      <div className="mt-3">
+        <p className="mb-1 px-1 text-[11px] font-medium text-primary/80">
+          {t("creatorFounderInvite:signupCard.yourMobileNumber")}
+        </p>
+        <div className="flex items-center w-full rounded-[16px] bg-white border border-black/10 p-[6px] pl-3 gap-2">
+          <Suspense fallback={null}>
+            <ValidatedPhoneInput
+              id="founder-hero-phone"
+              value={phone}
+              onChange={setPhone}
+              onCountryChange={(c) => c && setCountry(c)}
+              placeholder={t("hero.card.phonePlaceholder")}
+              disabled={phoneLocked}
+              autoComplete="off"
+              inputClassName="bg-transparent border-none outline-none text-base placeholder:text-[#999999] focus:outline-none focus:ring-0 w-full text-[#212529] disabled:bg-transparent"
+            />
+          </Suspense>
+          {(() => {
+            const isVerifying = verifyStatus === "verifying";
+            const ctaDisabled =
+              stage === "otpSending" ||
+              isVerifying ||
+              (phoneLocked &&
+                (verifyStatus === "verified" ||
+                  stage === "submitting" ||
+                  stage === "submitted"));
+            return (
+              <button
+                type="button"
+                onClick={phoneLocked ? changeNumber : sendOtp}
+                disabled={ctaDisabled}
+                className="flex-shrink-0 px-4 py-2 rounded-[8px] text-white text-sm font-semibold whitespace-nowrap bg-[linear-gradient(162deg,#dd2a7b_0%,#9747FF_64%)] hover:brightness-110 active:scale-95 transition-[filter,opacity,transform] duration-200 disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                {stage === "otpSending" ? (
+                  t("otp.sending")
+                ) : isVerifying ? (
+                  <span className="inline-flex items-center gap-1.5">
+                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                    {t("signupCard.verifying")}
+                  </span>
+                ) : phoneLocked ? (
+                  t("hero.card.edit")
+                ) : (
+                  t("creatorFounderInvite:signupCard.ctaSendOtp")
+                )}
+              </button>
+            );
+          })()}
+        </div>
+
+        {/* Phone-stage error — surfaces /authenticate failures (network,
+            VALIDATION_ERROR) and the rollback path from /verify when we
+            bumped back to phone (PHONE_ALREADY_IN_USE, USER_NOT_FOUND). */}
+        <AnimatePresence initial={false}>
+          {stage === "phone" && error && (
+            <motion.p
+              key="phone-error"
+              initial={{ height: 0, opacity: 0, marginTop: 0 }}
+              animate={{ height: "auto", opacity: 1, marginTop: 8 }}
+              exit={{ height: 0, opacity: 0, marginTop: 0 }}
+              transition={SHEET_TRANSITION}
+              role="alert"
+              className="overflow-hidden text-xs text-red-100 bg-red-600/20 px-2 py-1 rounded text-center"
+            >
+              {error}
+            </motion.p>
+          )}
+        </AnimatePresence>
+
+        {/* Disclaimer — only shown in stage 1 (hidden once OTP is sent) */}
+        <AnimatePresence initial={false}>
+          {stage === "phone" && (
+            <motion.p
+              key="disclaimer"
+              initial={{ height: 0, opacity: 0, marginTop: 0 }}
+              animate={{ height: "auto", opacity: 1, marginTop: 8 }}
+              exit={{ height: 0, opacity: 0, marginTop: 0 }}
+              transition={SHEET_TRANSITION}
+              className="overflow-hidden text-[10px] md:text-[11px] text-primary/85 text-center leading-snug px-1"
+            >
+              <Trans
+                i18nKey="creatorFounderInvite:signupCard.disclaimer"
+                t={t}
+                components={[
+                  <a
+                    key="terms"
+                    href="/legal/terms"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  />,
+                  <a
+                    key="privacy"
+                    href="/legal/privacy-policy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  />,
+                ]}
+              />
+            </motion.p>
+          )}
+        </AnimatePresence>
+      </div>
+
+      {/* Stage 2: OTP block */}
+      <AnimatePresence initial={false}>
+        {otpVisible && (
+          <motion.div
+            key="otp-section"
+            initial={{ height: 0, opacity: 0, marginTop: 0 }}
+            animate={{ height: "auto", opacity: 1, marginTop: 12 }}
+            exit={{ height: 0, opacity: 0, marginTop: 0 }}
+            transition={SHEET_TRANSITION}
+            className="overflow-hidden"
+          >
+            <div className="flex flex-col items-center gap-3 px-2">
+              <p className="flex items-center justify-center gap-1.5 text-xs font-normal text-white text-center">
+                <span>{t("signupCard.otpSentOverWhatsapp")}</span>
+                <WhatsAppGlyph />
+                <span className="font-medium text-white">
+                  +91-{phone.replace(/^\+?91/, "").trim() || phone}
+                </span>
+              </p>
+
+              <OtpInput
+                length={4}
+                value={otp}
+                onChange={setOtp}
+                autoFocus
+                disabled={stage === "submitting" || stage === "submitted"}
+                variant="light"
+              />
+
+              {verifyStatus === "verified" && (
+                <VerifiedBadge status={verifyStatus} t={t} />
+              )}
+
+              {error && verifyStatus !== "verified" && verifyStatus !== "error" && (
+                <p className="text-xs text-red-100 bg-red-600/20 px-2 py-0.5 rounded">{error}</p>
+              )}
+
+              {verifyStatus !== "verified" && (
+                <ResendRow
+                  resendIn={resendIn}
+                  resendOtp={resendOtp}
+                  disabled={verifyStatus === "verifying"}
+                  t={t}
+                />
+              )}
+
+              {/* "Incorrect OTP" pill drops to its own line under the resend
+                  row and auto-hides after 2s — see the verifyStatus-watcher
+                  effect in SignupContext. The verifying state is surfaced on
+                  the Edit button itself, not here. */}
+              <AnimatePresence initial={false}>
+                {verifyStatus === "error" && (
+                  <motion.div
+                    key="pill-error"
+                    initial={{ opacity: 0, y: -4 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -4 }}
+                    transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
+                  >
+                    <VerifiedBadge status={verifyStatus} t={t} />
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Stage 3: profile form */}
+      <AnimatePresence initial={false}>
+        {profileVisible && (
+          <motion.div
+            key="profile-section"
+            initial={{ height: 0, opacity: 0, marginTop: 0 }}
+            animate={{ height: "auto", opacity: 1, marginTop: 16 }}
+            exit={{ height: 0, opacity: 0, marginTop: 0 }}
+            transition={SHEET_TRANSITION}
+            className="overflow-hidden"
+          >
+            <div className="flex flex-col px-2">
+              <TextInput
+                label={t("signupCard.firstNameLabel")}
+                placeholder={t("signupCard.firstNamePlaceholder")}
+                value={profile.firstName}
+                onChange={(e) => setProfileField("firstName", e.target.value)}
+                autoComplete="off"
+              />
+
+              {/* Progressive reveal: lastName appears once firstName has
+                  content. Forward-only — see hasTypedFirstName state above. */}
+              <AnimatePresence initial={false}>
+                {hasTypedFirstName && (
+                  <motion.div
+                    key="last-name-row"
+                    initial={{ height: 0, opacity: 0, marginTop: 0 }}
+                    animate={{ height: "auto", opacity: 1, marginTop: 8 }}
+                    exit={{ height: 0, opacity: 0, marginTop: 0 }}
+                    transition={SHEET_TRANSITION}
+                    className="overflow-hidden"
+                  >
+                    <TextInput
+                      label={t("signupCard.lastNameLabel")}
+                      placeholder={t("signupCard.lastNamePlaceholder")}
+                      value={profile.lastName}
+                      onChange={(e) => setProfileField("lastName", e.target.value)}
+                      autoComplete="off"
+                    />
+                  </motion.div>
+                )}
+              </AnimatePresence>
+
+              {/* Email + submit + partner logos all arrive together once
+                  lastName has been touched. */}
+              <AnimatePresence initial={false}>
+                {hasTypedLastName && (
+                  <motion.div
+                    key="email-and-submit"
+                    initial={{ height: 0, opacity: 0, marginTop: 0 }}
+                    animate={{ height: "auto", opacity: 1, marginTop: 8 }}
+                    exit={{ height: 0, opacity: 0, marginTop: 0 }}
+                    transition={SHEET_TRANSITION}
+                    className="overflow-hidden"
+                  >
+                    <div className="flex flex-col gap-2">
+                      <TextInput
+                        label={t("signupCard.emailLabel")}
+                        placeholder={t("signupCard.emailPlaceholder")}
+                        value={profile.email}
+                        onChange={(e) => setProfileField("email", e.target.value)}
+                        type="email"
+                        autoComplete="off"
+                        error={
+                          fieldErrors.email ??
+                          (emailTrimmed && !isEmailValid
+                            ? "Please enter a valid email"
+                            : undefined)
+                        }
+                      />
+
+                      {stage === "profile" && error && !fieldErrors.email && (
+                        <p
+                          role="alert"
+                          className="text-xs text-red-100 bg-red-600/20 px-2 py-1 rounded text-center"
+                        >
+                          {error}
+                        </p>
+                      )}
+
+                      <button
+                        type="button"
+                        onClick={submitProfile}
+                        disabled={!canSubmitProfile || stage === "submitting" || stage === "submitted"}
+                        className="relative mt-1 w-full inline-flex items-center justify-center overflow-hidden rounded-full p-[1px] shadow-[0_4px_12px_rgba(129,52,165,0.18)] transition-[opacity] duration-200 disabled:opacity-60 disabled:cursor-not-allowed"
+                      >
+                        <span
+                          aria-hidden="true"
+                          className="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#ffffff_0%,rgba(221,42,123,1)_10%,rgba(151,71,255,1)_50%,rgba(221,42,123,0.5)_90%,#ffffff_100%)]"
+                        />
+                        <span className="relative z-10 inline-flex w-full items-center justify-center gap-2 rounded-full bg-white py-3 text-sm font-semibold">
+                          <span className="bg-[linear-gradient(162.34deg,#DD2A7B_4.78%,#9747FF_89.95%)] bg-clip-text text-transparent">
+                            {submitButtonLabel}
+                          </span>
+                          <motion.span
+                            aria-hidden="true"
+                            animate={{ x: [0, 4, 0] }}
+                            transition={{ duration: 1.1, ease: "easeInOut", repeat: Infinity }}
+                            className="inline-flex"
+                          >
+                            <ArrowRight className="h-4 w-4 text-[#DD2A7B]" strokeWidth={2.5} />
+                          </motion.span>
+                        </span>
+                      </button>
+
+                      <PartnerFooter />
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+}
+
+// Small VIP-INVITE ticket glyph rendered top-left of the card. Inline SVG
+// keeps the byte cost low (~600B compared with a PNG that has to be fetched)
+// and lets us tint via currentColor if we ever need a different palette.
+function VipInviteTicket({ label }: { label: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center w-[78px] flex-shrink-0">
+      <svg
+        viewBox="0 0 78 50"
+        width={78}
+        height={50}
+        className="drop-shadow-[0_2px_4px_rgba(122,53,8,0.25)]"
+        aria-hidden="true"
+      >
+        <defs>
+          <linearGradient id="vipTicketBody" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#FFE07A" />
+            <stop offset="100%" stopColor="#E59E20" />
+          </linearGradient>
+        </defs>
+        {/* Ticket body with two semicircular notches on the left + right
+            edges (path arcs cut inward) so it reads as a tear-strip ticket. */}
+        <path
+          d="M4,4 H74 a4,4 0 0 1 4,4 v10 a7,7 0 0 0 0,14 v8 a4,4 0 0 1 -4,4 H4 a4,4 0 0 1 -4,-4 v-8 a7,7 0 0 0 0,-14 V8 a4,4 0 0 1 4,-4 z"
+          fill="url(#vipTicketBody)"
+          stroke="#B97A12"
+          strokeWidth={1}
+        />
+        {/* Stars row */}
+        <g fill="#7A3508">
+          {[12, 24, 36, 48, 60].map((cx) => (
+            <polygon
+              key={cx}
+              points={`${cx},10 ${cx + 1.6},13.4 ${cx + 5.2},13.6 ${cx + 2.4},16 ${cx + 3.4},19.4 ${cx},17.4 ${cx - 3.4},19.4 ${cx - 2.4},16 ${cx - 5.2},13.6 ${cx - 1.6},13.4`}
+            />
+          ))}
+        </g>
+        <text
+          x="39"
+          y="33"
+          textAnchor="middle"
+          fontSize="7.5"
+          fontWeight={800}
+          fill="#7A3508"
+          letterSpacing="0.6"
+        >
+          {label}
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/components/creator/promo/PromoSignupCard.tsx
+++ b/components/creator/promo/PromoSignupCard.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { Suspense, useEffect, useState } from "react";
-import Image from "next/image";
 import { AnimatePresence, motion } from "framer-motion";
 import { Trans, useTranslation } from "react-i18next";
-import { ArrowRight, Check, Loader2, X } from "lucide-react";
+import { ArrowRight, Loader2 } from "lucide-react";
 import { ValidatedPhoneInput } from "@/components/creator/earn/ValidatedPhoneInput";
 import OtpInput from "@/components/creator/otp/OtpInput";
 import TextInput from "@/components/common/TextInput";
@@ -12,8 +11,14 @@ import { PROMO_CONFIG } from "@/lib/promo/config";
 import { useSignup } from "./SignupContext";
 import GiftCardStackAnimation from "./GiftCardStackAnimation";
 import CountUp from "./CountUp";
-
-const SHEET_TRANSITION = { duration: 0.35, ease: [0.4, 0, 0.2, 1] as const };
+import {
+  CARD_GRADIENT,
+  PartnerFooter,
+  ResendRow,
+  SHEET_TRANSITION,
+  VerifiedBadge,
+  WhatsAppGlyph,
+} from "./signup-card-shared";
 
 // Resting + lifted box-shadows for the "the card noticed you" cue on first
 // scroll. Same two-layer composition (warm glow + soft drop), the lifted
@@ -22,13 +27,6 @@ const REST_SHADOW =
   "0 18px 40px rgba(245,166,35,0.25), 0 8px 20px rgba(0,0,0,0.25)";
 const LIFT_SHADOW =
   "0 26px 52px rgba(245,166,35,0.4), 0 14px 28px rgba(0,0,0,0.35)";
-
-// Static background — replaces the previous infinite 12s gradient interpolation
-// (5 keyframes, full repaint each frame). Removing the loop drops PromoSignupCard
-// out of the long-tasks list on mobile and gives back ~40% of the page's mid-scroll
-// frame budget without any visible loss.
-const CARD_GRADIENT =
-  "linear-gradient(180deg, #FFCC00 0%, rgba(255, 204, 0, 0.7) 59.13%, rgba(255, 204, 0, 0.2) 100%)";
 
 interface PromoSignupCardProps {
   // When false, the gift-card bloom and ₹500 count-up are held in their
@@ -618,127 +616,5 @@ export default function PromoSignupCard({ play = true, variant }: PromoSignupCar
         )}
       </AnimatePresence>
     </motion.div>
-  );
-}
-
-function VerifiedBadge({
-  status,
-  t,
-}: {
-  status: "idle" | "verifying" | "verified" | "error";
-  t: ReturnType<typeof useTranslation>["t"];
-}) {
-  let icon: React.ReactNode;
-  let label: string;
-  let cls: string;
-
-  if (status === "verifying") {
-    icon = <Loader2 className="w-3.5 h-3.5 animate-spin" />;
-    label = t("signupCard.verifying");
-    cls = "border-primary/40 text-primary/80 bg-white/70";
-  } else if (status === "verified") {
-    icon = <Check className="w-3.5 h-3.5" style={{ color: "#01F93F" }} />;
-    label = t("signupCard.verified");
-    cls = "border-primary text-primary bg-black/10";
-  } else if (status === "error") {
-    icon = <X className="w-3.5 h-3.5" />;
-    label = t("signupCard.invalid");
-    cls = "border-red-500 text-red-600 bg-white";
-  } else {
-    icon = <X className="w-3.5 h-3.5" />;
-    label = t("signupCard.notVerified");
-    cls = "border-primary/40 text-primary/70 bg-[linear-gradient(162.34deg,_rgba(221,42,123,0.2)_4.78%,_rgba(151,71,255,0.2)_89.95%)]";
-  }
-
-  return (
-    <span
-      className={`inline-flex flex-shrink-0 items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-medium ${cls}`}
-    >
-      {icon}
-      {label}
-    </span>
-  );
-}
-
-function ResendRow({
-  resendIn,
-  resendOtp,
-  disabled,
-  t,
-}: {
-  resendIn: number;
-  resendOtp: () => Promise<void>;
-  disabled: boolean;
-  t: ReturnType<typeof useTranslation>["t"];
-}) {
-  const m = Math.floor(resendIn / 60)
-    .toString()
-    .padStart(2, "0");
-  const s = (resendIn % 60).toString().padStart(2, "0");
-  const ticking = resendIn > 0;
-  const channelClass = ticking
-    ? "font-semibold underline opacity-60"
-    : "font-semibold underline hover:text-white disabled:opacity-50";
-
-  return (
-    <div className="flex items-center justify-center gap-1.5 w-full text-[11px] text-white/90 text-center">
-      {ticking && (
-        <span className="font-medium tabular-nums">{`${m}:${s}`}</span>
-      )}
-      <span>{t("otp.resendViaPrefix")}</span>
-      <button
-        type="button"
-        onClick={resendOtp}
-        disabled={disabled || ticking}
-        className={channelClass}
-      >
-        {t("otp.smsChannel")}
-      </button>
-      <span>&amp;</span>
-      <button
-        type="button"
-        onClick={resendOtp}
-        disabled={disabled || ticking}
-        className={channelClass}
-      >
-        {t("otp.whatsappChannel")}
-      </button>
-    </div>
-  );
-}
-
-function PartnerFooter() {
-  return (
-    <div className="mt-3 flex items-center justify-center text-[11px] text-[#5C2E0B]/85">
-      <Image
-        src="/logos/Meta_White.png"
-        alt="Meta"
-        width={85}
-        height={30}
-        className="mr-3 border-r border-white pr-3"
-      />
-      <Image
-        src="/logos/Yt_White.png"
-        alt="YouTube"
-        width={85}
-        height={30}
-        className="ml-3"
-      />
-    </div>
-  );
-}
-
-function WhatsAppGlyph() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      aria-hidden="true"
-      className="text-white"
-    >
-      <path d="M.057 24l1.687-6.163c-1.041-1.804-1.588-3.849-1.587-5.946.003-6.556 5.338-11.891 11.893-11.891 3.181.001 6.167 1.24 8.413 3.488 2.245 2.248 3.481 5.236 3.48 8.414-.003 6.557-5.338 11.892-11.893 11.892-1.99-.001-3.951-.5-5.688-1.448l-6.305 1.654zm6.597-3.807c1.676.995 3.276 1.591 5.392 1.592 5.448 0 9.886-4.434 9.889-9.885.002-5.462-4.415-9.89-9.881-9.892-5.452 0-9.887 4.434-9.889 9.884-.001 2.225.651 3.891 1.746 5.634l-.999 3.648 3.742-.981zm11.387-5.464c-.074-.124-.272-.198-.57-.347-.297-.149-1.758-.868-2.031-.967-.272-.099-.47-.149-.669.149-.198.297-.768.967-.941 1.165-.173.198-.347.223-.644.074-.297-.149-1.255-.462-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.297-.347.446-.521.151-.172.2-.296.3-.495.099-.198.05-.372-.025-.521-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.501-.669-.51l-.57-.01c-.198 0-.52.074-.792.372s-1.04 1.016-1.04 2.479 1.065 2.876 1.213 3.074c.149.198 2.095 3.2 5.076 4.487.711.307 1.265.49 1.697.626.713.226 1.362.194 1.875.118.572-.085 1.758-.719 2.006-1.413.248-.695.248-1.29.173-1.414z" />
-    </svg>
   );
 }

--- a/components/creator/promo/signup-card-shared.tsx
+++ b/components/creator/promo/signup-card-shared.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import Image from "next/image";
+import { Check, Loader2, X } from "lucide-react";
+import type { useTranslation } from "react-i18next";
+
+// Shared spring used for the OTP/profile sheet reveals on both the promo and
+// founder-invite signup cards. Kept here so both cards open and close in the
+// same beat.
+export const SHEET_TRANSITION = { duration: 0.35, ease: [0.4, 0, 0.2, 1] as const };
+
+// Static yellow card background — replaces the previous infinite gradient
+// interpolation (which kept the card on the long-tasks list during scroll).
+// Reused by FounderInviteSignupCard so the two cards stay visually identical.
+export const CARD_GRADIENT =
+  "linear-gradient(180deg, #FFCC00 0%, rgba(255, 204, 0, 0.7) 59.13%, rgba(255, 204, 0, 0.2) 100%)";
+
+type TFn = ReturnType<typeof useTranslation>["t"];
+
+export function VerifiedBadge({
+  status,
+  t,
+}: {
+  status: "idle" | "verifying" | "verified" | "error";
+  t: TFn;
+}) {
+  let icon: React.ReactNode;
+  let label: string;
+  let cls: string;
+
+  if (status === "verifying") {
+    icon = <Loader2 className="w-3.5 h-3.5 animate-spin" />;
+    label = t("signupCard.verifying");
+    cls = "border-primary/40 text-primary/80 bg-white/70";
+  } else if (status === "verified") {
+    icon = <Check className="w-3.5 h-3.5" style={{ color: "#01F93F" }} />;
+    label = t("signupCard.verified");
+    cls = "border-primary text-primary bg-black/10";
+  } else if (status === "error") {
+    icon = <X className="w-3.5 h-3.5" />;
+    label = t("signupCard.invalid");
+    cls = "border-red-500 text-red-600 bg-white";
+  } else {
+    icon = <X className="w-3.5 h-3.5" />;
+    label = t("signupCard.notVerified");
+    cls = "border-primary/40 text-primary/70 bg-[linear-gradient(162.34deg,_rgba(221,42,123,0.2)_4.78%,_rgba(151,71,255,0.2)_89.95%)]";
+  }
+
+  return (
+    <span
+      className={`inline-flex flex-shrink-0 items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-medium ${cls}`}
+    >
+      {icon}
+      {label}
+    </span>
+  );
+}
+
+export function ResendRow({
+  resendIn,
+  resendOtp,
+  disabled,
+  t,
+}: {
+  resendIn: number;
+  resendOtp: () => Promise<void>;
+  disabled: boolean;
+  t: TFn;
+}) {
+  const m = Math.floor(resendIn / 60)
+    .toString()
+    .padStart(2, "0");
+  const s = (resendIn % 60).toString().padStart(2, "0");
+  const ticking = resendIn > 0;
+  const channelClass = ticking
+    ? "font-semibold underline opacity-60"
+    : "font-semibold underline hover:text-white disabled:opacity-50";
+
+  return (
+    <div className="flex items-center justify-center gap-1.5 w-full text-[11px] text-white/90 text-center">
+      {ticking && (
+        <span className="font-medium tabular-nums">{`${m}:${s}`}</span>
+      )}
+      <span>{t("otp.resendViaPrefix")}</span>
+      <button
+        type="button"
+        onClick={resendOtp}
+        disabled={disabled || ticking}
+        className={channelClass}
+      >
+        {t("otp.smsChannel")}
+      </button>
+      <span>&amp;</span>
+      <button
+        type="button"
+        onClick={resendOtp}
+        disabled={disabled || ticking}
+        className={channelClass}
+      >
+        {t("otp.whatsappChannel")}
+      </button>
+    </div>
+  );
+}
+
+export function PartnerFooter() {
+  return (
+    <div className="mt-3 flex items-center justify-center text-[11px] text-[#5C2E0B]/85">
+      <Image
+        src="/logos/Meta_White.png"
+        alt="Meta"
+        width={85}
+        height={30}
+        className="mr-3 border-r border-white pr-3"
+      />
+      <Image
+        src="/logos/Yt_White.png"
+        alt="YouTube"
+        width={85}
+        height={30}
+        className="ml-3"
+      />
+    </div>
+  );
+}
+
+export function WhatsAppGlyph() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      className="text-white"
+    >
+      <path d="M.057 24l1.687-6.163c-1.041-1.804-1.588-3.849-1.587-5.946.003-6.556 5.338-11.891 11.893-11.891 3.181.001 6.167 1.24 8.413 3.488 2.245 2.248 3.481 5.236 3.48 8.414-.003 6.557-5.338 11.892-11.893 11.892-1.99-.001-3.951-.5-5.688-1.448l-6.305 1.654zm6.597-3.807c1.676.995 3.276 1.591 5.392 1.592 5.448 0 9.886-4.434 9.889-9.885.002-5.462-4.415-9.89-9.881-9.892-5.452 0-9.887 4.434-9.889 9.884-.001 2.225.651 3.891 1.746 5.634l-.999 3.648 3.742-.981zm11.387-5.464c-.074-.124-.272-.198-.57-.347-.297-.149-1.758-.868-2.031-.967-.272-.099-.47-.149-.669.149-.198.297-.768.967-.941 1.165-.173.198-.347.223-.644.074-.297-.149-1.255-.462-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.297-.347.446-.521.151-.172.2-.296.3-.495.099-.198.05-.372-.025-.521-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.501-.669-.51l-.57-.01c-.198 0-.52.074-.792.372s-1.04 1.016-1.04 2.479 1.065 2.876 1.213 3.074c.149.198 2.095 3.2 5.076 4.487.711.307 1.265.49 1.697.626.713.226 1.362.194 1.875.118.572-.085 1.758-.719 2.006-1.413.248-.695.248-1.29.173-1.414z" />
+    </svg>
+  );
+}

--- a/lib/data/founder-referrals.ts
+++ b/lib/data/founder-referrals.ts
@@ -1,0 +1,32 @@
+// Founder-friend referral pairs. Each entry seeds a statically-generated route
+// at /creator/<slug>. Add a new pair = append an entry; no UI code changes.
+export type FounderReferral = {
+  slug: string;
+  friend: { name: string; image: string };
+  founder: { name: string; image: string; title: string; quote: string };
+};
+
+export const FOUNDER_REFERRALS: readonly FounderReferral[] = [
+  {
+    slug: "guneet-priya",
+    friend: {
+      name: "Priya",
+      image: "/promo/founder-ref/priya.jpg",
+    },
+    founder: {
+      name: "Guneet",
+      image: "/promo/founder-ref/guneet.jpg",
+      title: "Founder, Sparkonomy",
+      quote:
+        "Because Priya introduced us - your first year is FREE, on me.",
+    },
+  },
+];
+
+export function getFounderReferral(slug: string): FounderReferral | null {
+  return FOUNDER_REFERRALS.find((r) => r.slug === slug) ?? null;
+}
+
+export function getAllFounderReferralSlugs(): string[] {
+  return FOUNDER_REFERRALS.map((r) => r.slug);
+}

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -8,6 +8,10 @@ import hiLatnCreatorEarn from '@/public/locales/hi-Latn/creatorEarn.json';
 // creatorPromo is Hinglish-only — no English bundle. The promo route forces
 // hi-Latn at mount, so en pulls the same file as a defensive fallback.
 import hiLatnCreatorPromo from '@/public/locales/hi-Latn/creatorPromo.json';
+// creatorFounderInvite — Hinglish-style brand copy authored once and shipped
+// to both locales verbatim (project rule). Both bundles are identical files.
+import enCreatorFounderInvite from '@/public/locales/en/creatorFounderInvite.json';
+import hiLatnCreatorFounderInvite from '@/public/locales/hi-Latn/creatorFounderInvite.json';
 
 const isBrowser = typeof window !== 'undefined';
 
@@ -28,16 +32,18 @@ const initI18n = () => {
         lng: isBrowser ? undefined : 'en',
         supportedLngs: ['en', 'hi-Latn'],
         debug: false,
-        ns: ['creatorEarn', 'creatorPromo'],
+        ns: ['creatorEarn', 'creatorPromo', 'creatorFounderInvite'],
         defaultNS: 'creatorEarn',
         resources: {
           en: {
             creatorEarn: enCreatorEarn,
             creatorPromo: hiLatnCreatorPromo,
+            creatorFounderInvite: enCreatorFounderInvite,
           },
           'hi-Latn': {
             creatorEarn: hiLatnCreatorEarn,
             creatorPromo: hiLatnCreatorPromo,
+            creatorFounderInvite: hiLatnCreatorFounderInvite,
           },
         },
         detection: {
@@ -61,8 +67,10 @@ const initI18n = () => {
   // deep=true + overwrite=true makes HMR-friendly key additions Just Work.
   i18n.addResourceBundle('en', 'creatorEarn', enCreatorEarn, true, true);
   i18n.addResourceBundle('en', 'creatorPromo', hiLatnCreatorPromo, true, true);
+  i18n.addResourceBundle('en', 'creatorFounderInvite', enCreatorFounderInvite, true, true);
   i18n.addResourceBundle('hi-Latn', 'creatorEarn', hiLatnCreatorEarn, true, true);
   i18n.addResourceBundle('hi-Latn', 'creatorPromo', hiLatnCreatorPromo, true, true);
+  i18n.addResourceBundle('hi-Latn', 'creatorFounderInvite', hiLatnCreatorFounderInvite, true, true);
 };
 
 initI18n();

--- a/public/locales/en/creatorFounderInvite.json
+++ b/public/locales/en/creatorFounderInvite.json
@@ -1,0 +1,28 @@
+{
+  "banner": {
+    "left": "NOT PUBLICLY AVAILABLE",
+    "right": "BY INVITATION ONLY"
+  },
+  "hero": {
+    "invitedYou": "Invited you",
+    "exclusiveDivider": "EXCLUSIVE FOUNDERS' INVITE",
+    "headline": "A friend of the founders has a <0>gift for you</0>",
+    "founderTitle": "Founder, Sparkonomy",
+    "whatIs": "WHAT IS SPARKONOMY?",
+    "whatIsHeadline": "India's First AI for <0>Creators.</0>",
+    "whatIsBody": "Launching with payments — so invoicing, late payments, taxes, and endless reminders are no longer your problem.",
+    "whatIsFootnote": "Built by ex-Google & Meta leaders with 80+ years in the creator economy."
+  },
+  "signupCard": {
+    "ribbon": "VIP INVITE",
+    "headline": "First Year, Free",
+    "originalPrice": "₹3,600/ Year",
+    "checks": ["No credit card", "No auto-renewal"],
+    "topTierLine": "Full Top Tier access — from {{founder}}.",
+    "exclusiveLine": "Exclusively for {{friend}}'s referrals — not a public offer",
+    "yourMobileNumber": "Your mobile number",
+    "ctaSendOtp": "Claim Now",
+    "ctaCreateAccount": "Create An Account",
+    "disclaimer": "By tapping, you agree to create an account and Sparkonomy's <0>Terms</0> and <1>Privacy Policy</1>"
+  }
+}

--- a/public/locales/hi-Latn/creatorFounderInvite.json
+++ b/public/locales/hi-Latn/creatorFounderInvite.json
@@ -1,0 +1,28 @@
+{
+  "banner": {
+    "left": "NOT PUBLICLY AVAILABLE",
+    "right": "BY INVITATION ONLY"
+  },
+  "hero": {
+    "invitedYou": "Invited you",
+    "exclusiveDivider": "EXCLUSIVE FOUNDERS' INVITE",
+    "headline": "A friend of the founders has a <0>gift for you</0>",
+    "founderTitle": "Founder, Sparkonomy",
+    "whatIs": "WHAT IS SPARKONOMY?",
+    "whatIsHeadline": "India's First AI for <0>Creators.</0>",
+    "whatIsBody": "Launching with payments — so invoicing, late payments, taxes, and endless reminders are no longer your problem.",
+    "whatIsFootnote": "Built by ex-Google & Meta leaders with 80+ years in the creator economy."
+  },
+  "signupCard": {
+    "ribbon": "VIP INVITE",
+    "headline": "First Year, Free",
+    "originalPrice": "₹3,600/ Year",
+    "checks": ["No credit card", "No auto-renewal"],
+    "topTierLine": "Full Top Tier access — from {{founder}}.",
+    "exclusiveLine": "Exclusively for {{friend}}'s referrals — not a public offer",
+    "yourMobileNumber": "Your mobile number",
+    "ctaSendOtp": "Claim Now",
+    "ctaCreateAccount": "Create An Account",
+    "disclaimer": "By tapping, you agree to create an account and Sparkonomy's <0>Terms</0> and <1>Privacy Policy</1>"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a gated **`/creator/[founderFriend]`** dynamic route — a referral-driven sign-up experience that offers one free year of Sparkonomy Top Tier to creators introduced by a Friend of the Founders.

The page composes:
- Hero with the referrer's name + "Exclusive Founders' Invite" tag
- Founder quote card ("Because *Priya* introduced us — your first year is on me." — Guneet)
- Offer card with seat-scarcity progress and phone + OTP signup
- 3-step explainer, social proof, perks, FAQ, footer

## What changed

**New route + components**
- `app/creator/[founderFriend]/{page,loading,CreatorFounderInvitePage}.tsx` — dynamic route, slug → referral lookup
- `components/creator/founder-invite/{FounderInviteBackdrop,FounderInviteHero,InvitationOnlyBanner}.tsx`
- `components/creator/promo/FounderInviteSignupCard.tsx` — phone/OTP flow tailored to founder-invite copy
- `lib/data/founder-referrals.ts` — per-friend (referrer, sharer, seats) config keyed by `[founderFriend]`

**Refactor — shared signup primitives**
- Extracted `VerifiedBadge`, `ResendRow`, `PartnerFooter`, `WhatsAppGlyph`, `CARD_GRADIENT`, `SHEET_TRANSITION` from `PromoSignupCard` into `components/creator/promo/signup-card-shared.tsx`
- `PromoSignupCard.tsx` now imports from the shared module — same behaviour, ~135 fewer lines
- `FounderInviteSignupCard` reuses the same primitives so the two flows stay visually consistent

**i18n**
- New namespace `creatorFounderInvite` registered in `lib/i18n.ts`
- `public/locales/{en,hi-Latn}/creatorFounderInvite.json` — both bundles ship identical Hinglish copy (per project rule: brand copy is Hinglish across all locales)

**Fix — LanguageSwitcher hydration mismatch**
- SSR locks `i18n.language` to `en`, but on the client the LanguageDetector can flip to `hi-Latn` from localStorage *before* the first React render. Reading `i18n.language` during hydration produced "Hinglish" against an "English" SSR HTML and triggered a hydration warning.
- Gated the rendered label on a `mounted` flag so the SSR default is held until after mount, then the real language takes over.

**CSS**
- `app/globals.css` adds `.founder-bg-stage` / `.founder-bg-blob` GPU-promotion hints and a mobile media query that caps blur radii (150px → 80px, 100px → 60px) so painting stays cheap on lower-end GPUs. Inline gradient values come from `FounderInviteBackdrop.tsx`.

## Test plan

- [ ] Visit `/creator/<slug>` for each configured `founderFriend` slug — referrer name, sharer photo, and seat counts render correctly
- [ ] Visit an unknown slug — graceful fallback / 404 behaves as expected
- [ ] Toggle EN ↔ Hinglish — copy stays the same (Hinglish in both, intentional)
- [ ] Reload with `i18nextLng=hi-Latn` set in localStorage — no React hydration warning in console
- [ ] Phone input → Get OTP → Verify flow completes; "Resend via SMS / WhatsApp" cooldown ticks down
- [ ] PromoSignupCard (existing `/creator/promo` route) still renders identically after the shared-module extraction
- [ ] Inspect on a low-end Android — backdrop blobs don't drop frames during scroll