### PR TITLE
fix(earn): hide floating CTA until hero card has been seen

### DIFF
--- a/components/creator/earn/FloatingCTA.tsx
+++ b/components/creator/earn/FloatingCTA.tsx
@@ -67,12 +67,24 @@ export default function FloatingCTA({
 }: FloatingCTAProps = {}) {
   const { t } = useTranslation(namespace);
   const [isVisible, setIsVisible] = useState(false);
+  // Gate visibility on the hero card having been seen at least once. The
+  // observer's initial callback fires synchronously on observe(), so without
+  // this guard the bar pops up on first paint whenever the card starts below
+  // the fold (e.g. /creator/earn, where the story carousel pushes it down).
+  const hasBeenSeenRef = useRef(false);
 
   useEffect(() => {
     const target = triggerElementId ? document.getElementById(triggerElementId) : null;
     if (target) {
       const observer = new IntersectionObserver(
-        ([entry]) => setIsVisible(!entry.isIntersecting),
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            hasBeenSeenRef.current = true;
+            setIsVisible(false);
+          } else {
+            setIsVisible(hasBeenSeenRef.current);
+          }
+        },
         { threshold: 0 },
       );
       observer.observe(target);


### PR DESCRIPTION
## Summary
- Floating CTA on `/creator/earn` was appearing on the first viewport at page load instead of waiting until the user scrolled past the hero card.
- Root cause: `IntersectionObserver`'s initial callback fires synchronously on `observe()`. On `/creator/earn` the story carousel pushes `#promo-hero-card` below the fold at load, so the first tick reported `!isIntersecting` and immediately flipped the bar visible.
- Fix: gate visibility on a `hasBeenSeenRef` that flips `true` only once the hero card has intersected the viewport. The bar now stays hidden until the user has actually seen the card and scrolled past it.

## Behavior
| Moment | Before | After |
|---|---|---|
| Page loads (hero card below fold) | Bar visible | Bar hidden |
| User scrolls down, hero card enters viewport | Bar hides | Bar stays hidden |
| User scrolls past hero card | Bar shows | Bar shows |
| `/creator/promo` (hero card on-screen at load) | unchanged | unchanged |

## Test plan
- [ ] Load `/creator/earn` on a mobile viewport — floating CTA should NOT be visible on first paint.
- [ ] Scroll down past the hero signup card — floating CTA appears.
- [ ] Scroll back up so the hero card is on-screen — floating CTA hides.
- [ ] Load `/creator/promo` — behavior unchanged (bar hidden while hero card on-screen, shown after scroll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)