### PR TITLE
fix(home): hide footer links until hero-ready on mobile

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -107,7 +107,7 @@ export default function Footer({ minimal = false }: FooterProps) {
             <EmailCapture />
           </motion.div>
         )}
-        <HomeFooterLinks />
+        {(minimal || heroReady) && <HomeFooterLinks />}
       </div>
     </motion.footer>
   );


### PR DESCRIPTION
## Summary
- Gate [components/Footer.tsx](components/Footer.tsx) `<HomeFooterLinks />` behind `heroReady` (with a `minimal`-mode escape hatch).
- Fixes the regression where the new relative-on-mobile footer appeared on the "Igniting Now… touch to ignite" splash screen.

Follow-up to #176.

## Test plan
- [ ] Mobile homepage: on the initial "touch to ignite" splash, the footer (logo, link columns, social row) is hidden
- [ ] After tapping to ignite, the footer fades in along with the email capture
- [ ] Desktop homepage: 3-column link grid still appears in the fixed footer once the hero is ready
- [ ] Legal pages (`minimal` footer): link grid renders immediately, unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)