### PR TITLE
perf(creator/earn): faster story LCP + stable hero for Speed Index

### DIFF
--- a/app/creator/earn/page.tsx
+++ b/app/creator/earn/page.tsx
@@ -83,16 +83,20 @@ export default async function Page({ searchParams }: Props) {
   return (
     <>
       {shouldPreloadStories &&
-        // Skip index 0 — Next/Image `priority` already emits a matched
-        // high-priority preload for story 1. Warm 2-4 at low priority.
-        stories.slice(1).map((file) => (
+        stories.map((file, i) => (
           <link
             key={file}
             rel="preload"
             as="image"
             href={nextImageUrl(base + file, 640)}
             imageSrcSet={storySrcSet(base + file)}
-            fetchPriority="low"
+            // Story 1 is the LCP — preload it at high priority from the document
+            // head (Next/Image `priority` alone wasn't getting fetchpriority=high
+            // onto the actual request). The srcset matches the carousel <Image>
+            // exactly, so this preload is the request the browser uses. Stories
+            // 2-4 load at low priority during idle so they're decoded before the
+            // (load-gated) rotation reaches them — no black flash on swap.
+            fetchPriority={i === 0 ? "high" : "low"}
           />
         ))}
       <CreatorEarnPage />

--- a/components/creator/earn/HeroStoryCarousel.tsx
+++ b/components/creator/earn/HeroStoryCarousel.tsx
@@ -53,10 +53,32 @@ export default function HeroStoryCarousel() {
     // a frozen hero was hitting a large slice of mobile traffic, not just users
     // who opted into reduced motion. Reduced motion is honoured by swapping the
     // images instantly (no crossfade) below, not by stopping rotation.
-    const id = window.setInterval(() => {
-      setIndex((i) => (i + 1) % TOTAL_STORIES);
-    }, STORY_INTERVAL_MS);
-    return () => window.clearInterval(id);
+    let intervalId: number | undefined;
+    let fallbackId: number | undefined;
+    const start = () => {
+      if (intervalId !== undefined) return;
+      window.clearTimeout(fallbackId);
+      intervalId = window.setInterval(() => {
+        setIndex((i) => (i + 1) % TOTAL_STORIES);
+      }, STORY_INTERVAL_MS);
+    };
+    // Hold story 1 until the page finishes loading before auto-advancing. This
+    // keeps the hero visually stable through the first-paint window (so swaps
+    // don't inflate Speed Index) and guarantees stories 2-4 have been preloaded
+    // and decoded before they're shown (no black flash between stories on slow
+    // connections). Fast connections fire 'load' within a second or two, so real
+    // users still get prompt rotation; the 6s fallback covers a stalled 'load'.
+    if (document.readyState === "complete") {
+      start();
+    } else {
+      window.addEventListener("load", start, { once: true });
+      fallbackId = window.setTimeout(start, 6000);
+    }
+    return () => {
+      window.removeEventListener("load", start);
+      window.clearTimeout(fallbackId);
+      if (intervalId !== undefined) window.clearInterval(intervalId);
+    };
   }, []);
 
   // Hearts fountain only runs while the hearts story is active.

--- a/components/creator/earn/ValueProposition.tsx
+++ b/components/creator/earn/ValueProposition.tsx
@@ -36,7 +36,7 @@ export default function ValueProposition() {
             );
           })()}
         </h2>
-        <p className="text-base md:text-lg text-white/90 leading-relaxed max-w-[640px] mx-[9px]">
+        <p className="text-base md:text-lg text-white/90 leading-relaxed max-w-[640px] mx-auto">
           {t("pitch.description")}
         </p>
       </motion.div>


### PR DESCRIPTION
Follow-up to the merged mobile-perf PR (#207). After that landed, mobile PageSpeed went **53 → 80**, with **FCP 1.1s, TBT 110ms, CLS 0** all green. The two remaining weak metrics — **LCP 3.8s** and **Speed Index 8.0s** — are both dominated by the hero story image. This PR targets them.

## Changes

### 1. Story 1 loads first (LCP + the "black space before story renders")
PageSpeed's *"fetchpriority=high should be applied to the image preload request"* was still failing — Next/Image `priority` wasn't getting a high-priority hint onto the actual request, so the LCP image arrived at 3.8s. Now an **explicit high-priority preload for story 1** is emitted from the document `<head>`, with a srcset that matches the carousel `<Image>` exactly (so it's the request the browser actually uses, deduped with Next's own preload — no double fetch). Stories 2–4 stay at low priority so they fill during idle without competing with the LCP fetch.

### 2. Hero stays stable; swaps never flash black (Speed Index)
The carousel advanced every 2s — *faster than images load on Slow 4G* — so each swap flashed black → image, repeatedly, inflating SI to 8s. Auto-rotation now **waits for `window.load`** (6s fallback): the hero holds on story 1 through the first-paint window, and stories 2–4 finish decoding before they're shown. Fast connections fire `load` in ~1–2s, so real users still get prompt rotation — it self-adapts.

### 3. Value-proposition paragraph centering
Drive-by fix carried over: the pitch paragraph used `mx-[9px] md:mx-auto`, but the arbitrary-value margin can out-order the responsive rule in Tailwind's output, pinning the block 9px off-center on desktop. Switched to a plain `mx-auto`.

## Verify
- `next build` compiles successfully.
- Re-run PageSpeed after deploy — LCP and SI should move; the `fetchpriority` audit should pass.

## Note
Legacy-JS polyfills (26 KB) still showed in the last report — the `browserslist` from #207 was clearly not in the measured build yet. Should drop on the next deploy; if it persists, the polyfills are likely from a dependency and need separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)