### PR TITLE
tweak: homepage spacing + creator/earn mobile polish

### DIFF
--- a/components/EmailCapture.tsx
+++ b/components/EmailCapture.tsx
@@ -112,13 +112,13 @@ export default function EmailCapture() {
   const glowVariants: Variants = {
     initial: {
       boxShadow:
-        "0 0 35px rgba(108,99,255,0.7), 0 0 70px rgba(108,99,255,0.4), 0 0 100px rgba(108,99,255,0.2)",
+        "0 0 18px rgba(108,99,255,0.35), 0 0 35px rgba(108,99,255,0.2), 0 0 50px rgba(108,99,255,0.1)",
     },
     hover: {
       boxShadow: [
-        "0 0 40px rgba(108,99,255,0.8), 0 0 80px rgba(108,99,255,0.6), 0 0 120px rgba(108,99,255,0.4)",
-        "0 0 50px rgba(108,99,255,0.9), 0 0 100px rgba(108,99,255,0.7), 0 0 150px rgba(108,99,255,0.5)",
-        "0 0 40px rgba(108,99,255,0.8), 0 0 80px rgba(108,99,255,0.6), 0 0 120px rgba(108,99,255,0.4)",
+        "0 0 20px rgba(108,99,255,0.4), 0 0 40px rgba(108,99,255,0.3), 0 0 60px rgba(108,99,255,0.2)",
+        "0 0 25px rgba(108,99,255,0.45), 0 0 50px rgba(108,99,255,0.35), 0 0 75px rgba(108,99,255,0.25)",
+        "0 0 20px rgba(108,99,255,0.4), 0 0 40px rgba(108,99,255,0.3), 0 0 60px rgba(108,99,255,0.2)",
       ],
       transition: {
         duration: 2.5,
@@ -128,7 +128,7 @@ export default function EmailCapture() {
     },
     focus: {
       boxShadow:
-        "0 0 60px rgba(108,99,255,1), 0 0 100px rgba(108,99,255,0.8), 0 0 150px rgba(108,99,255,0.5)",
+        "0 0 30px rgba(108,99,255,0.5), 0 0 50px rgba(108,99,255,0.4), 0 0 75px rgba(108,99,255,0.25)",
     },
   };
 
@@ -151,7 +151,7 @@ export default function EmailCapture() {
   };
 
   return (
-    <div className="w-full max-w-md mx-auto relative">
+    <div className="w-full max-w-[331px] mx-auto relative">
       <AnimatePresence mode="wait">
         {!isSubmitted ? (
           <motion.form

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -42,7 +42,7 @@ export default function Footer({ minimal = false }: FooterProps) {
           href="https://beta.creator.sparkonomy.com/auth?service=earn&lang=hi-Latn"
           target="_blank"
           rel="noopener noreferrer"
-          className="pointer-events-auto relative overflow-hidden block w-full px-2 py-2 mb-[70px] text-center cursor-pointer"
+          className="pointer-events-auto relative overflow-hidden block w-full px-2 py-2 mt-[105px] mb-[105px] text-center cursor-pointer"
           style={{
             background:
               "linear-gradient(90deg, rgba(61, 88, 219, 0) 2.15%, rgba(110, 99, 255, 0.36) 30.53%, rgba(110, 99, 255, 0.36) 62.34%, rgba(61, 88, 219, 0) 96.24%)",

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -296,7 +296,7 @@ const HeroSection = () => {
       ref={containerRef}
       onMouseMove={handleUserInteraction}
       onClick={handleUserInteraction}
-      className={`flex flex-col items-center md:h-full p-4 relative overflow-hidden bg-none pointer-events-none`}
+      className={`flex flex-col items-center md:h-full px-4 pt-4 relative overflow-hidden bg-none pointer-events-none`}
     >
       {/* Blog link - top right */}
       {/*<Link*/}
@@ -340,7 +340,7 @@ const HeroSection = () => {
         />
       </div>
 
-      <div className={`md:flex-1 flex flex-col items-center md:justify-center pt-24 md:pt-0 pb-16 pointer-events-none ${isPromoActive ? "md:pb-[320px]" : "md:pb-[150px]"}`}>
+      <div className={`md:flex-1 flex flex-col items-center md:justify-center pt-12 md:pt-0 pb-0 pointer-events-none ${isPromoActive ? "md:pb-[320px]" : "md:pb-[150px]"}`}>
         <div className="text-center relative pointer-events-none">
           <motion.div
             className={`absolute inset-0 flex flex-col space-y-8 items-center justify-center mb-12 pointer-events-none ${showContent && 'hidden'}`}

--- a/components/creator/earn/FAQSection.tsx
+++ b/components/creator/earn/FAQSection.tsx
@@ -94,7 +94,7 @@ export default function FAQSection({
           </div>
 
           {/* Section Header */}
-          <h2 className="text-[40px] md:text-[40px] font-bold text-white mb-6 md:mb-12">
+          <h2 className="text-[40px] md:text-[40px] font-bold text-white leading-none md:leading-tight mb-1 md:mb-12">
             {t("faq.title")}
           </h2>
 

--- a/components/creator/earn/HeroStoryCarousel.tsx
+++ b/components/creator/earn/HeroStoryCarousel.tsx
@@ -52,10 +52,10 @@ export default function HeroStoryCarousel() {
   const activeImage = images[index];
 
   return (
-    <div className="relative mx-auto w-full max-w-[360px] aspect-[360/640] mb-6 md:mb-8 rounded-[28px] overflow-hidden bg-black/40">
+    <div className="relative mx-auto w-full max-w-[360px] aspect-[360/640] mb-6 md:mb-8 rounded-[28px] overflow-hidden bg-black/40 p-[9px]">
       {/* Top-edge progress dots — 4 thin bars, the active one filling left-to-right
           on the same 2s cadence as the carousel rotation. */}
-      <div className="absolute top-2 left-2 right-2 z-50 flex gap-1 pointer-events-none">
+      <div className="absolute top-[17px] left-[17px] right-[17px] z-50 flex gap-1 pointer-events-none">
         {STORY_COMPONENTS.map((_, i) => (
           <div
             key={i}
@@ -87,7 +87,7 @@ export default function HeroStoryCarousel() {
       <AnimatePresence mode="sync" initial={false}>
         <motion.div
           key={index}
-          className="absolute inset-0"
+          className="absolute inset-[9px]"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}

--- a/components/creator/earn/ValueProposition.tsx
+++ b/components/creator/earn/ValueProposition.tsx
@@ -23,7 +23,18 @@ export default function ValueProposition() {
         className="max-w-[760px] mx-auto text-center space-y-4 md:space-y-6"
       >
         <h2 className="text-[32px] md:text-[44px] font-bold text-white leading-tight">
-          {t("pitch.heading")}
+          {(() => {
+            const [before, after] = t("pitch.heading").split(" — ");
+            return after === undefined ? (
+              before
+            ) : (
+              <>
+                {before}
+                <br />
+                {after}
+              </>
+            );
+          })()}
         </h2>
         <p className="text-base md:text-lg text-white/90 leading-relaxed max-w-[640px] mx-auto">
           {t("pitch.description")}

--- a/components/creator/promo/PromoSignupCard.tsx
+++ b/components/creator/promo/PromoSignupCard.tsx
@@ -223,7 +223,7 @@ export default function PromoSignupCard({
         y: { duration: 0.7, times: [0, 0.4, 1], ease: [0.34, 1.4, 0.64, 1] },
         boxShadow: { duration: 0.7, times: [0, 0.4, 1], ease: [0.4, 0, 0.2, 1] },
       }}
-      className="relative mx-auto w-full max-w-[420px] rounded-[24px] px-2 py-4"
+      className="relative mx-auto w-full max-w-md rounded-[24px] px-2 py-4"
     >
       {/* Earn variant: top-right corner coin peeks above the card. Sibling of
           the voucher row so it's positioned relative to the outer card box

--- a/components/home/HomeFooterLinks.tsx
+++ b/components/home/HomeFooterLinks.tsx
@@ -26,7 +26,7 @@ export default function HomeFooterLinks({className}: HomeFooterLinksProps) {
             alt="Sparkonomy"
             width={196}
             height={36}
-            className="h-9 w-auto object-contain"
+            className="h-6 w-auto object-contain"
           />
         </div>
 


### PR DESCRIPTION
## Summary

Two related batches of visual polish, no logic changes:

1. **Homepage** — tighten hero/promo spacing, shrink the waitlist input pill, soften its purple glow.
2. **`/creator/earn`** — mobile typography + story-carousel frame inset + promo signup card width bump.

---

### 1. Homepage spacing & glow

**`components/HeroSection.tsx`**
- L299 — section: `p-4` → `px-4 pt-4` (drops the 16px bottom padding that was stacking above the promo banner).
- L343 — inner hero: `pt-24 md:pt-0 pb-16` → `pt-12 md:pt-0 pb-0` (mobile top padding 96 → 48px; mobile bottom padding removed; `md:pb-[150px] / md:pb-[320px]` desktop overrides untouched).

**`components/Footer.tsx`**
- L45 — promo banner anchor: added `mt-[105px]`, `mb-[70px]` → `mb-[105px]` (symmetric 105px gap above and below the Hinglish promo card).

**`components/EmailCapture.tsx`**
- L154 — wrapper: `max-w-md` (448px) → `max-w-[331px]`.
- L112-133 — `glowVariants` `boxShadow` stack (initial / hover / focus) reduced ~50% on blur radius and alpha so the purple halo is a soft accent instead of a full bloom.

### 2. `/creator/earn` mobile polish

**`components/creator/earn/FAQSection.tsx`**
- FAQ heading: added `leading-none md:leading-tight`, mobile `mb-6` → `mb-1` (desktop spacing unchanged).

**`components/creator/earn/HeroStoryCarousel.tsx`**
- Added a 9px inner frame inset on the story carousel: outer card gains `p-[9px]`, progress bar repositioned from `top/left/right-2` → `top/left/right-[17px]`, and the active slide switches from `absolute inset-0` → `absolute inset-[9px]`.

**`components/creator/earn/ValueProposition.tsx`**
- Pitch heading now splits on `" — "` and renders the second half on a new line via `<br />` — the em-dash always forces a line break.

**`components/creator/promo/PromoSignupCard.tsx`**
- Outer card max width: `max-w-[420px]` → `max-w-md` (448px).

## Test plan

### Homepage
- [ ] Mobile (≤ md) `/`: 48px from hero content top edge; 105px above and below the Hinglish promo banner (symmetric).
- [ ] Waitlist pill caps at 331px wide and stays centered.
- [ ] Purple glow visibly softer on idle, hover, and focus of the waitlist input.
- [ ] Desktop (md+) hero layout unchanged — `md:justify-center` still vertically centers and `md:pb-[150px] / md:pb-[320px]` overrides remain.
- [ ] Promo-inactive state: nothing visually regresses when `useIsPromoActive()` is false.

### /creator/earn
- [ ] FAQ heading: tighter line-height and mobile bottom gap; desktop unchanged.
- [ ] Story carousel: a 9px "frame" border now visible around the active story, progress dots aligned to the inset edge.
- [ ] Pitch heading: text after the em-dash breaks onto its own line on all viewports.
- [ ] Promo signup card slightly wider (max 448px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)