### PR TITLE
SEO: fix author-page canonicals + strengthen author entity signals

### DIFF
--- a/app/blogs/[slug]/page.tsx
+++ b/app/blogs/[slug]/page.tsx
@@ -3,9 +3,8 @@ import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { getPostBySlug, getPostBySlugForLang, hasHinglishVersion, getEnglishSlug, getFeaturedImageUrl, getAuthorName, getAuthorNames, getPostAuthors, getPostAuthorsAsync, formatDate, stripHtml, decodeHtmlEntities, getReadingTime, getPosts, getPostsByCategory, type BlogLang } from "@/lib/wordpress-improved";
+import { getPostBySlugForLang, hasHinglishVersion, getEnglishSlug, getFeaturedImageUrl, getAuthorNames, getPostAuthors, getPostAuthorsAsync, formatDate, stripHtml, decodeHtmlEntities, getReadingTime, getPosts, getPostsByCategory, type BlogLang } from "@/lib/wordpress-improved";
 import { extractHeadings, addHeadingIds, extractFAQs, extractVideos, removeWordPressTOC, extractFirstParagraph, removeLeadingFeaturedImageBlock, processH6Markers, lazyLoadImages, openLinksInNewTab } from "@/lib/content-processor";
-import ShareButtons from "@/components/blog/ShareButtons";
 import Breadcrumb from "@/components/blog/Breadcrumb";
 import BlogLanguageSwitcher from "@/components/blog/BlogLanguageSwitcher";
 import TOCEnhancer from "@/components/blog/TOCEnhancer";
@@ -31,6 +30,7 @@ import RelatedResourcesInjector from "@/components/blog/RelatedResourcesInjector
 import BlogScrollTracker from "@/components/blog/BlogScrollTracker";
 import MetaShareButton from "@/components/blog/MetaShareButton";
 import { getAuthorPageSlug, getAuthorByWordPressSlug, getAuthorBySlug, isFoundingTeamPost } from "@/data/authors";
+import { SITE_URL, authorUrl } from "@/lib/urls";
 import "../wordpress-content.css";
 
 interface BlogPostPageProps {
@@ -292,6 +292,45 @@ export default async function BlogPostPage({ params, searchParams }: BlogPostPag
   const faqItems = extractFAQs(post.content.rendered);
   const videoItems = extractVideos(post.content.rendered, stripHtml(post.title.rendered), post.date);
 
+  // Single source of truth for the author Person node so the BlogPosting.author,
+  // the standalone Person, and the author page's ProfilePage>Person all share one
+  // @id and canonical url — letting search engines and LLMs unify the article
+  // author with their profile entity instead of treating them as separate people.
+  const orgRef = {
+    "@type": "Organization",
+    "@id": "https://www.sparkonomy.com/#organization",
+    name: "Sparkonomy",
+    url: "https://www.sparkonomy.com",
+  };
+  const buildPersonNode = (a: (typeof authorsWithLocalData)[number]) => {
+    const profileUrl = authorUrl(a.authorPageSlug);
+    const img = a.avatarUrl
+      ? a.avatarUrl.startsWith("http")
+        ? a.avatarUrl
+        : `${SITE_URL}${a.avatarUrl}`
+      : undefined;
+    return {
+      "@type": "Person",
+      "@id": `${profileUrl}#person`,
+      name: a.name,
+      url: profileUrl,
+      ...(img ? { image: img } : {}),
+      jobTitle: a.role,
+      worksFor: orgRef,
+      sameAs: [
+        a.socialLinks?.linkedin,
+        a.socialLinks?.instagram,
+        a.socialLinks?.youtube,
+        a.socialLinks?.twitter,
+        a.socialLinks?.website,
+        a.wpAuthor?.link,
+      ].filter(Boolean),
+      ...(a.localAuthor?.areasOfExpertise?.length
+        ? { knowsAbout: a.localAuthor.areasOfExpertise }
+        : {}),
+    };
+  };
+
   // Generate comprehensive JSON-LD structured data for SEO
   const articleJsonLd = {
     "@context": "https://schema.org",
@@ -307,26 +346,8 @@ export default async function BlogPostPage({ params, searchParams }: BlogPostPag
     datePublished: post.date,
     dateModified: post.modified,
     author: authorsWithLocalData.length === 1
-      ? {
-          "@type": "Person",
-          name: authorsWithLocalData[0].name,
-          url: authorsWithLocalData[0].wpAuthor.link || "https://sparkonomy.com",
-          jobTitle: authorsWithLocalData[0].role,
-          worksFor: {
-            "@type": "Organization",
-            name: "Sparkonomy",
-          },
-        }
-      : authorsWithLocalData.map(authorData => ({
-          "@type": "Person",
-          name: authorData.name,
-          url: authorData.wpAuthor.link || "https://sparkonomy.com",
-          jobTitle: authorData.role,
-          worksFor: {
-            "@type": "Organization",
-            name: "Sparkonomy",
-          },
-        })),
+      ? buildPersonNode(authorsWithLocalData[0])
+      : authorsWithLocalData.map(buildPersonNode),
     publisher: {
       "@type": "Organization",
       name: "Sparkonomy",
@@ -392,25 +413,12 @@ export default async function BlogPostPage({ params, searchParams }: BlogPostPag
     ],
   };
 
-  // Author/Person structured data (array for multiple authors)
-  const authorJsonLd = authorsWithLocalData.map(authorData => ({
+  // Author/Person structured data (array for multiple authors). Shares the same
+  // @id, canonical url and absolute image as the BlogPosting.author node and the
+  // author page's ProfilePage>Person, unifying the author across documents.
+  const authorJsonLd = authorsWithLocalData.map((authorData) => ({
     "@context": "https://schema.org",
-    "@type": "Person",
-    name: authorData.name,
-    url: authorData.wpAuthor.link || "https://sparkonomy.com",
-    image: authorData.avatarUrl || "",
-    jobTitle: authorData.role,
-    worksFor: {
-      "@type": "Organization",
-      name: "Sparkonomy",
-      url: "https://sparkonomy.com",
-    },
-    sameAs: [
-      authorData.socialLinks?.linkedin,
-      authorData.socialLinks?.instagram,
-      authorData.socialLinks?.youtube,
-      authorData.socialLinks?.twitter,
-    ].filter(Boolean),
+    ...buildPersonNode(authorData),
   }));
 
   // FAQ structured data (if FAQs exist)

--- a/app/blogs/author/[slug]/page.tsx
+++ b/app/blogs/author/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
   decodeHtmlEntities,
   getReadingTime,
 } from "@/lib/wordpress-improved";
+import { SITE_URL, authorPath, authorUrl } from "@/lib/urls";
 
 interface AuthorPageProps {
   params: Promise<{
@@ -37,7 +38,7 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
 
   if (!author) {
     return {
-      metadataBase: new URL("https://www.sparkonomy.com/"),
+      metadataBase: new URL(SITE_URL),
       title: "Author Not Found",
       description: "The requested author could not be found.",
     };
@@ -52,8 +53,7 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
     author.shortBio ||
     `Read articles by ${author.name} on Sparkonomy. Expert insights on ${expertiseText}, and digital marketing.`;
 
-  const canonicalPath = author.canonicalPath || `/blogs/author/${author.slug}`;
-  const canonicalUrl = `https://www.sparkonomy.com${canonicalPath}`;
+  const canonicalUrl = authorUrl(author.slug);
 
   return {
     metadataBase: new URL("https://www.sparkonomy.com/"),
@@ -72,7 +72,7 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
     creator: author.name,
     publisher: "Sparkonomy",
     alternates: {
-      canonical: canonicalUrl,
+      canonical: authorPath(author.slug),
     },
     robots: {
       index: true,
@@ -179,15 +179,19 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     console.error("Error fetching latest WordPress posts:", latestResult.reason);
   }
 
-  // Build social links array for structured data
-  const sameAsLinks: string[] = [];
-  if (author.socialLinks?.linkedin) sameAsLinks.push(author.socialLinks.linkedin);
-  if (author.socialLinks?.twitter) sameAsLinks.push(author.socialLinks.twitter);
-  if (author.socialLinks?.website) sameAsLinks.push(author.socialLinks.website);
+  // Build social links array for structured data. sameAs is the dominant
+  // person-entity signal — include every known profile (not email).
+  const sameAsLinks: string[] = [
+    author.socialLinks?.linkedin,
+    author.socialLinks?.twitter,
+    author.socialLinks?.instagram,
+    author.socialLinks?.youtube,
+    author.socialLinks?.facebook,
+    author.socialLinks?.website,
+  ].filter((u): u is string => Boolean(u));
 
-  const canonicalPath = author.canonicalPath || `/blogs/author/${author.slug}`;
-  const canonicalUrl = `https://www.sparkonomy.com${canonicalPath}`;
-  const blogUrl = "https://www.sparkonomy.com/blogs";
+  const canonicalUrl = authorUrl(author.slug);
+  const blogUrl = `${SITE_URL}/blogs`;
 
   // Organization structured data (standalone for Identity Schema)
   const organizationJsonLd = {
@@ -209,9 +213,9 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     ],
   };
 
-  // Structured data for the author page
-  const authorJsonLd = {
-    "@context": "https://schema.org",
+  // Person entity — nested as the ProfilePage's mainEntity, so it carries no
+  // own @context.
+  const personEntity = {
     "@type": "Person",
     "@id": `${canonicalUrl}#person`,
     name: author.name,
@@ -226,20 +230,23 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     knowsAbout: author.areasOfExpertise,
   };
 
-  // Breadcrumb structured data
-  const breadcrumbItems =
-    author.canonicalPath && author.canonicalPath.startsWith("/authors/")
-      ? [
-          { name: "Home", item: "https://www.sparkonomy.com" },
-          { name: "Blog", item: blogUrl },
-          { name: "Authors", item: `${blogUrl}` },
-          { name: author.name, item: canonicalUrl },
-        ]
-      : [
-          { name: "Home", item: "https://www.sparkonomy.com" },
-          { name: "Blog", item: blogUrl },
-          { name: author.name, item: canonicalUrl },
-        ];
+  // ProfilePage wrapping the Person — Google's recommended shape for author
+  // pages; helps establish the author as an entity in the Knowledge Graph.
+  const profilePageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    "@id": canonicalUrl,
+    url: canonicalUrl,
+    name: author.metaTitle || `${author.name} — ${author.role}`,
+    mainEntity: personEntity,
+  };
+
+  // Breadcrumb structured data (Home › Blog › Author)
+  const breadcrumbItems = [
+    { name: "Home", item: SITE_URL },
+    { name: "Blog", item: blogUrl },
+    { name: author.name, item: canonicalUrl },
+  ];
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
@@ -260,10 +267,10 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
       />
 
-      {/* Author Structured Data */}
+      {/* Author Structured Data (ProfilePage → Person) */}
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(authorJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(profilePageJsonLd) }}
       />
 
       {/* Breadcrumb Structured Data */}

--- a/app/blogs/author/[slug]/page.tsx
+++ b/app/blogs/author/[slug]/page.tsx
@@ -13,7 +13,6 @@ import {
   getPostsByAuthorSlug,
   getFeaturedImageUrl,
   formatDate,
-  stripHtml,
   decodeHtmlEntities,
   getReadingTime,
 } from "@/lib/wordpress-improved";
@@ -23,6 +22,22 @@ interface AuthorPageProps {
   params: Promise<{
     slug: string;
   }>;
+}
+
+// Build an absolute URL from a possibly-relative asset path. JSON-LD is NOT
+// resolved against metadataBase, so Person/Organization images embedded in
+// structured data must be absolute or they are invalid.
+function absoluteUrl(path?: string): string | undefined {
+  if (!path) return undefined;
+  return path.startsWith("http") ? path : `${SITE_URL}${path}`;
+}
+
+// Convert a human "Month DD, YYYY" date into an ISO 8601 date (YYYY-MM-DD).
+// Appending " UTC" forces UTC parsing so the value never shifts by a day.
+function toIsoDate(human?: string): string | undefined {
+  if (!human) return undefined;
+  const d = new Date(`${human} UTC`);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString().slice(0, 10);
 }
 
 // Generate static params for all authors
@@ -54,6 +69,8 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
     `Read articles by ${author.name} on Sparkonomy. Expert insights on ${expertiseText}, and digital marketing.`;
 
   const canonicalUrl = authorUrl(author.slug);
+  const ogImage =
+    absoluteUrl(author.avatarUrl) || "https://www.sparkonomy.com/sparkonomy.png";
 
   return {
     metadataBase: new URL("https://www.sparkonomy.com/"),
@@ -90,19 +107,19 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
       type: "profile",
       images: [
         {
-          url: author.avatarUrl || "https://www.sparkonomy.com/sparkonomy.png",
+          url: ogImage,
           width: 400,
           height: 400,
           alt: author.name,
         },
       ],
-      locale: "en_IND",
+      locale: "en_IN",
     },
     twitter: {
       card: "summary",
       title,
       description,
-      images: [author.avatarUrl || "https://www.sparkonomy.com/sparkonomy.png"],
+      images: [ogImage],
       creator: "@sparkonomy",
       site: "@sparkonomy",
     },
@@ -136,32 +153,35 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     getPosts(1, 3),
   ]);
 
-  if (authorResult.status === "fulfilled") {
-    const posts = authorResult.value;
-    if (posts.length > 0) {
-      // First 2-3 posts as featured articles
-      featuredArticles = posts.slice(0, 3).map((post) => ({
-        id: String(post.id),
-        title: decodeHtmlEntities(post.title.rendered),
-        description: decodeHtmlEntities(post.excerpt.rendered).slice(0, 100) + "...",
-        imageSrc: getFeaturedImageUrl(post, "full") || "/blog/default-thumbnail.jpg",
-        date: formatDate(post.date),
-        readingTime: `${getReadingTime(post)} min read`,
-        href: `/blogs/${post.slug}`,
-      }));
-
-      // Remaining posts as recent articles (fallback if the latest-posts
-      // fetch below fails — otherwise it gets overwritten).
-      recentArticles = posts.slice(3).map((post) => ({
-        id: String(post.id),
-        title: decodeHtmlEntities(post.title.rendered),
-        date: formatDate(post.date),
-        imageSrc: getFeaturedImageUrl(post, "full") || "/blog/default-thumbnail.jpg",
-        href: `/blogs/${post.slug}`,
-      }));
-    }
-  } else {
+  // Hoisted so the author's own posts are available both for display and for
+  // the authored-articles ItemList structured data built further below.
+  const authorPosts: AuthorPostsData =
+    authorResult.status === "fulfilled" ? authorResult.value : [];
+  if (authorResult.status === "rejected") {
     console.error("Error fetching WordPress posts for author:", authorResult.reason);
+  }
+
+  if (authorPosts.length > 0) {
+    // First 2-3 posts as featured articles
+    featuredArticles = authorPosts.slice(0, 3).map((post) => ({
+      id: String(post.id),
+      title: decodeHtmlEntities(post.title.rendered),
+      description: decodeHtmlEntities(post.excerpt.rendered).slice(0, 100) + "...",
+      imageSrc: getFeaturedImageUrl(post, "full") || "/blog/default-thumbnail.jpg",
+      date: formatDate(post.date),
+      readingTime: `${getReadingTime(post)} min read`,
+      href: `/blogs/${post.slug}`,
+    }));
+
+    // Remaining posts as recent articles (fallback if the latest-posts
+    // fetch below fails — otherwise it gets overwritten).
+    recentArticles = authorPosts.slice(3).map((post) => ({
+      id: String(post.id),
+      title: decodeHtmlEntities(post.title.rendered),
+      date: formatDate(post.date),
+      imageSrc: getFeaturedImageUrl(post, "full") || "/blog/default-thumbnail.jpg",
+      href: `/blogs/${post.slug}`,
+    }));
   }
 
   if (latestResult.status === "fulfilled") {
@@ -213,6 +233,16 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     ],
   };
 
+  // Freshness + richer entity facts mapped from data we already hold.
+  const isoLastUpdated = toIsoDate(author.lastUpdated);
+  const alumniOf = author.previousCompanies.map((c) => ({
+    "@type": "Organization",
+    name: c.name,
+  }));
+  const awards = author.trustItems
+    .filter((t) => t.icon === "awards")
+    .map((t) => t.value);
+
   // Person entity — nested as the ProfilePage's mainEntity, so it carries no
   // own @context.
   const personEntity = {
@@ -220,12 +250,20 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     "@id": `${canonicalUrl}#person`,
     name: author.name,
     url: canonicalUrl,
-    image: author.avatarUrl || "",
+    mainEntityOfPage: canonicalUrl,
+    image: absoluteUrl(author.avatarUrl) || "https://www.sparkonomy.com/sparkonomy.png",
     description: author.metaDescription || author.shortBio || `${author.name} is a writer at Sparkonomy`,
     jobTitle: author.role,
+    hasOccupation: {
+      "@type": "Occupation",
+      name: author.role,
+    },
     worksFor: {
       "@id": "https://www.sparkonomy.com/#organization",
     },
+    ...(alumniOf.length ? { alumniOf } : {}),
+    ...(awards.length ? { award: awards } : {}),
+    ...(author.contactEmail ? { email: author.contactEmail } : {}),
     sameAs: sameAsLinks,
     knowsAbout: author.areasOfExpertise,
   };
@@ -238,6 +276,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     "@id": canonicalUrl,
     url: canonicalUrl,
     name: author.metaTitle || `${author.name} — ${author.role}`,
+    ...(isoLastUpdated ? { dateModified: isoLastUpdated } : {}),
     mainEntity: personEntity,
   };
 
@@ -259,6 +298,30 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     })),
   };
 
+  // Authored-works ItemList — an explicit machine link from this author entity
+  // to the articles they wrote (each item references the Person @id), so search
+  // engines and LLMs can answer "what has this author written".
+  const authoredArticlesJsonLd =
+    authorPosts.length > 0
+      ? {
+          "@context": "https://schema.org",
+          "@type": "ItemList",
+          name: `Articles by ${author.name}`,
+          numberOfItems: authorPosts.length,
+          itemListElement: authorPosts.slice(0, 10).map((post, idx) => ({
+            "@type": "ListItem",
+            position: idx + 1,
+            item: {
+              "@type": "BlogPosting",
+              "@id": `${SITE_URL}/blogs/${post.slug}`,
+              url: `${SITE_URL}/blogs/${post.slug}`,
+              headline: decodeHtmlEntities(post.title.rendered),
+              author: { "@id": `${canonicalUrl}#person` },
+            },
+          })),
+        }
+      : null;
+
   return (
     <>
       {/* Organization Structured Data (Identity Schema) */}
@@ -278,6 +341,14 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
+
+      {/* Authored Articles ItemList (entity → works machine link) */}
+      {authoredArticlesJsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(authoredArticlesJsonLd) }}
+        />
+      )}
 
       <AuthorPageTemplate
         author={author}

--- a/app/blogs/sitemap.ts
+++ b/app/blogs/sitemap.ts
@@ -1,6 +1,6 @@
 import { MetadataRoute } from 'next'
 import { getAllPostSlugs, getPostBySlug } from '@/lib/wordpress-improved'
-import { getAllAuthorSlugs } from '@/data/authors'
+import { authors } from '@/data/authors'
 import { SITE_URL, authorUrl } from '@/lib/urls'
 
 export const revalidate = 3600
@@ -64,12 +64,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Author/profile pages — entity pages for the founders + content team.
   // Indexable (rich expert bios + ProfilePage schema), so include them for
   // discovery. Served at /blogs/author/<slug>.
-  const authorPages: MetadataRoute.Sitemap = getAllAuthorSlugs().map((slug) => ({
-    url: authorUrl(slug),
-    lastModified: new Date(),
-    changeFrequency: 'monthly' as const,
-    priority: 0.6,
-  }))
+  const authorPages: MetadataRoute.Sitemap = authors.map((a) => {
+    // Use the author's own lastUpdated date so the sitemap reflects real profile
+    // freshness instead of stamping "modified now" on every build.
+    const parsed = a.lastUpdated ? new Date(`${a.lastUpdated} UTC`) : null
+    return {
+      url: authorUrl(a.slug),
+      lastModified: parsed && !Number.isNaN(parsed.getTime()) ? parsed : new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.6,
+    }
+  })
 
   return [...staticPages, ...authorPages, ...blogPosts]
 }

--- a/app/blogs/sitemap.ts
+++ b/app/blogs/sitemap.ts
@@ -1,10 +1,12 @@
 import { MetadataRoute } from 'next'
 import { getAllPostSlugs, getPostBySlug } from '@/lib/wordpress-improved'
+import { getAllAuthorSlugs } from '@/data/authors'
+import { SITE_URL, authorUrl } from '@/lib/urls'
 
 export const revalidate = 3600
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = 'https://www.sparkonomy.com'
+  const baseUrl = SITE_URL
 
   // Fetch all blog posts
   let blogPosts: MetadataRoute.Sitemap = []
@@ -59,5 +61,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ]
 
-  return [...staticPages, ...blogPosts]
+  // Author/profile pages — entity pages for the founders + content team.
+  // Indexable (rich expert bios + ProfilePage schema), so include them for
+  // discovery. Served at /blogs/author/<slug>.
+  const authorPages: MetadataRoute.Sitemap = getAllAuthorSlugs().map((slug) => ({
+    url: authorUrl(slug),
+    lastModified: new Date(),
+    changeFrequency: 'monthly' as const,
+    priority: 0.6,
+  }))
+
+  return [...staticPages, ...authorPages, ...blogPosts]
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { RootLayoutClient } from "./root-layout-client";
 import Script from "next/script";
 import type { Metadata } from "next";
 import CookieConsentScript from "@/components/CookieConsentScript";
+import { SITE_URL } from "@/lib/urls";
 
 const roboto = Roboto({
   subsets: ["latin"],
@@ -17,6 +18,7 @@ const roboto = Roboto({
 const isProduction = !process.env.SITE_URL?.startsWith('https://dev.')
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   robots: isProduction ? undefined : { index: false, follow: false },
   icons: {
     icon: [
@@ -70,6 +72,39 @@ gtag('config', '${id}', {
 })();
 `.trim();
 
+// Site-wide entity graph: declares the Sparkonomy Organization + WebSite once
+// for every page, so the brand is a consistent entity and author `worksFor`
+// references (@id .../#organization) resolve to a real node.
+const ORG_WEBSITE_JSONLD = JSON.stringify({
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.sparkonomy.com/#organization",
+      name: "Sparkonomy",
+      url: "https://www.sparkonomy.com",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://www.sparkonomy.com/sparkonomy.png",
+        width: 512,
+        height: 512,
+      },
+      sameAs: [
+        "https://twitter.com/sparkonomy",
+        "https://www.linkedin.com/company/sparkonomy",
+        "https://www.instagram.com/sparkonomy",
+      ],
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.sparkonomy.com/#website",
+      url: "https://www.sparkonomy.com",
+      name: "Sparkonomy",
+      publisher: { "@id": "https://www.sparkonomy.com/#organization" },
+    },
+  ],
+});
+
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="h-full">
@@ -82,6 +117,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           />
         )}
         <meta name="theme-color" content="#000000" />
+
+        {/* Site-wide Organization + WebSite entity graph (helps brand + author
+            entity understanding in the Knowledge Graph). */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: ORG_WEBSITE_JSONLD }}
+        />
 
         {/* Warm up the GTM/GA origin so the deferred loader (below) doesn't pay
             a fresh DNS+TLS round-trip on first fire. */}

--- a/components/blog/AuthorPageTemplate.tsx
+++ b/components/blog/AuthorPageTemplate.tsx
@@ -15,16 +15,52 @@ const TrustIconPaths: Record<string, string> = {
   featured: "/authors/Logos/Featured.png",
 };
 
-// Social Icons
+// Social Icons (decorative — the wrapping <a> carries the accessible label)
 const SocialIcons = {
   twitter: (
-    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
     </svg>
   ),
   linkedin: (
-    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  ),
+  instagram: (
+    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path fillRule="evenodd" d="M12.315 2c2.43 0 2.784.013 3.808.06 1.064.049 1.791.218 2.427.465a4.902 4.902 0 011.772 1.153 4.902 4.902 0 011.153 1.772c.247.636.416 1.363.465 2.427.048 1.067.06 1.407.06 4.123v.08c0 2.643-.012 2.987-.06 4.043-.049 1.064-.218 1.791-.465 2.427a4.902 4.902 0 01-1.153 1.772 4.902 4.902 0 01-1.772 1.153c-.636.247-1.363.416-2.427.465-1.067.048-1.407.06-4.123.06h-.08c-2.643 0-2.987-.012-4.043-.06-1.064-.049-1.791-.218-2.427-.465a4.902 4.902 0 01-1.772-1.153 4.902 4.902 0 01-1.153-1.772c-.247-.636-.416-1.363-.465-2.427-.047-1.024-.06-1.379-.06-3.808v-.63c0-2.43.013-2.784.06-3.808.049-1.064.218-1.791.465-2.427a4.902 4.902 0 011.153-1.772A4.902 4.902 0 015.45 2.525c.636-.247 1.363-.416 2.427-.465C8.901 2.013 9.256 2 11.685 2h.63zm-.081 1.802h-.468c-2.456 0-2.784.011-3.807.058-.975.045-1.504.207-1.857.344-.467.182-.8.398-1.15.748-.35.35-.566.683-.748 1.15-.137.353-.3.882-.344 1.857-.047 1.023-.058 1.351-.058 3.807v.468c0 2.456.011 2.784.058 3.807.045.975.207 1.504.344 1.857.182.466.399.8.748 1.15.35.35.683.566 1.15.748.353.137.882.3 1.857.344 1.054.048 1.37.058 4.041.058h.08c2.597 0 2.917-.01 3.96-.058.976-.045 1.505-.207 1.858-.344.466-.182.8-.398 1.15-.748.35-.35.566-.683.748-1.15.137-.353.3-.882.344-1.857.048-1.055.058-1.37.058-4.041v-.08c0-2.597-.01-2.917-.058-3.96-.045-.976-.207-1.505-.344-1.858a3.097 3.097 0 00-.748-1.15 3.098 3.098 0 00-1.15-.748c-.353-.137-.882-.3-1.857-.344-1.023-.047-1.351-.058-3.807-.058zM12 6.865a5.135 5.135 0 110 10.27 5.135 5.135 0 010-10.27zm0 1.802a3.333 3.333 0 100 6.666 3.333 3.333 0 000-6.666zm5.338-3.205a1.2 1.2 0 110 2.4 1.2 1.2 0 010-2.4z" clipRule="evenodd" />
+    </svg>
+  ),
+  youtube: (
+    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path fillRule="evenodd" d="M19.812 5.418c.861.23 1.538.907 1.768 1.768C21.998 8.746 22 12 22 12s0 3.255-.418 4.814a2.504 2.504 0 0 1-1.768 1.768c-1.56.419-7.814.419-7.814.419s-6.255 0-7.814-.419a2.505 2.505 0 0 1-1.768-1.768C2 15.255 2 12 2 12s0-3.255.417-4.814a2.507 2.507 0 0 1 1.768-1.768C5.744 5 11.998 5 11.998 5s6.255 0 7.814.418ZM15.194 12 10 15V9l5.194 3Z" clipRule="evenodd" />
+    </svg>
+  ),
+  facebook: (
+    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path fillRule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" clipRule="evenodd" />
+    </svg>
+  ),
+  website: (
+    <svg
+      className="w-5 h-5"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3.6 9h16.8M3.6 15h16.8M12 3a15 15 0 010 18M12 3a15 15 0 000 18"
+      />
     </svg>
   ),
   email: (
@@ -34,6 +70,7 @@ const SocialIcons = {
       stroke="currentColor"
       viewBox="0 0 24 24"
       strokeWidth="2"
+      aria-hidden="true"
     >
       <path
         strokeLinecap="round"
@@ -43,6 +80,14 @@ const SocialIcons = {
     </svg>
   ),
 };
+
+// Convert a human "Month DD, YYYY" date into an ISO 8601 date (YYYY-MM-DD) for
+// the <time> dateTime attribute. " UTC" forces UTC parsing (no day shift).
+function toIsoDate(human?: string): string | undefined {
+  if (!human) return undefined;
+  const d = new Date(`${human} UTC`);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString().slice(0, 10);
+}
 
 interface AuthorPageTemplateProps {
   author: AuthorEntry;
@@ -62,13 +107,13 @@ export default function AuthorPageTemplate({
   const displayRecentArticles = recentArticles ?? author.recentArticles ?? [];
 
   return (
-    <main className="min-h-screen bg-white">
-      {/* Breadcrumb */}
+    // <article> (not <main>) — the blog layout already provides the <main> landmark.
+    <article className="min-h-screen bg-white">
+      {/* Breadcrumb — mirrors the BreadcrumbList JSON-LD (Blog › Name) */}
       <div className="max-w-4xl mx-auto px-4 pt-[16px]">
         <Breadcrumb
           items={[
             { label: "Blog", href: "/blogs" },
-            { label: "Author", href: "/blogs" },
             { label: author.name },
           ]}
         />
@@ -130,6 +175,50 @@ export default function AuthorPageTemplate({
                 aria-label="LinkedIn"
               >
                 {SocialIcons.linkedin}
+              </a>
+            )}
+            {author.socialLinks.instagram && (
+              <a
+                href={author.socialLinks.instagram}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                aria-label="Instagram"
+              >
+                {SocialIcons.instagram}
+              </a>
+            )}
+            {author.socialLinks.youtube && (
+              <a
+                href={author.socialLinks.youtube}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                aria-label="YouTube"
+              >
+                {SocialIcons.youtube}
+              </a>
+            )}
+            {author.socialLinks.facebook && (
+              <a
+                href={author.socialLinks.facebook}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                aria-label="Facebook"
+              >
+                {SocialIcons.facebook}
+              </a>
+            )}
+            {author.socialLinks.website && (
+              <a
+                href={author.socialLinks.website}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                aria-label="Website"
+              >
+                {SocialIcons.website}
               </a>
             )}
             {author.socialLinks.email && (
@@ -305,7 +394,7 @@ export default function AuthorPageTemplate({
                 key={index}
                 className="flex items-start gap-2 text-[14px] md:text-[16px] font-normal text-[#999999]"
               >
-                <span className="text-[#999999] mt-1">✓</span>
+                <span className="text-[#999999] mt-1" aria-hidden="true">✓</span>
                 <span>{highlight}</span>
               </li>
             ))}
@@ -392,6 +481,7 @@ export default function AuthorPageTemplate({
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
+                    aria-hidden="true"
                   >
                     <path
                       strokeLinecap="round"
@@ -470,6 +560,7 @@ export default function AuthorPageTemplate({
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"
@@ -556,6 +647,14 @@ export default function AuthorPageTemplate({
           )}
         </div>
       </section>
-    </main>
+
+      {/* Profile freshness signal */}
+      {author.lastUpdated && (
+        <p className="text-center text-[12px] md:text-sm font-normal text-[#999999] pb-[16px]">
+          Profile last updated on{" "}
+          <time dateTime={toIsoDate(author.lastUpdated)}>{author.lastUpdated}</time>
+        </p>
+      )}
+    </article>
   );
 }

--- a/data/authors.ts
+++ b/data/authors.ts
@@ -58,8 +58,6 @@ export interface AuthorEntry {
   // SEO metadata
   metaTitle?: string;
   metaDescription?: string;
-  canonicalPath?: string;
-
   // WordPress matching - use ONE of these to match WordPress author to our data
   wordpressSlug?: string; // WordPress author slug (e.g., "dev-sparkonomy") - PREFERRED
   wordpressAuthorId?: number; // WordPress author ID (e.g., 1) - Alternative
@@ -120,8 +118,6 @@ export const authors: AuthorEntry[] = [
     // SEO metadata
     metaTitle: "Guneet Singh: Product, Tech Leader and Mentor at Sparkonomy",
     metaDescription: "Guneet Singh worked at Google and Microsoft. Now, he helps creators use technology to build real businesses. Read his guides on growth and AI.",
-    canonicalPath: "/authors/guneet-singh",
-
     // WordPress matching
     wordpressSlug: "cap-guneet",
     wordpressAuthorId: 5,
@@ -353,8 +349,6 @@ export const authors: AuthorEntry[] = [
     // SEO metadata
     metaTitle: "Binny Agarwal: CA and Business Guide at Sparkonomy",
     metaDescription: "Binny Agarwal is a Chartered Accountant and writer. She helps creators use AI and smart tools to build real businesses.",
-    canonicalPath: "/authors/binny-agarwal",
-
     // WordPress matching (Co-Authors Plus uses "cap-" prefix)
     wordpressSlug: "cap-binny",
     wordpressAuthorId: 7,
@@ -453,8 +447,6 @@ export const authors: AuthorEntry[] = [
     // SEO metadata
     metaTitle: "Saurabh Mongia, CA | VP Finance & Creator Payment Expert at Sparkonomy",
     metaDescription: "Saurabh Mongia bridges institutional finance and creator payouts. CA, VP at Morgan Stanley. Read invoicing & payment workflow guides.",
-    canonicalPath: "/authors/saurabh-mongia",
-
     // WordPress matching (Co-Authors Plus uses "cap-" prefix)
     wordpressSlug: "cap-saurabh",
     wordpressAuthorId: 8,
@@ -548,8 +540,6 @@ export const authors: AuthorEntry[] = [
     metaTitle: "Megha Thareja Tyagi: AI Strategy and Creator Economy Leader at Sparkonomy",
     metaDescription:
       "Meet Megha Thareja Tyagi, Co-Founder at Sparkonomy. Expert in AI strategy, creator economy infrastructure, growth, and commercialization. Explore her background across Google, PayPal, and American Express, and read her Sparkonomy insights.",
-    canonicalPath: "/authors/megha-thareja-tyagi",
-
     // WordPress matching (Co-Authors Plus uses "cap-" prefix)
     wordpressSlug: "cap-megha",
 
@@ -665,8 +655,6 @@ export const authors: AuthorEntry[] = [
     metaTitle: "Rachit Jain: Growth, partnerships, and GTM leader at Sparkonomy",
     metaDescription:
       "Meet Rachit Jain, growth and partnerships leader at Sparkonomy. He brings 20+ years across Meta, Google, SAP, and IBM to write about growth, GTM, and creator businesses.",
-    canonicalPath: "/authors/rachit-jain",
-
     // WordPress matching (Co-Authors Plus uses "cap-" prefix)
     wordpressSlug: "cap-rachit",
 
@@ -776,8 +764,6 @@ export const authors: AuthorEntry[] = [
     metaTitle: "Vipasha Joshi: Co-Founder & Creator Economy Veteran at Sparkonomy",
     metaDescription:
       "Meet Vipasha Joshi, Co-Founder at Sparkonomy. Former Googler and Jellysmack India lead with 16+ years building creator and brand businesses. LinkedIn Top Voice.",
-    canonicalPath: "/authors/vipasha-joshi",
-
     // WordPress matching (Co-Authors Plus uses "cap-" prefix)
     wordpressSlug: "cap-vipasha",
 
@@ -899,8 +885,6 @@ export const authors: AuthorEntry[] = [
     metaTitle: "The Sparkonomy Founding Team",
     metaDescription:
       "Meet the Sparkonomy founding team — Guneet Singh, Megha Thareja Tyagi, Vipasha Joshi, and Rachit Jain — building AI infrastructure for the creator economy.",
-    canonicalPath: "/authors/founding-team",
-
     // No WordPress slug — this is a synthetic author used to collapse multi-author posts
     // where all four co-founders appear together.
 

--- a/lib/urls.ts
+++ b/lib/urls.ts
@@ -1,0 +1,20 @@
+// Single source of truth for site URLs.
+//
+// The host and each route's path live here ONCE so that canonicals, JSON-LD,
+// the sitemap, and internal links all derive from the same place and cannot
+// drift apart. (A hand-typed per-author `canonicalPath` once pointed authors at
+// a non-existent `/authors/<slug>` URL — deriving from `slug` makes that class
+// of bug unrepresentable.)
+//
+// SITE_URL is for navigable URLs (canonical, OG, sitemap). Schema `@id` values
+// are intentionally kept as stable production literals elsewhere.
+
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.sparkonomy.com"
+).replace(/\/+$/, "");
+
+/** Relative path to an author page — use for canonicals (resolved by metadataBase). */
+export const authorPath = (slug: string): string => `/blogs/author/${slug}`;
+
+/** Absolute URL to an author page — use where an absolute URL is required (JSON-LD, sitemap). */
+export const authorUrl = (slug: string): string => `${SITE_URL}${authorPath(slug)}`;

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -18,6 +18,17 @@ api: No public API currently available
 - [Blog: Brands](https://www.sparkonomy.com/blogs/brand) — Insights and updates for brands working with creators and influencers.
 - [Blog: Company](https://www.sparkonomy.com/blogs/company) — Company news and updates from Sparkonomy.
 
+## Authors / Experts
+The Sparkonomy blog is written by named domain experts. Each has a profile (ProfilePage + Person structured data) at the URL below.
+- [Guneet Singh](https://www.sparkonomy.com/blogs/author/guneet-singh) — Founder; global tech leader, startup mentor & venture builder with 20+ years across Google, Microsoft and Samsung. Writes on the creator economy, AI productivity, platform ecosystems and business growth.
+- [Megha Thareja Tyagi](https://www.sparkonomy.com/blogs/author/megha-thareja-tyagi) — Co-Founder; AI strategy and creator-economy infrastructure leader, ex-Google, PayPal and American Express. Writes on go-to-market strategy, commercialization and payments.
+- [Vipasha Joshi](https://www.sparkonomy.com/blogs/author/vipasha-joshi) — Co-Founder & Global Head of Creator Business; creator-economy veteran and LinkedIn Top Voice, ex-Google and Jellysmack. Writes on creator business, AI content strategy and community.
+- [Rachit Jain](https://www.sparkonomy.com/blogs/author/rachit-jain) — Growth, partnerships and GTM leader with 20+ years across Meta, Google, SAP and IBM. Writes on growth strategy, monetization and partnerships.
+- [Binny Agarwal](https://www.sparkonomy.com/blogs/author/binny-agarwal) — Chartered Accountant (CA) and content strategist. Writes simple guides on creator money, pricing, getting paid and AI workflows.
+- [Saurabh Mongia](https://www.sparkonomy.com/blogs/author/saurabh-mongia) — Chartered Accountant and VP (Legal Entity Control) at Morgan Stanley. Writes on creator invoicing, payment workflows and cross-border taxation.
+- [Dev Sparkonomy](https://www.sparkonomy.com/blogs/author/dev-sparkonomy) — The Sparkonomy content team; guides on creator payments, monetization, taxation and growth.
+- [The Sparkonomy Founding Team](https://www.sparkonomy.com/blogs/author/founding-team) — Collective byline for deep dives co-written by all four co-founders.
+
 ## Product / Offering
 - **What it does:** Sparkonomy provides an AI Agent Team built specifically for creators, influencers, YouTubers, Instagrammers and social media influencers. These agents act as a "business team" that handles Content strategy, Commerce (brand deals), and Company Operations (legal and finance). These agents are powered by Sparkonomy’s proprietary Creator Genome, which uses AI to understand a creator’s unique persona & style.
 - **Creator Earn:** AI-powered invoicing tool for creators and influencers — handles GST-compliant invoicing, payment tracking, and professional billing so influencers, YouTubers and Instagrammers can get paid faster without messy spreadsheets.


### PR DESCRIPTION
- Fix author canonical bug: canonicalPath pointed at a non-existent /authors/<slug> (404), de-indexing founder pages. Derive canonical from slug via a single source of truth (lib/urls.ts); remove the canonicalPath field and the now-dead /authors/ breadcrumb branch.
- Add author pages to the blog sitemap for discovery.
- Wrap the author Person schema in ProfilePage and expand sameAs.
- Add site-wide Organization + WebSite JSON-LD and metadataBase in the layout.