### PR TITLE
feat(home): mobile-responsive hero + redesigned mobile footer

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -200,7 +200,10 @@
       "PowerShell(yarn tsc --noEmit 2>&1)",
       "PowerShell(npx --no tsc --noEmit 2>&1)",
       "Bash(git -C c:/Users/HP/Desktop/client/spark-landing-frontend status --short)",
-      "WebFetch(domain:dev.sparkonomy.com)"
+      "WebFetch(domain:dev.sparkonomy.com)",
+      "PowerShell(npx --no-install next lint --dir app --dir components 2>&1)",
+      "Bash(ls \"c:/Users/HP/Desktop/client/\")",
+      "Read(//c/Users/HP/Desktop/client/**)"
     ],
     "additionalDirectories": [
       "C:\\Users\\HP\\.claude\\plans",

--- a/app/blogs/sitemap.ts
+++ b/app/blogs/sitemap.ts
@@ -4,7 +4,7 @@ import { getAllPostSlugs, getPostBySlug } from '@/lib/wordpress-improved'
 export const revalidate = 3600
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = 'https://sparkonomy.com'
+  const baseUrl = 'https://www.sparkonomy.com'
 
   // Fetch all blog posts
   let blogPosts: MetadataRoute.Sitemap = []

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,7 +70,7 @@ export const metadata: Metadata = {
 
 export default function Home() {
   return (
-    <main className="h-[100dvh] overflow-hidden">
+    <main className="md:h-[100dvh] md:overflow-hidden">
       <Suspense>
         <HeroSection />
       </Suspense>

--- a/app/root-layout-client.tsx
+++ b/app/root-layout-client.tsx
@@ -103,7 +103,7 @@ export function RootLayoutClient({
       </Suspense>
       <ClarityInit />
       {toasterNode}
-      <div className={`relative min-h-[100dvh] w-full flex flex-col overflow-x-hidden ${isHomePage ? "touch-none" : "touch-pan-y"} overflow-hidden`}>
+      <div className={`relative min-h-[100dvh] w-full flex flex-col overflow-x-hidden ${isHomePage ? "touch-pan-y md:touch-none" : "touch-pan-y"} md:overflow-hidden`}>
         <div className="fixed inset-0 z-0">
           <WebGLFluidBackground />
         </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -34,7 +34,7 @@ export default function Footer({ minimal = false }: FooterProps) {
       className={
         minimal
           ? "relative w-full select-none z-10 mt-auto pt-8"
-          : "fixed bottom-0 w-full left-0 right-0 select-none z-50 pointer-events-none"
+          : "relative w-full left-0 right-0 select-none z-50 md:fixed md:bottom-0 pointer-events-none"
       }
     >
       {!minimal && mounted && isPromoActive && heroReady && (

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -296,7 +296,7 @@ const HeroSection = () => {
       ref={containerRef}
       onMouseMove={handleUserInteraction}
       onClick={handleUserInteraction}
-      className={`flex flex-col items-center h-full p-4 relative overflow-hidden bg-none pointer-events-none`}
+      className={`flex flex-col items-center md:h-full p-4 relative overflow-hidden bg-none pointer-events-none`}
     >
       {/* Blog link - top right */}
       {/*<Link*/}
@@ -340,7 +340,7 @@ const HeroSection = () => {
         />
       </div>
 
-      <div className={`flex-1 flex flex-col items-center justify-center pointer-events-none ${isPromoActive ? "pb-[360px] md:pb-[320px]" : "pb-[150px]"}`}>
+      <div className={`md:flex-1 flex flex-col items-center md:justify-center pt-24 md:pt-0 pb-16 pointer-events-none ${isPromoActive ? "md:pb-[320px]" : "md:pb-[150px]"}`}>
         <div className="text-center relative pointer-events-none">
           <motion.div
             className={`absolute inset-0 flex flex-col space-y-8 items-center justify-center mb-12 pointer-events-none ${showContent && 'hidden'}`}

--- a/components/home/HomeFooterLinks.tsx
+++ b/components/home/HomeFooterLinks.tsx
@@ -1,22 +1,12 @@
 "use client";
 
 import {motion} from "framer-motion";
+import Image from "next/image";
 import Link from "next/link";
 
 interface HomeFooterLinksProps {
   className?: string;
 }
-
-// Mobile-only condensed link row (matches the screenshot design).
-// Desktop keeps the 3-column grid further below.
-const MOBILE_LINKS = [
-  {href: "/about", label: "About Us"},
-  {href: "/legal/privacy-policy", label: "Privacy"},
-  {href: "/legal/terms", label: "Terms"},
-  {href: "/legal/refund-policy", label: "Refunds"},
-  {href: "/contact", label: "Contact Us"},
-  {href: "/blogs", label: "Blogs"},
-];
 
 export default function HomeFooterLinks({className}: HomeFooterLinksProps) {
   return (
@@ -26,22 +16,138 @@ export default function HomeFooterLinks({className}: HomeFooterLinksProps) {
       animate={{opacity: 1}}
       transition={{delay: 0.8}}
     >
-      {/* Mobile (<md): single row of links + centered copyright below */}
-      <div className="md:hidden flex flex-col items-center gap-2 w-full">
-        <div className="flex items-center justify-center gap-x-3 text-[11px] text-gray-400 w-full">
-          {MOBILE_LINKS.map(({href, label}) => (
+      {/* Mobile (<md): comprehensive footer with logo, columns, copyright + social row */}
+      <div className="md:hidden flex flex-col items-center gap-6 w-full pt-10 text-gray-400">
+        <div className="w-full border-t border-white/10" />
+
+        <Image
+          src="/sparkonomy_full.png"
+          alt="Sparkonomy"
+          width={196}
+          height={36}
+          className="h-9 w-auto object-contain"
+        />
+
+        <div className="grid grid-cols-2 gap-x-12 gap-y-6 w-full max-w-xs">
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-2">
+              <p className="text-white text-sm font-medium">Company</p>
+              <Link href="/about" className="text-sm text-gray-400 hover:text-white transition-colors">
+                About Us
+              </Link>
+              <Link href="/contact" className="text-sm text-gray-400 hover:text-white transition-colors">
+                Contact Us
+              </Link>
+              <Link href="/blogs" className="text-sm text-gray-400 hover:text-white transition-colors">
+                Blogs
+              </Link>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <p className="text-white text-sm font-medium">Products</p>
+              <Link
+                href="https://beta.creator.sparkonomy.com/auth?service=earn"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-gray-400 hover:text-white transition-colors"
+              >
+                Creator Payments
+              </Link>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <p className="text-white text-sm font-medium">Terms &amp; Policies</p>
             <Link
-              key={href}
-              href={href}
-              className="whitespace-nowrap hover:underline hover:text-purple-400 transition-colors duration-200"
+              href="/legal/privacy-policy"
+              className="text-sm text-gray-400 hover:text-white transition-colors"
             >
-              {label}
+              Privacy Policy
             </Link>
-          ))}
+            <Link
+              href="/legal/terms"
+              className="text-sm text-gray-400 hover:text-white transition-colors"
+            >
+              Terms of Services
+            </Link>
+            <Link
+              href="/legal/refund-policy"
+              className="text-sm text-gray-400 hover:text-white transition-colors"
+            >
+              Refund Policy
+            </Link>
+            <button
+              type="button"
+              className="cky-banner-element text-left text-sm text-gray-400 hover:text-white transition-colors"
+            >
+              Cookie Options
+            </button>
+          </div>
         </div>
-        <p className="text-[11px] text-gray-500 text-center">
+
+        <div className="w-full border-t border-white/10" />
+
+        <p className="text-xs text-gray-500 text-center">
           © Sparkonomy Pte. Ltd. All rights reserved
         </p>
+
+        <div className="flex items-center justify-center gap-6 pb-2">
+          <Link
+            href="https://x.com/SparkonomySays"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-400 hover:text-white transition-colors"
+            aria-label="X"
+          >
+            <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+            </svg>
+          </Link>
+          <Link
+            href="https://www.instagram.com/sparkonomy.official/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-400 hover:text-white transition-colors"
+            aria-label="Instagram"
+          >
+            <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path fillRule="evenodd" d="M12.315 2c2.43 0 2.784.013 3.808.06 1.064.049 1.791.218 2.427.465a4.902 4.902 0 011.772 1.153 4.902 4.902 0 011.153 1.772c.247.636.416 1.363.465 2.427.048 1.067.06 1.407.06 4.123v.08c0 2.643-.012 2.987-.06 4.043-.049 1.064-.218 1.791-.465 2.427a4.902 4.902 0 01-1.153 1.772 4.902 4.902 0 01-1.772 1.153c-.636.247-1.363.416-2.427.465-1.067.048-1.407.06-4.123.06h-.08c-2.643 0-2.987-.012-4.043-.06-1.064-.049-1.791-.218-2.427-.465a4.902 4.902 0 01-1.772-1.153 4.902 4.902 0 01-1.153-1.772c-.247-.636-.416-1.363-.465-2.427-.047-1.024-.06-1.379-.06-3.808v-.63c0-2.43.013-2.784.06-3.808.049-1.064.218-1.791.465-2.427a4.902 4.902 0 011.153-1.772A4.902 4.902 0 015.45 2.525c.636-.247 1.363-.416 2.427-.465C8.901 2.013 9.256 2 11.685 2h.63zm-.081 1.802h-.468c-2.456 0-2.784.011-3.807.058-.975.045-1.504.207-1.857.344-.467.182-.8.398-1.15.748-.35.35-.566.683-.748 1.15-.137.353-.3.882-.344 1.857-.047 1.023-.058 1.351-.058 3.807v.468c0 2.456.011 2.784.058 3.807.045.975.207 1.504.344 1.857.182.466.399.8.748 1.15.35.35.683.566 1.15.748.353.137.882.3 1.857.344 1.054.048 1.37.058 4.041.058h.08c2.597 0 2.917-.01 3.96-.058.976-.045 1.505-.207 1.858-.344.466-.182.8-.398 1.15-.748.35-.35.566-.683.748-1.15.137-.353.3-.882.344-1.857.048-1.055.058-1.37.058-4.041v-.08c0-2.597-.01-2.917-.058-3.96-.045-.976-.207-1.505-.344-1.858a3.097 3.097 0 00-.748-1.15 3.098 3.098 0 00-1.15-.748c-.353-.137-.882-.3-1.857-.344-1.023-.047-1.351-.058-3.807-.058zM12 6.865a5.135 5.135 0 110 10.27 5.135 5.135 0 010-10.27zm0 1.802a3.333 3.333 0 100 6.666 3.333 3.333 0 000-6.666zm5.338-3.205a1.2 1.2 0 110 2.4 1.2 1.2 0 010-2.4z" clipRule="evenodd" />
+            </svg>
+          </Link>
+          <Link
+            href="https://www.youtube.com/@Sparkonomy.official"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-400 hover:text-white transition-colors"
+            aria-label="YouTube"
+          >
+            <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path fillRule="evenodd" d="M19.812 5.418c.861.23 1.538.907 1.768 1.768C21.998 8.746 22 12 22 12s0 3.255-.418 4.814a2.504 2.504 0 0 1-1.768 1.768c-1.56.419-7.814.419-7.814.419s-6.255 0-7.814-.419a2.505 2.505 0 0 1-1.768-1.768C2 15.255 2 12 2 12s0-3.255.417-4.814a2.507 2.507 0 0 1 1.768-1.768C5.744 5 11.998 5 11.998 5s6.255 0 7.814.418ZM15.194 12 10 15V9l5.194 3Z" clipRule="evenodd" />
+            </svg>
+          </Link>
+          <Link
+            href="https://www.linkedin.com/company/sparkonomy/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-400 hover:text-white transition-colors"
+            aria-label="LinkedIn"
+          >
+            <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+            </svg>
+          </Link>
+          <Link
+            href="https://www.reddit.com/user/Sparkonomy/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-400 hover:text-white transition-colors"
+            aria-label="Reddit"
+          >
+            <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z" />
+            </svg>
+          </Link>
+        </div>
       </div>
 
       {/* Desktop (≥md): original 3-column grid */}

--- a/components/home/HomeFooterLinks.tsx
+++ b/components/home/HomeFooterLinks.tsx
@@ -20,13 +20,15 @@ export default function HomeFooterLinks({className}: HomeFooterLinksProps) {
       <div className="md:hidden flex flex-col items-center gap-6 w-full pt-10 text-gray-400">
         <div className="w-full border-t border-white/10" />
 
-        <Image
-          src="/sparkonomy_full.png"
-          alt="Sparkonomy"
-          width={196}
-          height={36}
-          className="h-9 w-auto object-contain"
-        />
+        <div className="w-full max-w-xs">
+          <Image
+            src="/sparkonomy_full.png"
+            alt="Sparkonomy"
+            width={196}
+            height={36}
+            className="h-9 w-auto object-contain"
+          />
+        </div>
 
         <div className="grid grid-cols-2 gap-x-12 gap-y-6 w-full max-w-xs">
           <div className="flex flex-col gap-6">

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,13 @@ const LANDING_PREFIXES = [
   '/creator/earn',
 ];
 
+const CONTENT_SIGNAL = 'ai-train=no, ai-search=yes';
+
+function withContentSignal(res: NextResponse) {
+  res.headers.set('Content-Signal', CONTENT_SIGNAL);
+  return res;
+}
+
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
   const lower = pathname.toLowerCase();
@@ -14,13 +21,13 @@ export function middleware(req: NextRequest) {
   const isLanding = LANDING_PREFIXES.some(
     (p) => lower === p || lower.startsWith(p + '/'),
   );
-  if (!isLanding) return NextResponse.next();
+  if (!isLanding) return withContentSignal(NextResponse.next());
 
-  if (pathname === lower) return NextResponse.next();
+  if (pathname === lower) return withContentSignal(NextResponse.next());
 
   const url = req.nextUrl.clone();
   url.pathname = lower;
-  return NextResponse.redirect(url, 308);
+  return withContentSignal(NextResponse.redirect(url, 308));
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- Allow vertical scroll on the homepage at mobile widths (desktop keeps the fixed `100dvh` viewport)
- Footer is `relative` on mobile and `fixed` on `md+`, so it flows in the document on small screens
- Rebuild the mobile homepage footer: logo, Company / Products / Terms & Policies columns, copyright, and a social icons row (X, Instagram, YouTube, LinkedIn, Reddit)
- Blog sitemap baseUrl: `sparkonomy.com` → `www.sparkonomy.com`
- Middleware emits `Content-Signal: ai-train=no, ai-search=yes` on all responses

## Test plan
- [ ] Homepage on mobile (<768px): page scrolls vertically, hero is readable, footer appears below with full link grid + social row
- [ ] Homepage on desktop (≥768px): viewport stays locked to `100dvh`, footer fixed at bottom (no regression)
- [ ] Footer links navigate correctly (About, Contact, Blogs, Creator Payments, Privacy, Terms, Refund Policy, Cookie Options)
- [ ] Social icons open the correct profiles in a new tab
- [ ] `/blogs/sitemap.xml` URLs use `https://www.sparkonomy.com`
- [ ] `curl -I` against any route returns `Content-Signal: ai-train=no, ai-search=yes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)