### PR TITLE
feat(home): add Creator Payments and Cookie Options to desktop footer

### DIFF
--- a/components/home/HomeFooterLinks.tsx
+++ b/components/home/HomeFooterLinks.tsx
@@ -165,6 +165,14 @@ export default function HomeFooterLinks({className}: HomeFooterLinksProps) {
             <Link href="/blogs" className="hover:underline hover:text-purple-400">
               Blogs
             </Link>
+            <Link
+              href="https://beta.creator.sparkonomy.com/auth?service=earn"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline hover:text-purple-400"
+            >
+              Creator Payments
+            </Link>
           </div>
         </div>
 
@@ -190,6 +198,12 @@ export default function HomeFooterLinks({className}: HomeFooterLinksProps) {
           >
             Refunds
           </Link>
+          <button
+            type="button"
+            className="cky-banner-element hover:underline hover:text-purple-400"
+          >
+            Cookie Options
+          </button>
         </div>
       </div>
     </motion.div>


### PR DESCRIPTION
## Summary
Extend the desktop 3-column footer in [components/home/HomeFooterLinks.tsx](components/home/HomeFooterLinks.tsx) to match the mobile layout's link coverage:
- **Left column:** add **Creator Payments** (opens `beta.creator.sparkonomy.com/auth?service=earn` in a new tab)
- **Right column:** add **Cookie Options** (uses the `cky-banner-element` class to trigger the CookieYes banner)

Follow-up to #176 / #177.

## Test plan
- [ ] Desktop homepage footer shows the new links: About Us · Contact Us · Blogs · Creator Payments  |  © …  |  Privacy Policy · Terms of Service · Refunds · Cookie Options
- [ ] Creator Payments opens the beta auth URL in a new tab
- [ ] Cookie Options opens the CookieYes banner
- [ ] Mobile footer unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)