### PR TITLE
feat(blogs): wire ACF Blog SEO Overrides into per-post metadata

### DIFF
--- a/app/blogs/[slug]/page.tsx
+++ b/app/blogs/[slug]/page.tsx
@@ -83,11 +83,20 @@ export async function generateMetadata({ params, searchParams }: BlogPostPagePro
   const categories = post._embedded?.["wp:term"]?.[0]?.map((cat) => cat.name) || [];
   const tags = post._embedded?.["wp:term"]?.[1]?.map((tag) => tag.name) || [];
 
+  // ACF SEO overrides — content team can set these per post via the
+  // "Blog SEO Overrides" field group in WordPress. ACF wins over Yoast.
+  const ogTitle = post.acf?.og_title || post.yoast_head_json?.og_title || seoTitle;
+  const ogDescription = post.acf?.og_description || post.yoast_head_json?.og_description || seoDescription;
+  const acfPrimaryKw = post.acf?.primary_keyword ? [post.acf.primary_keyword] : [];
+  const acfSecondaryKws = post.acf?.secondary_keywords
+    ? post.acf.secondary_keywords.split(",").map((k) => k.trim()).filter(Boolean)
+    : [];
+
   return {
     metadataBase: new URL("https://www.sparkonomy.com/"),
     title: seoTitle,
     description: seoDescription,
-    keywords: [...tags, ...categories, "Sparkonomy", "creator economy", "content monetization", "influencers", "social media influencers", "youtubers", "instagrammers", "content creators"],
+    keywords: [...acfPrimaryKw, ...acfSecondaryKws, ...tags, ...categories, "Sparkonomy", "creator economy", "content monetization", "influencers", "social media influencers", "youtubers", "instagrammers", "content creators"],
     authors: authors.map(a => ({ name: a.name, url: a.link })),
     creator: authorNames,
     publisher: "Sparkonomy",
@@ -112,8 +121,8 @@ export async function generateMetadata({ params, searchParams }: BlogPostPagePro
     openGraph: {
       siteName: "Sparkonomy",
       url: url,
-      title: post.yoast_head_json?.og_title || seoTitle,
-      description: post.yoast_head_json?.og_description || seoDescription,
+      title: ogTitle,
+      description: ogDescription,
       type: "article",
       publishedTime: publishedTime,
       modifiedTime: modifiedTime,
@@ -132,8 +141,8 @@ export async function generateMetadata({ params, searchParams }: BlogPostPagePro
     },
     twitter: {
       card: (post.yoast_head_json?.twitter_card as "summary_large_image" | "summary") || "summary_large_image",
-      title: post.yoast_head_json?.twitter_title || seoTitle,
-      description: post.yoast_head_json?.twitter_description || seoDescription,
+      title: post.acf?.og_title || post.yoast_head_json?.twitter_title || seoTitle,
+      description: post.acf?.og_description || post.yoast_head_json?.twitter_description || seoDescription,
       images: [post.yoast_head_json?.twitter_image || ogImage],
       creator: post.yoast_head_json?.twitter_creator || "@sparkonomy",
       site: post.yoast_head_json?.twitter_site || "@sparkonomy",

--- a/types/wordpress.ts
+++ b/types/wordpress.ts
@@ -67,6 +67,12 @@ export interface WordPressPost {
     "wp:featuredmedia"?: WordPressFeaturedMedia[];
     "wp:term"?: WordPressTerm[][];
   };
+  acf?: {
+    og_title?: string;
+    og_description?: string;
+    primary_keyword?: string;
+    secondary_keywords?: string;
+  };
 }
 
 export interface WordPressAuthor {


### PR DESCRIPTION
## Summary
- Adds an optional `acf` shape on `WordPressPost` ([types/wordpress.ts](types/wordpress.ts)) covering `og_title`, `og_description`, `primary_keyword`, `secondary_keywords`.
- In `generateMetadata` ([app/blogs/[slug]/page.tsx](app/blogs/%5Bslug%5D/page.tsx)), ACF wins over Yoast for OG title/description and Twitter title/description (Twitter inherits OG values so previews stay consistent).
- `primary_keyword` + comma-split `secondary_keywords` are prepended to the `keywords` meta array.

## Why
Per-post separate OG title / OG description (different from Meta Title / Meta Description) is a Yoast Premium feature. To stay on the free tier, we set those values via an ACF field group (\"Blog SEO Overrides\") on WordPress. The frontend now reads them via REST as `post.acf.*`.

## Fallback chain (unchanged when ACF empty)
- OG title: `post.acf.og_title` → `yoast_head_json.og_title` → SEO title → post title
- OG description: `post.acf.og_description` → `yoast_head_json.og_description` → meta description → excerpt
- Twitter title/description: ACF OG values → Yoast Twitter values → SEO title/description
- Keywords: `[primary, ...secondary, ...tags, ...categories, ...static brand keywords]`

Posts without ACF values behave exactly as before.

## WordPress setup (done)
- ACF plugin installed.
- Field Group: \"Blog SEO Overrides\" with 4 fields (`og_title`, `og_description`, `primary_keyword`, `secondary_keywords`).
- \"Show in REST API\" is ON at the group level.
- Location: Post Type = Post.

## Test plan
- [ ] On a post with ACF fields filled in (e.g. post 976), confirm OG and Twitter cards use the ACF values via the Facebook/LinkedIn debuggers.
- [ ] On a post without ACF values, confirm Yoast/post-default fallbacks still render correctly.
- [ ] View page source — confirm `<meta name=\"keywords\">` includes the primary keyword and comma-split secondary keywords.
- [ ] No TypeScript errors from the new `acf` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)