### PR TITLE
fix(blogs): use WordPress media alt_text for featured + OG image

### DIFF
--- a/app/blogs/[slug]/page.tsx
+++ b/app/blogs/[slug]/page.tsx
@@ -63,6 +63,7 @@ export async function generateMetadata({ params, searchParams }: BlogPostPagePro
   const title = stripHtml(post.title.rendered);
   const description = stripHtml(post.excerpt.rendered).substring(0, 160);
   const featuredImage = post._embedded?.["wp:featuredmedia"]?.[0]?.source_url || getFeaturedImageUrl(post, "full");
+  const featuredAlt = post._embedded?.["wp:featuredmedia"]?.[0]?.alt_text || title;
   const authors = getPostAuthors(post);
   const authorNames = getAuthorNames(post);
   const publishedTime = post.date;
@@ -125,7 +126,7 @@ export async function generateMetadata({ params, searchParams }: BlogPostPagePro
           url: ogImage,
           width: post.yoast_head_json?.og_image?.[0]?.width || 1200,
           height: post.yoast_head_json?.og_image?.[0]?.height || 630,
-          alt: title,
+          alt: featuredAlt,
         },
       ],
       locale: ogLocale,
@@ -166,6 +167,7 @@ export default async function BlogPostPage({ params, searchParams }: BlogPostPag
     : `https://sparkonomy.com/blogs/${canonicalSlug}`;
 
   const featuredImage = post._embedded?.["wp:featuredmedia"]?.[0]?.source_url || getFeaturedImageUrl(post, "full");
+  const featuredAlt = post._embedded?.["wp:featuredmedia"]?.[0]?.alt_text || stripHtml(post.title.rendered);
   // Use async version to fetch Co-Authors Plus guest authors
   const postAuthors = await getPostAuthorsAsync(post);
   const publishDate = formatDate(post.date);
@@ -674,7 +676,7 @@ export default async function BlogPostPage({ params, searchParams }: BlogPostPag
               <div className="relative w-full aspect-video rounded-2xl overflow-hidden">
                 <Image
                   src={featuredImage}
-                  alt={stripHtml(post.title.rendered)}
+                  alt={featuredAlt}
                   fill
                   className="object-cover"
                   priority


### PR DESCRIPTION
## Summary
- Read `alt_text` from the embedded WordPress featured media and use it for both the rendered `<Image>` and the `openGraph.images[].alt` in [app/blogs/[slug]/page.tsx](app/blogs/%5Bslug%5D/page.tsx).
- Falls back to the post title when `alt_text` is empty, so existing posts without alt set are unaffected.

## Why
Per the content team's per-post SEO spec, each blog ships with a custom "Image Alt Text" set in WordPress. Previously the frontend ignored that field and always used the post title as the alt — both for the visible image and the OG image meta. Now it respects what's set in the WP media library.

## Behavior
- Set Alt Text on the featured image in WP → it's used everywhere.
- Leave Alt Text blank → falls back to post title (current behavior preserved).

## Test plan
- [ ] On a post where `_embedded["wp:featuredmedia"][0].alt_text` is set, confirm the rendered `<img alt>` and `<meta property="og:image:alt">` both show that value.
- [ ] On a post with no alt set, confirm fallback to the post title still works.
- [ ] No type errors (`alt_text` already typed as `string` on `WordPressFeaturedMedia`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)