### PR TITLE
chore(promo): update promo dates to Jun 1 - Jul 31, 2026

### DIFF
--- a/app/gold-promo/terms/page.tsx
+++ b/app/gold-promo/terms/page.tsx
@@ -5,7 +5,7 @@ import { Home } from "lucide-react";
 export const metadata = {
   title: "Gold Shagun Promo — Terms & Conditions | Sparkonomy",
   description:
-    "Terms and conditions for the Sparkonomy Gold Shagun Promo lucky draw running May 4–31, 2026.",
+    "Terms and conditions for the Sparkonomy Gold Shagun Promo lucky draw running June 1 – July 31, 2026.",
 };
 
 export default function GoldPromoTermsPage() {
@@ -23,7 +23,7 @@ export default function GoldPromoTermsPage() {
           Gold Shagun Promo — Terms &amp; Conditions
         </h1>
         <p className="text-sm text-gray-500 mb-8">
-          Effective Date: May 04, 2026
+          Effective Date: June 01, 2026
         </p>
 
         <h2 className="text-xl font-semibold mt-8 mb-4">1. The Promo</h2>
@@ -38,7 +38,7 @@ export default function GoldPromoTermsPage() {
 
         <h2 className="text-xl font-semibold mt-8 mb-4">2. Promo Period</h2>
         <p className="mb-4">
-          The Promo runs from May 04, 2026 to May 31, 2026 (the &ldquo;Promo
+          The Promo runs from June 01, 2026 to July 31, 2026 (the &ldquo;Promo
           Period&rdquo;), inclusive of both dates. This Promo has one draw
           period, covering the full Promo Period. All times referenced in the
           Promo are in Indian Standard Time (IST).
@@ -102,7 +102,7 @@ export default function GoldPromoTermsPage() {
             Invoices that appear to be created solely for the purpose of
             entering this Promo may be disqualified at our discretion.
           </li>
-          <li>Sent during the Promo Period (May 4 – May 31, 2026).</li>
+          <li>Sent during the Promo Period (June 01 – July 31, 2026).</li>
         </ul>
         <p className="mb-4">
           The timestamp of your invoice submission, as recorded by

--- a/app/summer-promo/terms/page.tsx
+++ b/app/summer-promo/terms/page.tsx
@@ -5,7 +5,7 @@ import { Home } from "lucide-react";
 export const metadata = {
   title: "Summer Sign-up Promo — Terms & Conditions | Sparkonomy",
   description:
-    "Terms and conditions for the Sparkonomy Summer Sign-up Promo running May 4–31, 2026.",
+    "Terms and conditions for the Sparkonomy Summer Sign-up Promo running June 1 – July 31, 2026.",
 };
 
 export default function SummerPromoTermsPage() {
@@ -23,7 +23,7 @@ export default function SummerPromoTermsPage() {
           Summer Sign-up Promo — Terms &amp; Conditions
         </h1>
         <p className="text-sm text-gray-500 mb-8">
-          Effective Date: May 10, 2026
+          Effective Date: June 01, 2026
         </p>
 
         <h2 className="text-xl font-semibold mt-8 mb-4">1. The Promo</h2>
@@ -37,7 +37,7 @@ export default function SummerPromoTermsPage() {
 
         <h2 className="text-xl font-semibold mt-8 mb-4">2. Promo Period</h2>
         <p className="mb-4">
-          The Promo runs from May 04, 2026 to May 31, 2026 (the &ldquo;Promo
+          The Promo runs from June 01, 2026 to July 31, 2026 (the &ldquo;Promo
           Period&rdquo;), inclusive of both dates. We may extend or withdraw
           the Promo at any time, at our sole discretion. If we do, we&apos;ll
           let you know through our promotional channels. All times referenced

--- a/lib/promo/config.ts
+++ b/lib/promo/config.ts
@@ -44,10 +44,10 @@ function dateRange(
   };
 }
 
-// Summer Sign-up Daily Vouchers Promo: 2nd May 2026 – 31st May 2026.
+// Summer Sign-up Daily Vouchers Promo: 1st June 2026 – 31st July 2026.
 const SUMMER_SIGNUP_WINDOW = dateRange(
-  { year: 2026, month: 3, day: 1 },
-  { year: 2026, month: 4, day: 31 },
+  { year: 2026, month: 5, day: 1 },
+  { year: 2026, month: 6, day: 31 },
 );
 
 export const PROMO_CONFIG: PromoConfig = {


### PR DESCRIPTION
## Summary

Updates the **Gold Shagun** and **Summer Sign-up** promos to the new promo period of **June 01 – July 31, 2026**, across both the Terms & Conditions pages and the site-wide banner activation window.

## Changes

### Gold Shagun T&C — `app/gold-promo/terms/page.tsx`
- Effective Date: `May 04, 2026` → `June 01, 2026`
- Promo Period (Section 2): `May 04 – May 31, 2026` → `June 01 – July 31, 2026`
- Section 4 qualifying-invoice bullet: `(May 4 – May 31, 2026)` → `(June 01 – July 31, 2026)`
- `metadata.description` date range updated

### Summer Sign-up T&C — `app/summer-promo/terms/page.tsx`
- Effective Date: `May 10, 2026` → `June 01, 2026`
- Promo Period (Section 2): `May 04 – May 31, 2026` → `June 01 – July 31, 2026`
- `metadata.description` date range updated

### Promo banner config — `lib/promo/config.ts`
- Activation window `SUMMER_SIGNUP_WINDOW` now starts **Jun 1** and ends **Jul 31, 2026** (IST), matching the T&C pages
- Comment updated to reflect the new window

## Notes
- The only substantive change in the source copy was the dates; the rest of the T&C bodies were already in sync.
- Two copy-paste artifacts from the source were intentionally **not** introduced: a dropped Facebook URL in Summer §3 and a duplicated sentence in Summer §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
