### PR TITLE
feat: redirect apex sparkonomy.com to www.sparkonomy.com

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -15,6 +15,13 @@ function withContentSignal(res: NextResponse) {
 }
 
 export function middleware(req: NextRequest) {
+  const host = req.headers.get("host") ?? "";
+  if (host === "sparkonomy.com") {
+    const url = req.nextUrl.clone();
+    url.host = "www.sparkonomy.com";
+    return NextResponse.redirect(url, 301);
+  }
+
   const { pathname } = req.nextUrl;
   const lower = pathname.toLowerCase();
 


### PR DESCRIPTION
## Summary
- Adds a 301 redirect in Next.js middleware: `sparkonomy.com` → `www.sparkonomy.com`
- Both domains are mapped to Cloud Run via A/AAAA records; Hostinger can't do the redirect at DNS level because the apex records conflict
- Uses exact host match (`host === "sparkonomy.com"`) so localhost, `.run.app`, and `dev.sparkonomy.com` are unaffected

## Test plan
- [ ] `curl -I https://sparkonomy.com` → 301 to `https://www.sparkonomy.com/`
- [ ] `curl -I https://www.sparkonomy.com` → 200 (no redirect loop)
- [ ] `curl -I https://sparkonomy.com/blogs` → 301 to `https://www.sparkonomy.com/blogs` (path preserved)
- [ ] Verify localhost dev server still works without redirecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)