### PR TITLE
fix(seo): make homepage footer nav links crawlable (SSR) without breaking the intro

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -107,7 +107,10 @@ export default function Footer({ minimal = false }: FooterProps) {
             <EmailCapture />
           </motion.div>
         )}
-        {(minimal || heroReady) && <HomeFooterLinks />}
+        {/* Always rendered so the nav links exist in the server-rendered HTML
+            (crawlable without interaction); only the visual reveal is gated on
+            heroReady, preserving the pitch-black intro before interaction. */}
+        <HomeFooterLinks visible={minimal || heroReady} />
       </div>
     </motion.footer>
   );

--- a/components/home/HomeFooterLinks.tsx
+++ b/components/home/HomeFooterLinks.tsx
@@ -6,15 +6,22 @@ import Link from "next/link";
 
 interface HomeFooterLinksProps {
   className?: string;
+  /**
+   * Controls the visual reveal. When false the links stay invisible
+   * (opacity 0, non-interactive) but remain in the server-rendered HTML
+   * so crawlers can discover them without a user interaction. Defaults to
+   * true so minimal footers (legal/creator/etc.) behave exactly as before.
+   */
+  visible?: boolean;
 }
 
-export default function HomeFooterLinks({className}: HomeFooterLinksProps) {
+export default function HomeFooterLinks({className, visible = true}: HomeFooterLinksProps) {
   return (
     <motion.div
-      className={`pointer-events-auto w-full ${className ?? ""}`}
+      className={`w-full ${visible ? "pointer-events-auto" : "pointer-events-none"} ${className ?? ""}`}
       initial={{opacity: 0}}
-      animate={{opacity: 1}}
-      transition={{delay: 0.8}}
+      animate={{opacity: visible ? 1 : 0}}
+      transition={{delay: visible ? 0.8 : 0}}
     >
       {/* Mobile (<md): comprehensive footer with logo, columns, copyright + social row */}
       <div className="md:hidden flex flex-col items-center gap-6 w-full pt-10 text-gray-400">


### PR DESCRIPTION
## Problem

On the homepage, the footer navigation links were **conditionally mounted** behind the `heroReady` state ([Footer.tsx](components/Footer.tsx)). `heroReady` only flips `true` after the GSAP intro finishes **and** a user gesture (`mousemove`/`click`/`touchstart`) fires the `hero-ready` event.

Googlebot does not move a mouse, click, or scroll — Google states plainly that Google Search does not interact with your page. So on a normal crawl of `/`, the footer links were **absent from the server-rendered HTML** and effectively uncrawlable. This is a *mounting* problem, not a CSS-visibility problem.

## Fix

Stop unmounting the links — always render `<HomeFooterLinks>`, and gate only the **visual reveal** (opacity + pointer-events) on `heroReady` via a new `visible` prop.

- The real anchors now appear in the initial SSR HTML, so they are crawlable with **no interaction**.
- The pitch-black intro is fully preserved: the wrapper stays `opacity:0` + `pointer-events-none` until `heroReady`, so links are invisible and non-clickable before reveal.
- Reveal behaviour on interaction is unchanged.
- `visible` defaults to `true`, so the minimal footers (legal/creator pages) behave exactly as before.

## What this is NOT

- No `clip()` / `sr-only` hidden-text trick (gray-zone spam risk; serves no real user value).
- No `SiteNavigationElement` JSON-LD — sitelinks are 100% algorithmic and that type is not a supported Google structured-data feature, so it would be inert.
- No hardcoded `/pricing` `/terms` `/privacy` `/cookies` URLs (3 of those 404). Reuses the existing correct routes.

## Verification

Ran the dev server and fetched the homepage **raw** (no JS execution = exactly what a crawler's initial fetch sees). With zero interaction, the server HTML contained all 7 links inside an `opacity:0` / `pointer-events-none` wrapper (About Us, Contact Us, Blogs, Creator Payments, Privacy Policy, Terms of Services, Refund Policy).

## Files changed

- `components/Footer.tsx` — always render `<HomeFooterLinks visible={minimal || heroReady} />`
- `components/home/HomeFooterLinks.tsx` — add `visible` prop driving opacity + interactivity

## Note on sitelinks

This gets core links into crawlable HTML (a legitimate internal-linking signal), but search sitelinks remain algorithmic and not guaranteed — give Google recrawl time and keep these pages in the sitemap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
