### PR TITLE
Polish earn page mobile, shared mobile footer, light-theme phone input

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -172,3 +172,16 @@ img {
     color: white;
     opacity: 0.7;
 }
+
+/* Light-bg variant: pill sits on white (promo / earn signup card), so the
+   default white arrow disappears. Match the input text color (#212529) and
+   bump opacity up so it reads clearly. */
+.validated-phone-input--light .PhoneInputCountrySelectArrow {
+    color: #212529;
+    opacity: 1;
+}
+
+.validated-phone-input--light .PhoneInputCountrySelect {
+    background: #ffffff;
+    color: #212529;
+}

--- a/components/blog/BlogFooter.tsx
+++ b/components/blog/BlogFooter.tsx
@@ -1,10 +1,17 @@
 import Link from "next/link";
 import Image from "next/image";
+import SiteMobileFooter from "@/components/common/SiteMobileFooter";
 
 export default function BlogFooter() {
   return (
     <footer className="w-full bg-transparent md:bg-white py-4 md:py-5 lg:py-9">
-      <div className="border-t border-gray-200 py-4 md:mx-[84px]">
+      {/* Mobile (<md): shared site footer (light variant) */}
+      <div className="md:hidden px-4">
+        <SiteMobileFooter theme="light" />
+      </div>
+
+      {/* Tablet + Desktop (≥md): existing footer with added links */}
+      <div className="hidden md:block border-t border-gray-200 py-4 md:mx-[84px]">
         <div className="max-w-7xl mx-auto px-4 md:px-6 lg:px-8">
           <div className="flex flex-col items-center text-center gap-4">
           {/* Logo */}
@@ -32,6 +39,17 @@ export default function BlogFooter() {
               <Link href="/legal/refund-policy" className="hover:text-purple-600 transition-colors whitespace-nowrap">
                 Refund Policy
               </Link>
+              <span className="text-gray-400">|</span>
+              <Link href="/creator/earn" className="hover:text-purple-600 transition-colors whitespace-nowrap">
+                Creator Payments
+              </Link>
+              <span className="text-gray-400">|</span>
+              <button
+                type="button"
+                className="cky-banner-element hover:text-purple-600 transition-colors whitespace-nowrap"
+              >
+                Cookie Options
+              </button>
             </div>
             <span className="text-xs md:text-sm lg:text-base font-normal text-gray-600 whitespace-nowrap">
               ©All rights reserved.

--- a/components/common/SiteMobileFooter.tsx
+++ b/components/common/SiteMobileFooter.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+
+interface SiteMobileFooterProps {
+  theme?: "dark" | "light";
+  className?: string;
+}
+
+export default function SiteMobileFooter({
+  theme = "dark",
+  className,
+}: SiteMobileFooterProps) {
+  const isDark = theme === "dark";
+
+  const dividerClass = isDark ? "border-white/10" : "border-gray-200";
+  const headingClass = isDark ? "text-white" : "text-gray-900";
+  const linkClass = isDark
+    ? "text-sm text-gray-400 hover:text-white transition-colors"
+    : "text-sm text-gray-600 hover:text-purple-600 transition-colors";
+  const copyrightClass = isDark ? "text-gray-500" : "text-gray-500";
+  const socialClass = isDark
+    ? "text-gray-400 hover:text-white transition-colors"
+    : "text-gray-600 hover:text-purple-600 transition-colors";
+
+  return (
+    <div
+      className={`md:hidden flex flex-col items-center gap-6 w-full pt-10 ${className ?? ""}`}
+    >
+      <div className={`w-full border-t ${dividerClass}`} />
+
+      <div className="w-full max-w-xs flex justify-start">
+        <Image
+          src={isDark ? "/sparkonomy_full.png" : "/FooterLogo.png"}
+          alt="Sparkonomy"
+          width={196}
+          height={36}
+          className="h-6 w-auto object-contain"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-12 gap-y-6 w-full max-w-xs">
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-2">
+            <p className={`${headingClass} text-sm font-medium`}>Company</p>
+            <Link href="/about" className={linkClass}>
+              About Us
+            </Link>
+            <Link href="/contact" className={linkClass}>
+              Contact Us
+            </Link>
+            <Link href="/blogs" className={linkClass}>
+              Blogs
+            </Link>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <p className={`${headingClass} text-sm font-medium`}>Products</p>
+            <Link href="/creator/earn" className={linkClass}>
+              Creator Payments
+            </Link>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <p className={`${headingClass} text-sm font-medium`}>
+            Terms &amp; Policies
+          </p>
+          <Link href="/legal/privacy-policy" className={linkClass}>
+            Privacy Policy
+          </Link>
+          <Link href="/legal/terms" className={linkClass}>
+            Terms of Services
+          </Link>
+          <Link href="/legal/refund-policy" className={linkClass}>
+            Refund Policy
+          </Link>
+          <button
+            type="button"
+            className={`cky-banner-element text-left ${linkClass}`}
+          >
+            Cookie Options
+          </button>
+        </div>
+      </div>
+
+      <div className={`w-full border-t ${dividerClass}`} />
+
+      <p className={`text-xs ${copyrightClass} text-center`}>
+        © Sparkonomy Pte. Ltd. All rights reserved
+      </p>
+
+      <div className="flex items-center justify-center gap-6 pb-2">
+        <Link
+          href="https://x.com/SparkonomySays"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={socialClass}
+          aria-label="X"
+        >
+          <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+          </svg>
+        </Link>
+        <Link
+          href="https://www.instagram.com/sparkonomy.official/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={socialClass}
+          aria-label="Instagram"
+        >
+          <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path fillRule="evenodd" d="M12.315 2c2.43 0 2.784.013 3.808.06 1.064.049 1.791.218 2.427.465a4.902 4.902 0 011.772 1.153 4.902 4.902 0 011.153 1.772c.247.636.416 1.363.465 2.427.048 1.067.06 1.407.06 4.123v.08c0 2.643-.012 2.987-.06 4.043-.049 1.064-.218 1.791-.465 2.427a4.902 4.902 0 01-1.153 1.772 4.902 4.902 0 01-1.772 1.153c-.636.247-1.363.416-2.427.465-1.067.048-1.407.06-4.123.06h-.08c-2.643 0-2.987-.012-4.043-.06-1.064-.049-1.791-.218-2.427-.465a4.902 4.902 0 01-1.772-1.153 4.902 4.902 0 01-1.153-1.772c-.247-.636-.416-1.363-.465-2.427-.047-1.024-.06-1.379-.06-3.808v-.63c0-2.43.013-2.784.06-3.808.049-1.064.218-1.791.465-2.427a4.902 4.902 0 011.153-1.772A4.902 4.902 0 015.45 2.525c.636-.247 1.363-.416 2.427-.465C8.901 2.013 9.256 2 11.685 2h.63zm-.081 1.802h-.468c-2.456 0-2.784.011-3.807.058-.975.045-1.504.207-1.857.344-.467.182-.8.398-1.15.748-.35.35-.566.683-.748 1.15-.137.353-.3.882-.344 1.857-.047 1.023-.058 1.351-.058 3.807v.468c0 2.456.011 2.784.058 3.807.045.975.207 1.504.344 1.857.182.466.399.8.748 1.15.35.35.683.566 1.15.748.353.137.882.3 1.857.344 1.054.048 1.37.058 4.041.058h.08c2.597 0 2.917-.01 3.96-.058.976-.045 1.505-.207 1.858-.344.466-.182.8-.398 1.15-.748.35-.35.566-.683.748-1.15.137-.353.3-.882.344-1.857.048-1.055.058-1.37.058-4.041v-.08c0-2.597-.01-2.917-.058-3.96-.045-.976-.207-1.505-.344-1.858a3.097 3.097 0 00-.748-1.15 3.098 3.098 0 00-1.15-.748c-.353-.137-.882-.3-1.857-.344-1.023-.047-1.351-.058-3.807-.058zM12 6.865a5.135 5.135 0 110 10.27 5.135 5.135 0 010-10.27zm0 1.802a3.333 3.333 0 100 6.666 3.333 3.333 0 000-6.666zm5.338-3.205a1.2 1.2 0 110 2.4 1.2 1.2 0 010-2.4z" clipRule="evenodd" />
+          </svg>
+        </Link>
+        <Link
+          href="https://www.youtube.com/@Sparkonomy.official"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={socialClass}
+          aria-label="YouTube"
+        >
+          <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path fillRule="evenodd" d="M19.812 5.418c.861.23 1.538.907 1.768 1.768C21.998 8.746 22 12 22 12s0 3.255-.418 4.814a2.504 2.504 0 0 1-1.768 1.768c-1.56.419-7.814.419-7.814.419s-6.255 0-7.814-.419a2.505 2.505 0 0 1-1.768-1.768C2 15.255 2 12 2 12s0-3.255.417-4.814a2.507 2.507 0 0 1 1.768-1.768C5.744 5 11.998 5 11.998 5s6.255 0 7.814.418ZM15.194 12 10 15V9l5.194 3Z" clipRule="evenodd" />
+          </svg>
+        </Link>
+        <Link
+          href="https://www.linkedin.com/company/sparkonomy/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={socialClass}
+          aria-label="LinkedIn"
+        >
+          <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+          </svg>
+        </Link>
+        <Link
+          href="https://www.reddit.com/user/Sparkonomy/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={socialClass}
+          aria-label="Reddit"
+        >
+          <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z" />
+          </svg>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/creator/earn/BenefitsSection.tsx
+++ b/components/creator/earn/BenefitsSection.tsx
@@ -51,7 +51,7 @@ export default function BenefitsSection() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.6 }}
-          className="text-center mb-12 md:mb-16"
+          className="text-center mb-12 md:mb-6"
         >
           <h2 className="text-2xl md:text-[52px] font-bold text-white">
             {t("benefits.title")}

--- a/components/creator/earn/EarnFooter.tsx
+++ b/components/creator/earn/EarnFooter.tsx
@@ -4,6 +4,7 @@ import {motion} from "framer-motion";
 import { useTranslation } from "react-i18next";
 import Image from "next/image";
 import Link from "next/link";
+import SiteMobileFooter from "@/components/common/SiteMobileFooter";
 
 export default function EarnFooter() {
   const { t } = useTranslation("creatorEarn");
@@ -17,7 +18,11 @@ export default function EarnFooter() {
         transition={{ duration: 0.6 }}
         className="max-w-[1440px] mx-auto"
       >
-        <div className="max-w-[392px] md:max-w-[1058px] mx-auto space-y-4">
+        {/* Mobile (<md): shared site footer with full link columns + socials */}
+        <SiteMobileFooter theme="dark" />
+
+        {/* Tablet + Desktop (≥md): existing compact footer with added links */}
+        <div className="hidden md:block max-w-[392px] md:max-w-[1058px] mx-auto space-y-4">
           {/* Divider Line */}
           <div className="w-full h-[1px] bg-white/20" />
 
@@ -38,7 +43,7 @@ export default function EarnFooter() {
 
           {/* Footer Links */}
           <div className="flex flex-col items-center gap-1 text-gray-500 text-xs">
-            <div className="flex items-center justify-center gap-1">
+            <div className="flex flex-wrap items-center justify-center gap-1">
               <Link href="/legal/terms" className="hover:text-white transition-colors">
                 {t("footer.terms")}
               </Link>
@@ -50,6 +55,17 @@ export default function EarnFooter() {
               <Link href="/legal/refund-policy" className="hover:text-white transition-colors">
                 {t("footer.refund")}
               </Link>
+              <span>|</span>
+              <Link href="/creator/earn" className="hover:text-white transition-colors">
+                Creator Payments
+              </Link>
+              <span>|</span>
+              <button
+                type="button"
+                className="cky-banner-element hover:text-white transition-colors"
+              >
+                Cookie Options
+              </button>
             </div>
             <span>{t("footer.copyright")}</span>
           </div>

--- a/components/creator/earn/FAQSection.tsx
+++ b/components/creator/earn/FAQSection.tsx
@@ -69,7 +69,7 @@ export default function FAQSection({
       >
         <div className="w-full mx-auto">
           {/* Compliance Badges */}
-          <div className="flex items-center justify-center gap-6 mb-12">
+          <div className="flex items-center justify-center gap-6 mb-10">
             <Image
               src="/logos/GDPR_White.png"
               alt="GDPR"

--- a/components/creator/earn/FloatingCTA.tsx
+++ b/components/creator/earn/FloatingCTA.tsx
@@ -219,6 +219,7 @@ function EarnFloatingCTA({ isVisible, t, trackingPrefix }: EarnVariantProps) {
                   value={phone}
                   onChange={setPhone}
                   placeholder={t("hero.card.phonePlaceholder")}
+                  theme="light"
                   inputClassName="bg-transparent border-none outline-none text-base placeholder:text-[#999999] focus:outline-none focus:ring-0 w-full text-[#212529]"
                 />
               </Suspense>
@@ -234,7 +235,7 @@ function EarnFloatingCTA({ isVisible, t, trackingPrefix }: EarnVariantProps) {
             </div>
 
             {/* Disclaimer */}
-            <p className="mt-1.5 text-[9.5px] text-white/90 text-center leading-snug px-1">
+            <p className="mt-1.5 text-[8.5px] text-white/90 text-center leading-snug px-1">
               <Trans
                 i18nKey="hero.card.disclaimer"
                 t={t}
@@ -425,6 +426,7 @@ function PromoFloatingCTA({ isVisible, t, trackingPrefix }: PromoVariantProps) {
                     value={phone}
                     onChange={setPhone}
                     placeholder={t("floatingCta.placeholder")}
+                    theme="light"
                     inputClassName="bg-transparent border-none outline-none text-base placeholder:text-[#999999] focus:outline-none focus:ring-0 w-full text-[#212529]"
                   />
                 </Suspense>

--- a/components/creator/earn/HeroSection.tsx
+++ b/components/creator/earn/HeroSection.tsx
@@ -34,7 +34,7 @@ export default function HeroSection() {
         {/* Headline — plain text leading line + yellow-highlighted script tail.
             i18nKey "hero.title" uses <0/> for the mobile line break and
             <1>...</1> to mark the portion that should get the highlight. */}
-        <h1 className="text-[25px] font-bold text-white text-center leading-[2] tracking-[-0.04em] mb-6 max-w-[640px] mx-auto">
+        <h1 className="text-[25px] font-bold text-white text-center leading-[2] tracking-[-0.04em] mb-1.5 max-w-[640px] mx-auto">
           <Trans
             i18nKey="hero.title"
             t={t}

--- a/components/creator/earn/HeroStoryCarousel.tsx
+++ b/components/creator/earn/HeroStoryCarousel.tsx
@@ -1,20 +1,26 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import dynamic from "next/dynamic";
+import Image from "next/image";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useTranslation } from "react-i18next";
-import StoryContent1 from "./stories/StoryContent1";
+import { Heart, Send } from "lucide-react";
+import AnimatedEmojis from "./stories/AnimatedEmojis";
+import FloatingHearts from "./stories/FloatingHearts";
 
-// Stories 2–4 are not the LCP candidate (story 1 is the only one painted at
-// hydration) so they stream in on demand.
-const StoryContent2 = dynamic(() => import("./stories/StoryContent2"), { ssr: false });
-const StoryContent3 = dynamic(() => import("./stories/StoryContent3"), { ssr: false });
-const StoryContent4 = dynamic(() => import("./stories/StoryContent4"), { ssr: false });
+const HEARTS_STORY_INDEX = 3; // Story 4 — gets the rising-hearts fountain
+const HEARTS_TRIGGER_MS = 1400;
+
+// Emoji sets per story — mirror the full-screen StoryContent1..4 bottom bars.
+const STORY_EMOJIS: readonly (readonly string[])[] = [
+  ["🙋🏼‍♂️", "🙋🏼‍♀️", "🙋🏻‍♂️", "🙋🏻‍♀️", "🙋🏾‍♀️", "🙋🏽", "🙋🏽‍♀️", "🙋‍♂️"],
+  ["💔", "💔", "💔", "💔", "💔", "💔", "💔", "💔"],
+  ["😤", "🤯", "😤", "🤯", "😤", "🤯", "😤", "🤯", "😤", "😫"],
+  ["❤️", "❤️", "❤️", "❤️", "❤️", "❤️", "❤️", "❤️", "❤️", "❤️"],
+];
 
 const STORY_INTERVAL_MS = 2000;
-
-const STORY_COMPONENTS = [StoryContent1, StoryContent2, StoryContent3, StoryContent4] as const;
+const TOTAL_STORIES = 4;
 
 const STORY_IMAGES: Record<"en" | "hi-Latn", readonly string[]> = {
   en: [
@@ -35,67 +41,115 @@ export default function HeroStoryCarousel() {
   const { i18n } = useTranslation();
   const prefersReducedMotion = useReducedMotion();
   const [index, setIndex] = useState(0);
+  const [heartTriggerCount, setHeartTriggerCount] = useState(0);
 
   const lang: "en" | "hi-Latn" = i18n.language?.startsWith("hi") ? "hi-Latn" : "en";
   const images = STORY_IMAGES[lang];
 
-  // 2s loop. Reduced-motion users see the first story only — no rotation.
   useEffect(() => {
     if (prefersReducedMotion) return;
     const id = window.setInterval(() => {
-      setIndex((i) => (i + 1) % STORY_COMPONENTS.length);
+      setIndex((i) => (i + 1) % TOTAL_STORIES);
     }, STORY_INTERVAL_MS);
     return () => window.clearInterval(id);
   }, [prefersReducedMotion]);
 
-  const ActiveStory = STORY_COMPONENTS[index];
+  // Hearts fountain only runs while the hearts story is active.
+  useEffect(() => {
+    if (index !== HEARTS_STORY_INDEX) return;
+    setHeartTriggerCount((c) => c + 1);
+    const id = window.setInterval(() => {
+      setHeartTriggerCount((c) => c + 1);
+    }, HEARTS_TRIGGER_MS);
+    return () => window.clearInterval(id);
+  }, [index]);
+
   const activeImage = images[index];
+  const isHeartsStory = index === HEARTS_STORY_INDEX;
 
   return (
-    <div className="relative mx-auto w-full max-w-[360px] aspect-[360/640] mb-6 md:mb-8 rounded-[28px] overflow-hidden bg-black/40 p-[9px]">
-      {/* Top-edge progress dots — 4 thin bars, the active one filling left-to-right
-          on the same 2s cadence as the carousel rotation. */}
-      <div className="absolute top-[17px] left-[17px] right-[17px] z-50 flex gap-1 pointer-events-none">
-        {STORY_COMPONENTS.map((_, i) => (
-          <div
-            key={i}
-            className="flex-1 h-0.5 rounded-full bg-white/30 overflow-hidden"
-          >
+    <div className="relative mx-auto w-fit px-2 py-1.5 mb-6 md:mb-8 rounded-[18.5px] bg-black">
+      <div className="flex flex-col gap-1.5 w-[210px]">
+        {/* Progress bars — sit above the image, not over it */}
+        <div className="flex gap-1 pointer-events-none">
+          {Array.from({ length: TOTAL_STORIES }).map((_, i) => (
+            <div
+              key={i}
+              className="flex-1 h-0.5 rounded-full bg-white/30 overflow-hidden"
+            >
+              <motion.div
+                className="h-full bg-white"
+                initial={false}
+                animate={{
+                  width:
+                    i < index
+                      ? "100%"
+                      : i === index
+                        ? prefersReducedMotion
+                          ? "100%"
+                          : ["0%", "100%"]
+                        : "0%",
+                }}
+                transition={
+                  i === index && !prefersReducedMotion
+                    ? { duration: STORY_INTERVAL_MS / 1000, ease: "linear" }
+                    : { duration: 0 }
+                }
+              />
+            </div>
+          ))}
+        </div>
+
+        <div className="relative w-[210px] h-[312px] rounded-2xl overflow-hidden">
+          {/* Story image */}
+          <AnimatePresence mode="sync" initial={false}>
             <motion.div
-              className="h-full bg-white"
-              initial={false}
-              animate={{
-                width:
-                  i < index
-                    ? "100%"
-                    : i === index
-                      ? prefersReducedMotion
-                        ? "100%"
-                        : ["0%", "100%"]
-                      : "0%",
-              }}
-              transition={
-                i === index && !prefersReducedMotion
-                  ? { duration: STORY_INTERVAL_MS / 1000, ease: "linear" }
-                  : { duration: 0 }
-              }
-            />
+              key={index}
+              className="absolute inset-0"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.35, ease: "easeInOut" }}
+            >
+              <Image
+                src={activeImage}
+                alt={`Story ${index + 1}`}
+                width={210}
+                height={312}
+                priority={index === 0}
+                className="w-full h-full object-cover"
+              />
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        {/* Bottom bar — type bar + heart + send */}
+        <div className="flex items-center gap-[9px]">
+          <div className="flex-1 min-w-0 overflow-hidden border border-white/50 rounded-full px-2 py-0.5 flex items-center">
+            <AnimatedEmojis key={index} emojis={[...STORY_EMOJIS[index]]} className="text-[9px]" />
           </div>
-        ))}
+          <Heart
+            width={13.5}
+            height={13.5}
+            className={isHeartsStory ? "text-[#FF0000]" : "text-white"}
+            fill={isHeartsStory ? "#FF0000" : "none"}
+          />
+          <Send width={13.5} height={13.5} className="text-white" />
+        </div>
       </div>
 
-      <AnimatePresence mode="sync" initial={false}>
-        <motion.div
-          key={index}
-          className="absolute inset-[9px]"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.35, ease: "easeInOut" }}
+      {/* Rising hearts fountain — Story 4 only. FloatingHearts is sized for
+          the 390×773 panel, so scale it down to match this 210-wide frame.
+          Rendered outside the image's overflow-hidden box so hearts can
+          rise from the heart icon and past the image. */}
+      {isHeartsStory && (
+        <div
+          className="absolute inset-0 pointer-events-none overflow-hidden"
+          style={{ transform: "scale(0.55)", transformOrigin: "bottom right" }}
         >
-          <ActiveStory imageSrc={activeImage} priority={index === 0} />
-        </motion.div>
-      </AnimatePresence>
+          <FloatingHearts triggerCount={heartTriggerCount} />
+        </div>
+      )}
     </div>
   );
 }

--- a/components/creator/earn/TestimonialCard.tsx
+++ b/components/creator/earn/TestimonialCard.tsx
@@ -2,7 +2,6 @@
 
 import {motion} from "framer-motion";
 import Image from "next/image";
-import {Check} from "lucide-react";
 
 interface TestimonialCardProps {
   quote: string;
@@ -39,34 +38,29 @@ export default function TestimonialCard({
     <motion.div
       {...motionProps}
       className={`
-        px-3 py-6 rounded-[32px] bg-gradient-to-br from-white/10 via-white/0 to-black/10 border border-white/20 backdrop-blur-[2px]
+        p-3 rounded-[24px] bg-gradient-to-br from-white/10 via-white/0 to-black/10 border border-[#FFFFFF33] backdrop-blur-[2px]
         ${highlighted ? "bg-white/10" : "bg-transparent"}
-        min-w-[315px] md:max-w-[364px]
+        min-w-[315px] md:max-w-[364px] flex flex-col gap-4
       `}
     >
       {/* Quote */}
-      <p className="text-white text-[15px] leading-normal text-center mb-3 h-[124px] flex items-center justify-center italic">
+      <p className="text-white text-base leading-[1.2] text-center italic min-h-[77px] flex items-center justify-center">
         &ldquo;{quote}&rdquo;
       </p>
 
       {/* User Info */}
-      <div className="flex items-center gap-3 px-0 pt-3">
+      <div className="flex items-center justify-center gap-3">
         {/* Avatar */}
-        <div className="relative w-10 h-10 rounded-full overflow-hidden flex-shrink-0">
+        <div className="relative w-12 h-12 rounded-full overflow-hidden flex-shrink-0">
           <Image src={avatarUrl} alt={name} fill className="object-cover" />
         </div>
 
         {/* Name and Handle */}
-        <div className="flex flex-col flex-1">
-          <div className="flex items-center gap-1">
-            <span className="text-white font-medium text-[14px] leading-normal">
-              {name}
-            </span>
-            <div className="w-4 h-4 rounded-full bg-blue-500 flex items-center justify-center">
-              <Check className="w-3 h-3 text-white" strokeWidth={3} />
-            </div>
-          </div>
-          <span className="text-white leading-5 text-[12px]">{handle}</span>
+        <div className="flex flex-col">
+          <span className="text-white font-medium text-base leading-normal">
+            {name}
+          </span>
+          <span className="text-white font-normal leading-5 text-sm">{handle}</span>
         </div>
       </div>
     </motion.div>

--- a/components/creator/earn/ValidatedPhoneInput.tsx
+++ b/components/creator/earn/ValidatedPhoneInput.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import PhoneInput from "react-phone-number-input";
 import type { Country } from "react-phone-number-input";
 import "react-phone-number-input/style.css";
@@ -21,6 +22,11 @@ interface ValidatedPhoneInputProps {
   // Override the inner <input>'s autoComplete. Defaults to "tel"; pass "off"
   // (or a non-standard token) to suppress browser saved-number suggestions.
   autoComplete?: string;
+  // Surface theme. "dark" (default) keeps the white country-arrow + dark
+  // dropdown for dark pill backgrounds. "light" switches the arrow to #212529
+  // and the dropdown to white text-on-white so it stays visible on light
+  // pills (e.g. the promo / earn signup card).
+  theme?: "dark" | "light";
 }
 
 const DEFAULT_INPUT_CLASS =
@@ -39,29 +45,62 @@ export const ValidatedPhoneInput = ({
   disabled = false,
   inputClassName = DEFAULT_INPUT_CLASS,
   autoComplete = "tel",
+  theme = "dark",
 }: ValidatedPhoneInputProps) => {
+  const wrapperClass =
+    theme === "light"
+      ? "validated-phone-input validated-phone-input--light"
+      : "validated-phone-input";
+  // react-phone-number-input mutates the input's `value` (injects the country
+  // dial prefix, e.g. "+91") and renders the country-flag <select> during
+  // initialization, which the server can't reproduce. Render a layout-matching
+  // placeholder on SSR + the first client paint, then swap in the real widget
+  // after mount so React never sees a hydration mismatch.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
   return (
     <div className="relative w-full">
-      <PhoneInput
-        id={id}
-        international
-        defaultCountry={defaultCountry}
-        country={country}
-        value={value}
-        onChange={(value) => onChange(value || "")}
-        onCountryChange={onCountryChange}
-        onBlur={onBlur}
-        placeholder={placeholder}
-        disabled={disabled}
-        className="validated-phone-input"
-        numberInputProps={{
-          className: inputClassName,
-          disabled,
-          name: "phone",
-          autoComplete,
-          inputMode: "tel",
-        }}
-      />
+      {mounted ? (
+        <PhoneInput
+          id={id}
+          international
+          defaultCountry={defaultCountry}
+          country={country}
+          value={value}
+          onChange={(value) => onChange(value || "")}
+          onCountryChange={onCountryChange}
+          onBlur={onBlur}
+          placeholder={placeholder}
+          disabled={disabled}
+          className={wrapperClass}
+          numberInputProps={{
+            className: inputClassName,
+            disabled,
+            name: "phone",
+            autoComplete,
+            inputMode: "tel",
+          }}
+        />
+      ) : (
+        <div className={`${wrapperClass} PhoneInput`}>
+          {/* Flag slot placeholder — matches the .PhoneInputCountry width so the
+              text input lands at the same x-position post-hydration. */}
+          <div className="PhoneInputCountry" aria-hidden="true" />
+          <input
+            id={id}
+            type="tel"
+            inputMode="tel"
+            name="phone"
+            autoComplete={autoComplete}
+            className={inputClassName}
+            placeholder={placeholder}
+            value=""
+            disabled
+            readOnly
+          />
+        </div>
+      )}
       {error && <p className="text-red-400 text-xs mt-1">{error}</p>}
     </div>
   );

--- a/components/creator/earn/ValueProposition.tsx
+++ b/components/creator/earn/ValueProposition.tsx
@@ -20,7 +20,7 @@ export default function ValueProposition() {
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true, margin: "-80px" }}
         transition={{ duration: 0.6 }}
-        className="max-w-[760px] mx-auto text-center space-y-4 md:space-y-6"
+        className="max-w-[760px] mx-auto text-center space-y-3"
       >
         <h2 className="text-[32px] md:text-[44px] font-bold text-white leading-tight">
           {(() => {
@@ -29,14 +29,14 @@ export default function ValueProposition() {
               before
             ) : (
               <>
-                {before}
+                {before} —
                 <br />
                 {after}
               </>
             );
           })()}
         </h2>
-        <p className="text-base md:text-lg text-white/90 leading-relaxed max-w-[640px] mx-auto">
+        <p className="text-base md:text-lg text-white/90 leading-relaxed max-w-[640px] mx-[9px]">
           {t("pitch.description")}
         </p>
       </motion.div>

--- a/components/creator/earn/stories/FloatingHearts.tsx
+++ b/components/creator/earn/stories/FloatingHearts.tsx
@@ -39,7 +39,7 @@ export default function FloatingHearts({ triggerCount }: FloatingHeartsProps) {
 
   return (
     <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-full max-w-[390px] pointer-events-none z-50">
-      <div className="absolute bottom-[51px] right-[76px]">
+      <div className="absolute bottom-[40px] right-[85px]">
         {hearts.map((heart) => (
           <FloatingHeart
             key={heart.id}

--- a/components/creator/earn/stories/StoryContent1.tsx
+++ b/components/creator/earn/stories/StoryContent1.tsx
@@ -13,7 +13,7 @@ export default function StoryContent1({ imageSrc = "/images/creator/earn/story-1
   return (
     <div className="relative w-full h-full">
       {/* Header */}
-      <div className="absolute top-[41px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
+      <div className="absolute top-[16px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
         <div className="flex items-center gap-2">
           {/*<div className="w-9 h-9 rounded-full bg-white overflow-hidden flex items-center justify-center">*/}
           {/*  <span className="text-lg">🐶</span>*/}
@@ -33,7 +33,7 @@ export default function StoryContent1({ imageSrc = "/images/creator/earn/story-1
       </div>
 
       {/* Main Image */}
-      <div className="absolute top-[12%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-3xl overflow-hidden ">
+      <div className="absolute top-[12%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-xl overflow-hidden ">
         <Image
           src={imageSrc}
           alt={"Story"}

--- a/components/creator/earn/stories/StoryContent2.tsx
+++ b/components/creator/earn/stories/StoryContent2.tsx
@@ -14,7 +14,7 @@ export default function StoryContent2({ imageSrc = "/images/creator/earn/story-4
     return (
         <div className="relative w-full h-full ">
             {/* Header */}
-            <div className="absolute top-[41px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
+            <div className="absolute top-[16px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
                 <div className="flex items-center gap-2">
                     {/*<div className="w-9 h-9 rounded-full bg-white overflow-hidden flex items-center justify-center">*/}
                     {/*  <span className="text-lg">🐶</span>*/}
@@ -34,7 +34,7 @@ export default function StoryContent2({ imageSrc = "/images/creator/earn/story-4
             </div>
 
             {/* Main Image */}
-            <div className="absolute top-[12%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-3xl overflow-hidden ">
+            <div className="absolute top-[12%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-xl overflow-hidden ">
                 <Image
                     src={imageSrc}
                     alt={"Story"}

--- a/components/creator/earn/stories/StoryContent3.tsx
+++ b/components/creator/earn/stories/StoryContent3.tsx
@@ -14,7 +14,7 @@ export default function StoryContent3({ imageSrc = "/images/creator/earn/story-3
     return (
         <div className="relative w-full h-full">
             {/* Header */}
-            <div className="absolute top-[41px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
+            <div className="absolute top-[16px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
                 <div className="flex items-center gap-2">
                     {/*<div className="w-9 h-9 rounded-full bg-white overflow-hidden flex items-center justify-center">*/}
                     {/*  <span className="text-lg">🐶</span>*/}
@@ -34,7 +34,7 @@ export default function StoryContent3({ imageSrc = "/images/creator/earn/story-3
             </div>
 
             {/* Main Image */}
-            <div className="absolute top-[12%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-3xl overflow-hidden">
+            <div className="absolute top-[12%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-xl overflow-hidden">
                 <Image
                     src={imageSrc}
                     alt={"Story"}

--- a/components/creator/earn/stories/StoryContent4.tsx
+++ b/components/creator/earn/stories/StoryContent4.tsx
@@ -30,7 +30,7 @@ export default function StoryContent4({ imageSrc = "/images/creator/earn/story-2
   return (
     <div className="relative w-full h-full">
       {/* Header */}
-      <div className="absolute top-[41px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
+      <div className="absolute top-[16px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
         <div className="flex items-center gap-2">
           <Image src={"/images/creator/earn/story-avatar.png"} alt={"Avatar"} width={36} height={36}/>
           <div className="flex flex-col">
@@ -47,7 +47,7 @@ export default function StoryContent4({ imageSrc = "/images/creator/earn/story-2
       </div>
 
       {/* Main Image */}
-      <div className="absolute top-[12%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-3xl overflow-hidden ">
+      <div className="absolute top-[12%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-xl overflow-hidden ">
         <Image
           src={imageSrc}
           alt={"Story"}

--- a/components/creator/earn/stories/StoryPanel.tsx
+++ b/components/creator/earn/stories/StoryPanel.tsx
@@ -85,7 +85,7 @@ export default function StoryPanel({
       </AnimatePresence>
       {/* Close button overlay - positioned to match the X icon in story content */}
       <button
-        className="absolute top-[41px] right-3 z-50 text-white text-3xl p-2"
+        className="absolute top-[16px] right-3 z-50 text-white text-3xl p-2"
         onClick={handleCloseClick}
         onMouseDown={(e) => e.stopPropagation()}
         onTouchStart={(e) => e.stopPropagation()}

--- a/components/creator/otp/PhoneOtpFlow.tsx
+++ b/components/creator/otp/PhoneOtpFlow.tsx
@@ -148,6 +148,7 @@ export default function PhoneOtpFlow({
               value={phone}
               onChange={setPhone}
               placeholder={t("hero.card.phonePlaceholder")}
+              theme={isLight ? "light" : "dark"}
               inputClassName={
                 isLight
                   ? "bg-transparent border-none outline-none text-base placeholder:text-[#999999] focus:outline-none focus:ring-0 w-full text-[#212529]"

--- a/components/creator/promo/PromoSignupCard.tsx
+++ b/components/creator/promo/PromoSignupCard.tsx
@@ -223,7 +223,7 @@ export default function PromoSignupCard({
         y: { duration: 0.7, times: [0, 0.4, 1], ease: [0.34, 1.4, 0.64, 1] },
         boxShadow: { duration: 0.7, times: [0, 0.4, 1], ease: [0.4, 0, 0.2, 1] },
       }}
-      className={`relative mx-auto w-full max-w-md rounded-[24px] px-3 py-4 ${isEarn ? "border-b border-white/80" : ""}`}
+      className={`relative mx-auto w-full max-w-md rounded-[24px] px-3 py-4 ${isEarn ? "border-b border-white" : ""}`}
     >
       {/* Earn variant: top-right corner coin peeks above the card. Sibling of
           the voucher row so it's positioned relative to the outer card box
@@ -422,6 +422,7 @@ export default function PromoSignupCard({
               placeholder={t("hero.card.phonePlaceholder")}
               disabled={phoneLocked}
               autoComplete="off"
+              theme="light"
               inputClassName="bg-transparent border-none outline-none text-base placeholder:text-[#999999] focus:outline-none focus:ring-0 w-full text-[#212529] disabled:bg-transparent"
             />
           </Suspense>

--- a/components/creator/promo/ThreeStepSection.tsx
+++ b/components/creator/promo/ThreeStepSection.tsx
@@ -25,18 +25,18 @@ function StepCard({ index, title, description, tags, imageUrl }: ThreeStepItem &
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, margin: "-50px" }}
       transition={{ duration: 0.5, delay: index * 0.05 }}
-      className="relative w-full max-w-[420px] rounded-[24px] p-3.5 md:p-5 bg-white/5 border border-white/10 backdrop-blur-md shadow-[0_8px_24px_rgba(0,0,0,0.18)]"
+      className="relative w-full max-w-[420px] rounded-[24px] px-2 py-3 md:p-5 bg-white/5 border border-white/10 backdrop-blur-md shadow-[0_8px_24px_rgba(0,0,0,0.18)]"
     >
-      <div className="flex items-start gap-2">
+      <div className="flex items-center gap-2">
         {/* Phone illustration */}
-        <div className="relative shrink-0 w-16 h-16">
+        <div className="relative shrink-0 w-16 h-[63px]">
           <Image src={imageUrl} alt="" fill sizes="64px" className="object-contain" />
         </div>
 
         {/* Title + description + tags */}
         <div className="flex-1 min-w-0">
           <h3 className="text-white font-bold text-lg md:text-xl leading-tight tracking-[-0.04em]">{title}</h3>
-          <p className="mt-1.5 text-white text-sm leading-snug">{description}</p>
+          <p className="mt-1.5 text-white text-sm leading-[150%]">{description}</p>
 
           {tags.length > 0 && (
             <div className="mt-3 flex flex-wrap gap-1">
@@ -78,7 +78,7 @@ export default function BenefitsSection({
   const steps: ThreeStepItem[] = Array.isArray(rawItems) ? (rawItems as ThreeStepItem[]) : [];
 
   return (
-    <section ref={sectionRef} className="relative py-5 md:py-12 px-5 md:px-20">
+    <section ref={sectionRef} className="relative pb-5 md:pb-12 px-5 md:px-20">
       <div className="max-w-[1200px] mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 16 }}

--- a/public/locales/hi-Latn/creatorEarn.json
+++ b/public/locales/hi-Latn/creatorEarn.json
@@ -28,7 +28,7 @@
     }
   },
   "pitch": {
-    "heading": "Duniya ka pehla AI — sirf creators ke liye.",
+    "heading": "Duniya ka pehla AI — sirf Creators ke liye.",
     "description": "Late payments, baar-baar follow-ups aur tax ka jhanjhat — ab khatam! Creators ke liye banaya pehla AI — jo smart payments se shuru hota hai. Aap content banayein, Follow-ups hum sambhal lenge."
   },
   "threeStep": {


### PR DESCRIPTION
## Summary

Polish pass on the creator/earn mobile experience plus a new shared mobile footer used by blog and earn. Also adds a `light` theme to `ValidatedPhoneInput` so the country dropdown is visible on white pill backgrounds, and ships an SSR-safe placeholder to kill the hydration mismatch the library was causing.

Detailed change breakdown is posted as the first comment on this PR.

## Test plan

- [ ] `/creator/earn` on mobile: story carousel renders in the compact embedded frame; progress bars animate; story 4 lights the heart red and shows rising hearts.
- [ ] Phone input on the earn / promo signup card shows a dark country arrow and white dropdown (no invisible arrow on white background).
- [ ] No React hydration warning in the console for any phone input.
- [ ] `/blogs` and `/creator/earn` on mobile show the new `SiteMobileFooter` (light on blogs, dark on earn) with all link columns + socials.
- [ ] Desktop footer (`>=md`) on both blog and earn still shows the existing layout with the added **Creator Payments** + **Cookie Options** links.
- [ ] Open a story full-screen: header and close button align with the new `top-[16px]`.
- [ ] hi-Latn `/creator/earn`: `pitch.heading` shows "Creators" capitalized.
