### PR TITLE
tweak: drop earn stories A/B test and polish mobile spacing

### DIFF
--- a/app/creator/earn/CreatorEarnPage.tsx
+++ b/app/creator/earn/CreatorEarnPage.tsx
@@ -2,16 +2,13 @@
 
 import {Suspense, useEffect, useState} from "react";
 import {useSearchParams} from "next/navigation";
-import {AnimatePresence, motion} from "framer-motion";
 import {useTranslation} from "react-i18next";
 import dynamic from "next/dynamic";
 import "@/lib/i18n"; // Initialize i18n
 import Navigation from "@/components/creator/earn/Navigation";
 import HeroSection from "@/components/creator/earn/HeroSection";
-import StoriesContainer from "@/components/creator/earn/stories/StoriesContainer";
 import ReferralBanner from "@/components/creator/earn/ReferralBanner";
 import { SignupProvider } from "@/components/creator/promo/SignupContext";
-import {track} from "@/lib/analytics/track";
 
 const ValueProposition = dynamic(() => import("@/components/creator/earn/ValueProposition"));
 const ThreeStepSection = dynamic(() => import("@/components/creator/promo/ThreeStepSection"));
@@ -25,8 +22,6 @@ const FloatingCTA = dynamic(() => import("@/components/creator/earn/FloatingCTA"
 function CreatorEarnPageContent() {
   const {i18n} = useTranslation();
   const searchParams = useSearchParams();
-  const [showStories, setShowStories] = useState(false);
-  const [showLandingPage, setShowLandingPage] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -37,38 +32,8 @@ function CreatorEarnPageContent() {
     }
     // Don't force English - let the user's selection persist
 
-    const storiesViewed = sessionStorage.getItem("storiesViewed");
-    const referralCode = searchParams.get("ref");
-
-    if (referralCode || storiesViewed === "true") {
-      setShowLandingPage(true);
-      setShowStories(false);
-    } else {
-      const variant = Math.random() < 0.5 ? "show_stories" : "no_stories";
-      track("earn_stories_ab_exposure", {
-        test_name: "earn_stories_50_50",
-        variant,
-      });
-
-      if (variant === "show_stories") {
-        setShowStories(true);
-        setShowLandingPage(false);
-      } else {
-        sessionStorage.setItem("storiesViewed", "true");
-        setShowLandingPage(true);
-        setShowStories(false);
-      }
-    }
-
     setIsLoading(false);
   }, [searchParams, i18n]);
-
-  const handleStoriesComplete = () => {
-    setShowStories(false);
-    setTimeout(() => {
-      setShowLandingPage(true);
-    }, 300);
-  };
 
   // Show loading state briefly
   if (isLoading) {
@@ -81,71 +46,62 @@ function CreatorEarnPageContent() {
 
   return (
     <SignupProvider>
-      {/* Stories Experience */}
-      {showStories && <StoriesContainer onComplete={handleStoriesComplete} />}
+      <main className="relative min-h-screen bg-black overflow-hidden">
+        {/* Background Gradients — tuned to reach the end of the FAQ
+            (the "View All" / "Show Less" toggle), so bg-black only
+            shows behind the footer below it. */}
+        <div className="absolute -top-[400px] -left-[940px] inset-0 pointer-events-none">
+          <div className="mt-[900px] w-[2422px] h-[2422px] md:w-[4500px] gradient-blob" />
+          <div className="-mt-[1000px] w-[2422px] h-[44%] md:w-[4500px] md:h-[41%] gradient-blob" />
+        </div>
 
-      {/* Main Landing Page */}
-      <AnimatePresence>
-        {showLandingPage && (
-          <motion.main
-            className="relative min-h-screen bg-black overflow-hidden"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.6 }}
-          >
-            {/* Background Gradients — tuned to reach the end of the FAQ
-                (the "View All" / "Show Less" toggle), so bg-black only
-                shows behind the footer below it. */}
-            <div className="absolute -top-[400px] -left-[940px] inset-0 pointer-events-none">
-              <div className="mt-[900px] w-[2422px] h-[2422px] md:w-[4500px] gradient-blob" />
-              <div className="-mt-[1000px] w-[2422px] h-[44%] md:w-[4500px] md:h-[41%] gradient-blob" />
-            </div>
+        {/* Content */}
+        <div className="relative z-10">
+          <Navigation />
+          <Suspense fallback={null}>
+            <ReferralBanner />
+          </Suspense>
+          <HeroSection />
+          <ValueProposition />
+          <ThreeStepSection namespace="creatorEarn" trackingId="earn_three_step" />
+          <PhoneMockupSection />
+          <TestimonialsSection
+            namespace="creatorEarn"
+            trackingId="earn_testimonials"
+            disableSlideEntryAnimation
+          />
+          <AdvantageSection
+            variant="promo"
+            namespace="creatorEarn"
+            trackingId="earn_advantage"
+            analyticsEvent="earn_cta_click"
+          />
+          <FAQSection
+            namespace="creatorEarn"
+            trackingId="earn_faq"
+            analyticsEvent="earn_faq_toggle"
+            expandInline
+          />
+          <EarnFooter />
+        </div>
 
-            {/* Content */}
-            <div className="relative z-10">
-              <Navigation />
-              <Suspense fallback={null}>
-                <ReferralBanner />
-              </Suspense>
-              <HeroSection />
-              <ValueProposition />
-              <ThreeStepSection namespace="creatorEarn" trackingId="earn_three_step" />
-              <PhoneMockupSection />
-              <TestimonialsSection
-                namespace="creatorEarn"
-                trackingId="earn_testimonials"
-                disableSlideEntryAnimation
-              />
-              <AdvantageSection
-                variant="promo"
-                namespace="creatorEarn"
-                trackingId="earn_advantage"
-                analyticsEvent="earn_cta_click"
-              />
-              <FAQSection
-                namespace="creatorEarn"
-                trackingId="earn_faq"
-                analyticsEvent="earn_faq_toggle"
-                expandInline
-              />
-              <EarnFooter />
-            </div>
-
-            {/* Floating CTA — earn variant mirrors the hero card's pitch
-                (dark surface, FlippingCoin, Win-Gold-Coin heading, inline
-                checks, white phone pill, Win Now). Phone input is piped into
-                the shared SignupContext so submitting from the bottom bar
-                advances the hero card straight to OTP. triggerElementId
-                hides the bar while the hero card is on-screen. */}
-            <FloatingCTA
-              variant="earn"
-              namespace="creatorEarn"
-              trackingPrefix="earn"
-              triggerElementId="promo-hero-card"
-            />
-          </motion.main>
-        )}
-      </AnimatePresence>
+        {/* Floating CTA — earn variant mirrors the hero card's pitch
+            (dark surface, FlippingCoin, Win-Gold-Coin heading, inline
+            checks, white phone pill, Win Now). Phone input is piped into
+            the shared SignupContext so submitting from the bottom bar
+            advances the hero card straight to OTP. triggerElementId
+            hides the bar while the hero card is on-screen.
+            Kept as a direct child of <main> (no motion wrapper) so
+            position:fixed anchors to the viewport — wrapping in motion.*
+            can promote the ancestor to a containing block on some mobile
+            browsers and pin the bar mid-page. */}
+        <FloatingCTA
+          variant="earn"
+          namespace="creatorEarn"
+          trackingPrefix="earn"
+          triggerElementId="promo-hero-card"
+        />
+      </main>
     </SignupProvider>
   );
 }

--- a/components/common/SiteMobileFooter.tsx
+++ b/components/common/SiteMobileFooter.tsx
@@ -30,7 +30,7 @@ export default function SiteMobileFooter({
     >
       <div className={`w-full border-t ${dividerClass}`} />
 
-      <div className="w-full max-w-xs flex justify-start">
+      <div className="w-full flex justify-start">
         <Image
           src={isDark ? "/sparkonomy_full.png" : "/FooterLogo.png"}
           alt="Sparkonomy"
@@ -40,7 +40,7 @@ export default function SiteMobileFooter({
         />
       </div>
 
-      <div className="grid grid-cols-2 gap-x-12 gap-y-6 w-full max-w-xs">
+      <div className="flex justify-between w-full">
         <div className="flex flex-col gap-6">
           <div className="flex flex-col gap-2">
             <p className={`${headingClass} text-sm font-medium`}>Company</p>

--- a/components/creator/earn/FloatingCTA.tsx
+++ b/components/creator/earn/FloatingCTA.tsx
@@ -201,7 +201,7 @@ function EarnFloatingCTA({ isVisible, t, trackingPrefix }: EarnVariantProps) {
             {/* Inline checks — single row mirroring the hero card's earn
                 layout. 10.5px so all three fit on a 360px viewport. */}
             {checks.length > 0 && (
-              <ul className="mt-1.5 flex items-center text-[10.5px] font-normal text-white whitespace-nowrap gap-x-2">
+              <ul className="mt-1.5 flex items-center text-[10.5px] font-normal text-white whitespace-nowrap gap-x-3.5">
                 {checks.map((label, i) => (
                   <li key={i} className="flex items-center gap-1">
                     <span aria-hidden="true">✅</span>

--- a/components/creator/promo/PromoSignupCard.tsx
+++ b/components/creator/promo/PromoSignupCard.tsx
@@ -223,7 +223,7 @@ export default function PromoSignupCard({
         y: { duration: 0.7, times: [0, 0.4, 1], ease: [0.34, 1.4, 0.64, 1] },
         boxShadow: { duration: 0.7, times: [0, 0.4, 1], ease: [0.4, 0, 0.2, 1] },
       }}
-      className={`relative mx-auto w-full max-w-md rounded-[24px] px-3 py-4 ${isEarn ? "border-b border-white" : ""}`}
+      className={`relative mx-auto w-full max-w-[468px] rounded-[24px] px-3 py-4 ${isEarn ? "border-b border-white" : ""}`}
     >
       {/* Earn variant: top-right corner coin peeks above the card. Sibling of
           the voucher row so it's positioned relative to the outer card box
@@ -396,7 +396,7 @@ export default function PromoSignupCard({
           </ul>
         </div>
       ) : !otpVisible ? (
-        <ul className="mt-1 px-1 flex items-center justify-center text-[11px] font-normal text-white whitespace-nowrap">
+        <ul className="mt-1 px-1 flex items-center justify-center text-[11px] font-normal text-white whitespace-nowrap gap-x-3.5">
           {checks.map((label, i) => (
             <li key={i} className="flex items-center gap-1">
               <span aria-hidden="true">✅</span>


### PR DESCRIPTION
## Summary
- Removed the stories A/B test from the creator earn flow — `CreatorEarnPage` now renders the landing directly (no `StoriesContainer`, no `AnimatePresence`/`motion.main` wrapper, no `earn_stories_ab_exposure` track call, no `storiesViewed` sessionStorage branch).
- `SiteMobileFooter`: dropped the `max-w-xs` clamp on the logo + link sections and switched the link grid from `grid-cols-2 gap-x-12` to `flex justify-between w-full` so the Company / Resources columns spread to the full footer width on mobile.
- `FloatingCTA` (earn variant) and `PromoSignupCard`: widened the inline check-row gap from `gap-x-2` → `gap-x-3.5` so the ✅ items breathe at small viewports.
- `PromoSignupCard`: widened the card cap from `max-w-md` to `max-w-[468px]` to match the new floating CTA proportions.

## Test plan
- [ ] `/creator/earn` loads directly into the landing page (no stories intro, no flash) on a fresh session
- [ ] `?ref=` referral links still land correctly with the ReferralBanner visible
- [ ] Floating CTA stays pinned to the viewport bottom on mobile and only hides while the hero card is on-screen
- [ ] Mobile footer logo + Company/Resources columns span the full width with comfortable spacing
- [ ] Hero card + floating CTA ✅ check rows render on a 360px viewport without clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)