### PR TITLE
SEO: fix author-page canonicals + strengthen author entity signals

### DIFF
--- a/app/blogs/[slug]/page.tsx
+++ b/app/blogs/[slug]/page.tsx
@@ -3,9 +3,8 @@ import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { getPostBySlug, getPostBySlugForLang, hasHinglishVersion, getEnglishSlug, getFeaturedImageUrl, getAuthorName, getAuthorNames, getPostAuthors, getPostAuthorsAsync, formatDate, stripHtml, decodeHtmlEntities, getReadingTime, getPosts, getPostsByCategory, type BlogLang } from "@/lib/wordpress-improved";
+import { getPostBySlugForLang, hasHinglishVersion, getEnglishSlug, getFeaturedImageUrl, getAuthorNames, getPostAuthors, getPostAuthorsAsync, formatDate, stripHtml, decodeHtmlEntities, getReadingTime, getPosts, getPostsByCategory, type BlogLang } from "@/lib/wordpress-improved";
 import { extractHeadings, addHeadingIds, extractFAQs, extractVideos, removeWordPressTOC, extractFirstParagraph, removeLeadingFeaturedImageBlock, processH6Markers, lazyLoadImages, openLinksInNewTab } from "@/lib/content-processor";
-import ShareButtons from "@/components/blog/ShareButtons";
 import Breadcrumb from "@/components/blog/Breadcrumb";
 import BlogLanguageSwitcher from "@/components/blog/BlogLanguageSwitcher";
 import TOCEnhancer from "@/components/blog/TOCEnhancer";
@@ -31,6 +30,7 @@ import RelatedResourcesInjector from "@/components/blog/RelatedResourcesInjector
 import BlogScrollTracker from "@/components/blog/BlogScrollTracker";
 import MetaShareButton from "@/components/blog/MetaShareButton";
 import { getAuthorPageSlug, getAuthorByWordPressSlug, getAuthorBySlug, isFoundingTeamPost } from "@/data/authors";
+import { SITE_URL, authorUrl } from "@/lib/urls";
 import "../wordpress-content.css";
 
 interface BlogPostPageProps {
@@ -292,6 +292,45 @@ export default async function BlogPostPage({ params, searchParams }: BlogPostPag
   const faqItems = extractFAQs(post.content.rendered);
   const videoItems = extractVideos(post.content.rendered, stripHtml(post.title.rendered), post.date);
 
+  // Single source of truth for the author Person node so the BlogPosting.author,
+  // the standalone Person, and the author page's ProfilePage>Person all share one
+  // @id and canonical url — letting search engines and LLMs unify the article
+  // author with their profile entity instead of treating them as separate people.
+  const orgRef = {
+    "@type": "Organization",
+    "@id": "https://www.sparkonomy.com/#organization",
+    name: "Sparkonomy",
+    url: "https://www.sparkonomy.com",
+  };
+  const buildPersonNode = (a: (typeof authorsWithLocalData)[number]) => {
+    const profileUrl = authorUrl(a.authorPageSlug);
+    const img = a.avatarUrl
+      ? a.avatarUrl.startsWith("http")
+        ? a.avatarUrl
+        : `${SITE_URL}${a.avatarUrl}`
+      : undefined;
+    return {
+      "@type": "Person",
+      "@id": `${profileUrl}#person`,
+      name: a.name,
+      url: profileUrl,
+      ...(img ? { image: img } : {}),
+      jobTitle: a.role,
+      worksFor: orgRef,
+      sameAs: [
+        a.socialLinks?.linkedin,
+        a.socialLinks?.instagram,
+        a.socialLinks?.youtube,
+        a.socialLinks?.twitter,
+        a.socialLinks?.website,
+        a.wpAuthor?.link,
+      ].filter(Boolean),
+      ...(a.localAuthor?.areasOfExpertise?.length
+        ? { knowsAbout: a.localAuthor.areasOfExpertise }
+        : {}),
+    };
+  };
+
   // Generate comprehensive JSON-LD structured data for SEO
   const articleJsonLd = {
     "@context": "https://schema.org",
@@ -307,26 +346,8 @@ export default async function BlogPostPage({ params, searchParams }: BlogPostPag
     datePublished: post.date,
     dateModified: post.modified,
     author: authorsWithLocalData.length === 1
-      ? {
-          "@type": "Person",
-          name: authorsWithLocalData[0].name,
-          url: authorsWithLocalData[0].wpAuthor.link || "https://sparkonomy.com",
-          jobTitle: authorsWithLocalData[0].role,
-          worksFor: {
-            "@type": "Organization",
-            name: "Sparkonomy",
-          },
-        }
-      : authorsWithLocalData.map(authorData => ({
-          "@type": "Person",
-          name: authorData.name,
-          url: authorData.wpAuthor.link || "https://sparkonomy.com",
-          jobTitle: authorData.role,
-          worksFor: {
-            "@type": "Organization",
-            name: "Sparkonomy",
-          },
-        })),
+      ? buildPersonNode(authorsWithLocalData[0])
+      : authorsWithLocalData.map(buildPersonNode),
     publisher: {
       "@type": "Organization",
       name: "Sparkonomy",
@@ -392,25 +413,12 @@ export default async function BlogPostPage({ params, searchParams }: BlogPostPag
     ],
   };
 
-  // Author/Person structured data (array for multiple authors)
-  const authorJsonLd = authorsWithLocalData.map(authorData => ({
+  // Author/Person structured data (array for multiple authors). Shares the same
+  // @id, canonical url and absolute image as the BlogPosting.author node and the
+  // author page's ProfilePage>Person, unifying the author across documents.
+  const authorJsonLd = authorsWithLocalData.map((authorData) => ({
     "@context": "https://schema.org",
-    "@type": "Person",
-    name: authorData.name,
-    url: authorData.wpAuthor.link || "https://sparkonomy.com",
-    image: authorData.avatarUrl || "",
-    jobTitle: authorData.role,
-    worksFor: {
-      "@type": "Organization",
-      name: "Sparkonomy",
-      url: "https://sparkonomy.com",
-    },
-    sameAs: [
-      authorData.socialLinks?.linkedin,
-      authorData.socialLinks?.instagram,
-      authorData.socialLinks?.youtube,
-      authorData.socialLinks?.twitter,
-    ].filter(Boolean),
+    ...buildPersonNode(authorData),
   }));
 
   // FAQ structured data (if FAQs exist)

--- a/app/blogs/author/[slug]/page.tsx
+++ b/app/blogs/author/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
   decodeHtmlEntities,
   getReadingTime,
 } from "@/lib/wordpress-improved";
+import { SITE_URL, authorPath, authorUrl } from "@/lib/urls";
 
 interface AuthorPageProps {
   params: Promise<{
@@ -37,7 +38,7 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
 
   if (!author) {
     return {
-      metadataBase: new URL("https://www.sparkonomy.com/"),
+      metadataBase: new URL(SITE_URL),
       title: "Author Not Found",
       description: "The requested author could not be found.",
     };
@@ -52,8 +53,7 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
     author.shortBio ||
     `Read articles by ${author.name} on Sparkonomy. Expert insights on ${expertiseText}, and digital marketing.`;
 
-  const canonicalPath = author.canonicalPath || `/blogs/author/${author.slug}`;
-  const canonicalUrl = `https://www.sparkonomy.com${canonicalPath}`;
+  const canonicalUrl = authorUrl(author.slug);
 
   return {
     metadataBase: new URL("https://www.sparkonomy.com/"),
@@ -72,7 +72,7 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
     creator: author.name,
     publisher: "Sparkonomy",
     alternates: {
-      canonical: canonicalUrl,
+      canonical: authorPath(author.slug),
     },
     robots: {
       index: true,
@@ -179,15 +179,19 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     console.error("Error fetching latest WordPress posts:", latestResult.reason);
   }
 
-  // Build social links array for structured data
-  const sameAsLinks: string[] = [];
-  if (author.socialLinks?.linkedin) sameAsLinks.push(author.socialLinks.linkedin);
-  if (author.socialLinks?.twitter) sameAsLinks.push(author.socialLinks.twitter);
-  if (author.socialLinks?.website) sameAsLinks.push(author.socialLinks.website);
+  // Build social links array for structured data. sameAs is the dominant
+  // person-entity signal — include every known profile (not email).
+  const sameAsLinks: string[] = [
+    author.socialLinks?.linkedin,
+    author.socialLinks?.twitter,
+    author.socialLinks?.instagram,
+    author.socialLinks?.youtube,
+    author.socialLinks?.facebook,
+    author.socialLinks?.website,
+  ].filter((u): u is string => Boolean(u));
 
-  const canonicalPath = author.canonicalPath || `/blogs/author/${author.slug}`;
-  const canonicalUrl = `https://www.sparkonomy.com${canonicalPath}`;
-  const blogUrl = "https://www.sparkonomy.com/blogs";
+  const canonicalUrl = authorUrl(author.slug);
+  const blogUrl = `${SITE_URL}/blogs`;
 
   // Organization structured data (standalone for Identity Schema)
   const organizationJsonLd = {
@@ -209,9 +213,9 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     ],
   };
 
-  // Structured data for the author page
-  const authorJsonLd = {
-    "@context": "https://schema.org",
+  // Person entity — nested as the ProfilePage's mainEntity, so it carries no
+  // own @context.
+  const personEntity = {
     "@type": "Person",
     "@id": `${canonicalUrl}#person`,
     name: author.name,
@@ -226,20 +230,23 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     knowsAbout: author.areasOfExpertise,
   };
 
-  // Breadcrumb structured data
-  const breadcrumbItems =
-    author.canonicalPath && author.canonicalPath.startsWith("/authors/")
-      ? [
-          { name: "Home", item: "https://www.sparkonomy.com" },
-          { name: "Blog", item: blogUrl },
-          { name: "Authors", item: `${blogUrl}` },
-          { name: author.name, item: canonicalUrl },
-        ]
-      : [
-          { name: "Home", item: "https://www.sparkonomy.com" },
-          { name: "Blog", item: blogUrl },
-          { name: author.name, item: canonicalUrl },
-        ];
+  // ProfilePage wrapping the Person — Google's recommended shape for author
+  // pages; helps establish the author as an entity in the Knowledge Graph.
+  const profilePageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    "@id": canonicalUrl,
+    url: canonicalUrl,
+    name: author.metaTitle || `${author.name} — ${author.role}`,
+    mainEntity: personEntity,
+  };
+
+  // Breadcrumb structured data (Home › Blog › Author)
+  const breadcrumbItems = [
+    { name: "Home", item: SITE_URL },
+    { name: "Blog", item: blogUrl },
+    { name: author.name, item: canonicalUrl },
+  ];
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
@@ -260,10 +267,10 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
       />
 
-      {/* Author Structured Data */}
+      {/* Author Structured Data (ProfilePage → Person) */}
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(authorJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(profilePageJsonLd) }}
       />
 
       {/* Breadcrumb Structured Data */}

--- a/app/blogs/author/[slug]/page.tsx
+++ b/app/blogs/author/[slug]/page.tsx
@@ -13,7 +13,6 @@ import {
   getPostsByAuthorSlug,
   getFeaturedImageUrl,
   formatDate,
-  stripHtml,
   decodeHtmlEntities,
   getReadingTime,
 } from "@/lib/wordpress-improved";
@@ -23,6 +22,22 @@ interface AuthorPageProps {
   params: Promise<{
     slug: string;
   }>;
+}
+
+// Build an absolute URL from a possibly-relative asset path. JSON-LD is NOT
+// resolved against metadataBase, so Person/Organization images embedded in
+// structured data must be absolute or they are invalid.
+function absoluteUrl(path?: string): string | undefined {
+  if (!path) return undefined;
+  return path.startsWith("http") ? path : `${SITE_URL}${path}`;
+}
+
+// Convert a human "Month DD, YYYY" date into an ISO 8601 date (YYYY-MM-DD).
+// Appending " UTC" forces UTC parsing so the value never shifts by a day.
+function toIsoDate(human?: string): string | undefined {
+  if (!human) return undefined;
+  const d = new Date(`${human} UTC`);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString().slice(0, 10);
 }
 
 // Generate static params for all authors
@@ -54,6 +69,8 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
     `Read articles by ${author.name} on Sparkonomy. Expert insights on ${expertiseText}, and digital marketing.`;
 
   const canonicalUrl = authorUrl(author.slug);
+  const ogImage =
+    absoluteUrl(author.avatarUrl) || "https://www.sparkonomy.com/sparkonomy.png";
 
   return {
     metadataBase: new URL("https://www.sparkonomy.com/"),
@@ -90,19 +107,19 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
       type: "profile",
       images: [
         {
-          url: author.avatarUrl || "https://www.sparkonomy.com/sparkonomy.png",
+          url: ogImage,
           width: 400,
           height: 400,
           alt: author.name,
         },
       ],
-      locale: "en_IND",
+      locale: "en_IN",
     },
     twitter: {
       card: "summary",
       title,
       description,
-      images: [author.avatarUrl || "https://www.sparkonomy.com/sparkonomy.png"],
+      images: [ogImage],
       creator: "@sparkonomy",
       site: "@sparkonomy",
     },
@@ -136,32 +153,35 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     getPosts(1, 3),
   ]);
 
-  if (authorResult.status === "fulfilled") {
-    const posts = authorResult.value;
-    if (posts.length > 0) {
-      // First 2-3 posts as featured articles
-      featuredArticles = posts.slice(0, 3).map((post) => ({
-        id: String(post.id),
-        title: decodeHtmlEntities(post.title.rendered),
-        description: decodeHtmlEntities(post.excerpt.rendered).slice(0, 100) + "...",
-        imageSrc: getFeaturedImageUrl(post, "full") || "/blog/default-thumbnail.jpg",
-        date: formatDate(post.date),
-        readingTime: `${getReadingTime(post)} min read`,
-        href: `/blogs/${post.slug}`,
-      }));
-
-      // Remaining posts as recent articles (fallback if the latest-posts
-      // fetch below fails — otherwise it gets overwritten).
-      recentArticles = posts.slice(3).map((post) => ({
-        id: String(post.id),
-        title: decodeHtmlEntities(post.title.rendered),
-        date: formatDate(post.date),
-        imageSrc: getFeaturedImageUrl(post, "full") || "/blog/default-thumbnail.jpg",
-        href: `/blogs/${post.slug}`,
-      }));
-    }
-  } else {
+  // Hoisted so the author's own posts are available both for display and for
+  // the authored-articles ItemList structured data built further below.
+  const authorPosts: AuthorPostsData =
+    authorResult.status === "fulfilled" ? authorResult.value : [];
+  if (authorResult.status === "rejected") {
     console.error("Error fetching WordPress posts for author:", authorResult.reason);
+  }
+
+  if (authorPosts.length > 0) {
+    // First 2-3 posts as featured articles
+    featuredArticles = authorPosts.slice(0, 3).map((post) => ({
+      id: String(post.id),
+      title: decodeHtmlEntities(post.title.rendered),
+      description: decodeHtmlEntities(post.excerpt.rendered).slice(0, 100) + "...",
+      imageSrc: getFeaturedImageUrl(post, "full") || "/blog/default-thumbnail.jpg",
+      date: formatDate(post.date),
+      readingTime: `${getReadingTime(post)} min read`,
+      href: `/blogs/${post.slug}`,
+    }));
+
+    // Remaining posts as recent articles (fallback if the latest-posts
+    // fetch below fails — otherwise it gets overwritten).
+    recentArticles = authorPosts.slice(3).map((post) => ({
+      id: String(post.id),
+      title: decodeHtmlEntities(post.title.rendered),
+      date: formatDate(post.date),
+      imageSrc: getFeaturedImageUrl(post, "full") || "/blog/default-thumbnail.jpg",
+      href: `/blogs/${post.slug}`,
+    }));
   }
 
   if (latestResult.status === "fulfilled") {
@@ -213,6 +233,16 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     ],
   };
 
+  // Freshness + richer entity facts mapped from data we already hold.
+  const isoLastUpdated = toIsoDate(author.lastUpdated);
+  const alumniOf = author.previousCompanies.map((c) => ({
+    "@type": "Organization",
+    name: c.name,
+  }));
+  const awards = author.trustItems
+    .filter((t) => t.icon === "awards")
+    .map((t) => t.value);
+
   // Person entity — nested as the ProfilePage's mainEntity, so it carries no
   // own @context.
   const personEntity = {
@@ -220,12 +250,20 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     "@id": `${canonicalUrl}#person`,
     name: author.name,
     url: canonicalUrl,
-    image: author.avatarUrl || "",
+    mainEntityOfPage: canonicalUrl,
+    image: absoluteUrl(author.avatarUrl) || "https://www.sparkonomy.com/sparkonomy.png",
     description: author.metaDescription || author.shortBio || `${author.name} is a writer at Sparkonomy`,
     jobTitle: author.role,
+    hasOccupation: {
+      "@type": "Occupation",
+      name: author.role,
+    },
     worksFor: {
       "@id": "https://www.sparkonomy.com/#organization",
     },
+    ...(alumniOf.length ? { alumniOf } : {}),
+    ...(awards.length ? { award: awards } : {}),
+    ...(author.contactEmail ? { email: author.contactEmail } : {}),
     sameAs: sameAsLinks,
     knowsAbout: author.areasOfExpertise,
   };
@@ -238,6 +276,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     "@id": canonicalUrl,
     url: canonicalUrl,
     name: author.metaTitle || `${author.name} — ${author.role}`,
+    ...(isoLastUpdated ? { dateModified: isoLastUpdated } : {}),
     mainEntity: personEntity,
   };
 
@@ -259,6 +298,30 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     })),
   };
 
+  // Authored-works ItemList — an explicit machine link from this author entity
+  // to the articles they wrote (each item references the Person @id), so search
+  // engines and LLMs can answer "what has this author written".
+  const authoredArticlesJsonLd =
+    authorPosts.length > 0
+      ? {
+          "@context": "https://schema.org",
+          "@type": "ItemList",
+          name: `Articles by ${author.name}`,
+          numberOfItems: authorPosts.length,
+          itemListElement: authorPosts.slice(0, 10).map((post, idx) => ({
+            "@type": "ListItem",
+            position: idx + 1,
+            item: {
+              "@type": "BlogPosting",
+              "@id": `${SITE_URL}/blogs/${post.slug}`,
+              url: `${SITE_URL}/blogs/${post.slug}`,
+              headline: decodeHtmlEntities(post.title.rendered),
+              author: { "@id": `${canonicalUrl}#person` },
+            },
+          })),
+        }
+      : null;
+
   return (
     <>
       {/* Organization Structured Data (Identity Schema) */}
@@ -278,6 +341,14 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
+
+      {/* Authored Articles ItemList (entity → works machine link) */}
+      {authoredArticlesJsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(authoredArticlesJsonLd) }}
+        />
+      )}
 
       <AuthorPageTemplate
         author={author}

--- a/app/blogs/sitemap.ts
+++ b/app/blogs/sitemap.ts
@@ -1,6 +1,6 @@
 import { MetadataRoute } from 'next'
 import { getAllPostSlugs, getPostBySlug } from '@/lib/wordpress-improved'
-import { getAllAuthorSlugs } from '@/data/authors'
+import { authors } from '@/data/authors'
 import { SITE_URL, authorUrl } from '@/lib/urls'
 
 export const revalidate = 3600
@@ -64,12 +64,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Author/profile pages — entity pages for the founders + content team.
   // Indexable (rich expert bios + ProfilePage schema), so include them for
   // discovery. Served at /blogs/author/<slug>.
-  const authorPages: MetadataRoute.Sitemap = getAllAuthorSlugs().map((slug) => ({
-    url: authorUrl(slug),
-    lastModified: new Date(),
-    changeFrequency: 'monthly' as const,
-    priority: 0.6,
-  }))
+  const authorPages: MetadataRoute.Sitemap = authors.map((a) => {
+    // Use the author's own lastUpdated date so the sitemap reflects real profile
+    // freshness instead of stamping "modified now" on every build.
+    const parsed = a.lastUpdated ? new Date(`${a.lastUpdated} UTC`) : null
+    return {
+      url: authorUrl(a.slug),
+      lastModified: parsed && !Number.isNaN(parsed.getTime()) ? parsed : new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.6,
+    }
+  })
 
   return [...staticPages, ...authorPages, ...blogPosts]
 }

--- a/app/blogs/sitemap.ts
+++ b/app/blogs/sitemap.ts
@@ -1,10 +1,12 @@
 import { MetadataRoute } from 'next'
 import { getAllPostSlugs, getPostBySlug } from '@/lib/wordpress-improved'
+import { getAllAuthorSlugs } from '@/data/authors'
+import { SITE_URL, authorUrl } from '@/lib/urls'
 
 export const revalidate = 3600
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = 'https://www.sparkonomy.com'
+  const baseUrl = SITE_URL
 
   // Fetch all blog posts
   let blogPosts: MetadataRoute.Sitemap = []
@@ -59,5 +61,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ]
 
-  return [...staticPages, ...blogPosts]
+  // Author/profile pages — entity pages for the founders + content team.
+  // Indexable (rich expert bios + ProfilePage schema), so include them for
+  // discovery. Served at /blogs/author/<slug>.
+  const authorPages: MetadataRoute.Sitemap = getAllAuthorSlugs().map((slug) => ({
+    url: authorUrl(slug),
+    lastModified: new Date(),
+    changeFrequency: 'monthly' as const,
+    priority: 0.6,
+  }))
+
+  return [...staticPages, ...authorPages, ...blogPosts]
 }

--- a/app/creator/earn/CreatorEarnPage.tsx
+++ b/app/creator/earn/CreatorEarnPage.tsx
@@ -1,128 +1,102 @@
 "use client";
 
-import {Suspense, useEffect, useState} from "react";
+import {Suspense, useEffect} from "react";
 import {useSearchParams} from "next/navigation";
-import {AnimatePresence, motion} from "framer-motion";
 import {useTranslation} from "react-i18next";
 import dynamic from "next/dynamic";
 import "@/lib/i18n"; // Initialize i18n
 import Navigation from "@/components/creator/earn/Navigation";
 import HeroSection from "@/components/creator/earn/HeroSection";
-import StoriesContainer from "@/components/creator/earn/stories/StoriesContainer";
 import ReferralBanner from "@/components/creator/earn/ReferralBanner";
-import {track} from "@/lib/analytics/track";
+import { SignupProvider } from "@/components/creator/promo/SignupContext";
 
 const ValueProposition = dynamic(() => import("@/components/creator/earn/ValueProposition"));
-const BenefitsSection = dynamic(() => import("@/components/creator/earn/BenefitsSection"));
+const ThreeStepSection = dynamic(() => import("@/components/creator/promo/ThreeStepSection"));
+const PhoneMockupSection = dynamic(() => import("@/components/creator/promo/PhoneMockupSection"));
 const AdvantageSection = dynamic(() => import("@/components/creator/earn/AdvantageSection"));
 const TestimonialsSection = dynamic(() => import("@/components/creator/earn/TestimonialsSection"));
-const VideoSection = dynamic(() => import("@/components/creator/earn/VideoSection"));
 const FAQSection = dynamic(() => import("@/components/creator/earn/FAQSection"));
-const CTASection = dynamic(() => import("@/components/creator/earn/CTASection"));
 const EarnFooter = dynamic(() => import("@/components/creator/earn/EarnFooter"));
 const FloatingCTA = dynamic(() => import("@/components/creator/earn/FloatingCTA"), { ssr: false });
 
 function CreatorEarnPageContent() {
   const {i18n} = useTranslation();
   const searchParams = useSearchParams();
-  const [showStories, setShowStories] = useState(false);
-  const [showLandingPage, setShowLandingPage] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    // Set language from URL param only if present
+    // Set language from URL param only if present. Runs after the first paint
+    // so the server-rendered English content hydrates cleanly; i18next then
+    // swaps the strings in place (no remount) when ?lang=hi-Latn is set.
+    // Don't force English - let the user's selection persist.
     const langParam = searchParams.get("lang");
     if (langParam && ["en", "hi-Latn"].includes(langParam)) {
       i18n.changeLanguage(langParam);
     }
-    // Don't force English - let the user's selection persist
-
-    const storiesViewed = sessionStorage.getItem("storiesViewed");
-    const referralCode = searchParams.get("ref");
-
-    if (referralCode || storiesViewed === "true") {
-      setShowLandingPage(true);
-      setShowStories(false);
-    } else {
-      const variant = Math.random() < 0.5 ? "show_stories" : "no_stories";
-      track("earn_stories_ab_exposure", {
-        test_name: "earn_stories_50_50",
-        variant,
-      });
-
-      if (variant === "show_stories") {
-        setShowStories(true);
-        setShowLandingPage(false);
-      } else {
-        sessionStorage.setItem("storiesViewed", "true");
-        setShowLandingPage(true);
-        setShowStories(false);
-      }
-    }
-
-    setIsLoading(false);
   }, [searchParams, i18n]);
 
-  const handleStoriesComplete = () => {
-    setShowStories(false);
-    setTimeout(() => {
-      setShowLandingPage(true);
-    }, 300);
-  };
-
-  // Show loading state briefly
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-black flex items-center justify-center">
-        <div className="text-white">Loading...</div>
-      </div>
-    );
-  }
+  // No loading gate: rendering real content on the server (instead of a
+  // "Loading..." placeholder behind a client-only state flip) lets the hero
+  // and LCP element paint from the SSR HTML rather than waiting on hydration.
 
   return (
-    <>
-      {/* Stories Experience */}
-      {showStories && <StoriesContainer onComplete={handleStoriesComplete} />}
+    <SignupProvider>
+      <main className="relative min-h-screen bg-black overflow-hidden">
+        {/* Background Gradients — tuned to reach the end of the FAQ
+            (the "View All" / "Show Less" toggle), so bg-black only
+            shows behind the footer below it. */}
+        <div className="absolute -top-[400px] -left-[940px] inset-0 pointer-events-none">
+          <div className="mt-[900px] w-[2422px] h-[2422px] md:w-[4500px] gradient-blob" />
+          <div className="-mt-[1000px] w-[2422px] h-[44%] md:w-[4500px] md:h-[41%] gradient-blob" />
+        </div>
 
-      {/* Main Landing Page */}
-      <AnimatePresence>
-        {showLandingPage && (
-          <motion.main
-            className="relative min-h-screen bg-black overflow-hidden"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.6 }}
-          >
-            {/* Background Gradients */}
-            <div className="absolute -top-[400px] -left-[940px] inset-0 pointer-events-none">
-              {/* Pink to Purple Gradient Blob */}
-              <div className="mt-[500px] w-[2422px] h-[2422px] md:w-[4500px] gradient-blob" />
-              <div className="-mt-[1000px] w-[2422px] h-[65%] md:w-[4500px] md:h-[62%] gradient-blob" />
-            </div>
+        {/* Content */}
+        <div className="relative z-10">
+          <Navigation />
+          <Suspense fallback={null}>
+            <ReferralBanner />
+          </Suspense>
+          <HeroSection />
+          <ValueProposition />
+          <ThreeStepSection namespace="creatorEarn" trackingId="earn_three_step" />
+          <PhoneMockupSection />
+          <TestimonialsSection
+            namespace="creatorEarn"
+            trackingId="earn_testimonials"
+            disableSlideEntryAnimation
+          />
+          <AdvantageSection
+            variant="promo"
+            namespace="creatorEarn"
+            trackingId="earn_advantage"
+            analyticsEvent="earn_cta_click"
+          />
+          <FAQSection
+            namespace="creatorEarn"
+            trackingId="earn_faq"
+            analyticsEvent="earn_faq_toggle"
+            expandInline
+          />
+          <EarnFooter />
+        </div>
 
-            {/* Content */}
-            <div className="relative z-10">
-              <Navigation />
-              <Suspense fallback={null}>
-                <ReferralBanner />
-              </Suspense>
-              <HeroSection />
-              <ValueProposition />
-              <BenefitsSection />
-              <AdvantageSection />
-              <TestimonialsSection />
-              <VideoSection />
-              <FAQSection />
-              <CTASection />
-              <EarnFooter />
-            </div>
-
-            {/* Floating CTA Button */}
-            <FloatingCTA />
-          </motion.main>
-        )}
-      </AnimatePresence>
-    </>
+        {/* Floating CTA — earn variant mirrors the hero card's pitch
+            (dark surface, FlippingCoin, Win-Gold-Coin heading, inline
+            checks, white phone pill, Win Now). Phone input is piped into
+            the shared SignupContext so submitting from the bottom bar
+            advances the hero card straight to OTP. triggerElementId
+            hides the bar while the hero card is on-screen.
+            Kept as a direct child of <main> (no motion wrapper) so
+            position:fixed anchors to the viewport — wrapping in motion.*
+            can promote the ancestor to a containing block on some mobile
+            browsers and pin the bar mid-page. */}
+        <FloatingCTA
+          variant="earn"
+          namespace="creatorEarn"
+          trackingPrefix="earn"
+          triggerElementId="promo-hero-card"
+        />
+      </main>
+    </SignupProvider>
   );
 }
 

--- a/app/creator/earn/layout.tsx
+++ b/app/creator/earn/layout.tsx
@@ -1,6 +1,18 @@
 import type {Metadata} from "next";
 import {ReactNode} from "react";
+import { Solitreo } from "next/font/google";
 import MetaPixelScript from "@/components/MetaPixelScript";
+
+// Script font for the hero title's second line ("Jaldi payment paayein!" /
+// "Get paid faster!") and the gold "Win Gold Coin" portion of the signup
+// card. Scoped to /creator/earn via a CSS variable so the rest of the site
+// keeps shipping just Roboto. Solitreo only ships at weight 400.
+const solitreo = Solitreo({
+  subsets: ["latin"],
+  weight: ["400"],
+  display: "swap",
+  variable: "--font-solitreo",
+});
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.sparkonomy.com/"),
@@ -75,9 +87,9 @@ export default function EarnLayout({
   // set of font-face blocks (adding 600 weight and unused --font-roboto var)
   // and shipping an extra font file on the earn route. Consolidated into root.
   return (
-    <>
+    <div className={solitreo.variable}>
       <MetaPixelScript />
       {children}
-    </>
+    </div>
   );
 }

--- a/app/creator/earn/page.tsx
+++ b/app/creator/earn/page.tsx
@@ -5,15 +5,35 @@ type Props = {
   searchParams: Promise<{ lang?: string; ref?: string }>;
 };
 
-// Preload hint for the first story's image. First-time visitors see the
-// stories overlay as their LCP, and since the <Image> only mounts after the
-// client finishes hydrating (behind the Loading... gate), the browser otherwise
-// can't begin fetching it until React runs. Emitting a srcset-matching preload
-// on the server lets the fetch overlap hydration. Skipped when ?ref= is
-// present, since referral visitors bypass the stories entirely.
+// Story-image preloads. First-time visitors see the auto-rotating story
+// carousel as their LCP. Story 1 is now rendered straight from the server HTML
+// (the old client-only "Loading..." gate is gone) with Next/Image `priority`,
+// so Next emits a correctly-matched high-priority preload for it automatically.
+// We additionally warm stories 2-4 here at LOW priority so the 2s/4s/6s carousel
+// swaps are instant without ever competing with the LCP fetch or hydration.
+// Skipped when ?ref= is present, since referral visitors bypass the stories.
 function nextImageUrl(src: string, width: number, quality = 75): string {
   return `/_next/image?url=${encodeURIComponent(src)}&w=${width}&q=${quality}`;
 }
+
+// Mirror the srcset Next/Image generates for the carousel's <Image> (width=192
+// → 1x w=256, 2x w=384, default q=75). Keeping these byte-identical is what lets
+// the browser reuse the preloaded variant instead of refetching.
+function storySrcSet(src: string): string {
+  return `${nextImageUrl(src, 256)} 1x, ${nextImageUrl(src, 384)} 2x`;
+}
+
+// Filenames mirror HeroStoryCarousel's STORY_IMAGES exactly, so the preloads
+// line up with what the component actually requests.
+const STORY_FILES: Record<"en" | "hi-Latn", readonly string[]> = {
+  en: ["story-1.png", "Story2.png", "story-3.png", "story-4.png"],
+  "hi-Latn": [
+    "story-1-hi-Latn.png",
+    "Story2-hi.png",
+    "story-3-hi-Latn.png",
+    "story-4-hi-Latn.png",
+  ],
+};
 
 export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
   const { lang } = await searchParams;
@@ -56,23 +76,29 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
 
 export default async function Page({ searchParams }: Props) {
   const { lang, ref } = await searchParams;
-  const storyImage = lang === "hi-Latn"
-    ? "/images/creator/earn/story-1-hi-Latn.png"
-    : "/images/creator/earn/story-1.png";
-  const shouldPreloadStory = !ref;
+  const stories = STORY_FILES[lang === "hi-Latn" ? "hi-Latn" : "en"];
+  const base = "/images/creator/earn/";
+  const shouldPreloadStories = !ref;
 
   return (
     <>
-      {shouldPreloadStory && (
-        <link
-          rel="preload"
-          as="image"
-          href={nextImageUrl(storyImage, 828)}
-          imageSrcSet={`${nextImageUrl(storyImage, 640)} 640w, ${nextImageUrl(storyImage, 828)} 828w, ${nextImageUrl(storyImage, 1080)} 1080w`}
-          imageSizes="(max-width: 640px) 90vw, 362px"
-          fetchPriority="high"
-        />
-      )}
+      {shouldPreloadStories &&
+        stories.map((file, i) => (
+          <link
+            key={file}
+            rel="preload"
+            as="image"
+            href={nextImageUrl(base + file, 384)}
+            imageSrcSet={storySrcSet(base + file)}
+            // Story 1 is the LCP — preload it at high priority from the document
+            // head (Next/Image `priority` alone wasn't getting fetchpriority=high
+            // onto the actual request). The srcset matches the carousel <Image>
+            // exactly, so this preload is the request the browser uses. Stories
+            // 2-4 load at low priority during idle so they're decoded before the
+            // (load-gated) rotation reaches them — no black flash on swap.
+            fetchPriority={i === 0 ? "high" : "low"}
+          />
+        ))}
       <CreatorEarnPage />
     </>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { RootLayoutClient } from "./root-layout-client";
 import Script from "next/script";
 import type { Metadata } from "next";
 import CookieConsentScript from "@/components/CookieConsentScript";
+import { SITE_URL } from "@/lib/urls";
 
 const roboto = Roboto({
   subsets: ["latin"],
@@ -17,6 +18,7 @@ const roboto = Roboto({
 const isProduction = !process.env.SITE_URL?.startsWith('https://dev.')
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   robots: isProduction ? undefined : { index: false, follow: false },
   icons: {
     icon: [
@@ -70,6 +72,39 @@ gtag('config', '${id}', {
 })();
 `.trim();
 
+// Site-wide entity graph: declares the Sparkonomy Organization + WebSite once
+// for every page, so the brand is a consistent entity and author `worksFor`
+// references (@id .../#organization) resolve to a real node.
+const ORG_WEBSITE_JSONLD = JSON.stringify({
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.sparkonomy.com/#organization",
+      name: "Sparkonomy",
+      url: "https://www.sparkonomy.com",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://www.sparkonomy.com/sparkonomy.png",
+        width: 512,
+        height: 512,
+      },
+      sameAs: [
+        "https://twitter.com/sparkonomy",
+        "https://www.linkedin.com/company/sparkonomy",
+        "https://www.instagram.com/sparkonomy",
+      ],
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.sparkonomy.com/#website",
+      url: "https://www.sparkonomy.com",
+      name: "Sparkonomy",
+      publisher: { "@id": "https://www.sparkonomy.com/#organization" },
+    },
+  ],
+});
+
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="h-full">
@@ -82,6 +117,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           />
         )}
         <meta name="theme-color" content="#000000" />
+
+        {/* Site-wide Organization + WebSite entity graph (helps brand + author
+            entity understanding in the Knowledge Graph). */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: ORG_WEBSITE_JSONLD }}
+        />
 
         {/* Warm up the GTM/GA origin so the deferred loader (below) doesn't pay
             a fresh DNS+TLS round-trip on first fire. */}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -34,7 +34,7 @@ export default function Footer({ minimal = false }: FooterProps) {
       className={
         minimal
           ? "relative w-full select-none z-10 mt-auto pt-8"
-          : "relative w-full left-0 right-0 select-none z-50 md:fixed md:bottom-0 pointer-events-none"
+          : "relative w-full left-0 right-0 select-none z-50 md:fixed md:bottom-0 pointer-events-none pt-20"
       }
     >
       {!minimal && mounted && isPromoActive && heroReady && (

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -34,7 +34,7 @@ export default function Footer({ minimal = false }: FooterProps) {
       className={
         minimal
           ? "relative w-full select-none z-10 mt-auto pt-8"
-          : "relative w-full left-0 right-0 select-none z-50 md:fixed md:bottom-0 pointer-events-none pt-20"
+          : "relative w-full left-0 right-0 select-none z-50 md:fixed md:bottom-0 pointer-events-none"
       }
     >
       {!minimal && mounted && isPromoActive && heroReady && (

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -411,7 +411,7 @@ const HeroSection = () => {
             >
               <h2
                 ref={sparkonomyRef}
-                className="text-5xl xs:text-5xl sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-bold mb-6 pt-20 tracking-normal text-white select-none whitespace-nowrap pointer-events-none"
+                className="text-5xl xs:text-5xl sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-bold mb-6 tracking-normal text-white select-none whitespace-nowrap pointer-events-none"
                 style={{
                   textShadow: "0 0 20px rgba(108,99,255,0.3)",
                 }}

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -411,7 +411,7 @@ const HeroSection = () => {
             >
               <h2
                 ref={sparkonomyRef}
-                className="text-5xl xs:text-5xl sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-bold mb-6 tracking-normal text-white select-none whitespace-nowrap pointer-events-none"
+                className="text-5xl xs:text-5xl sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-bold mb-6 pt-20 tracking-normal text-white select-none whitespace-nowrap pointer-events-none"
                 style={{
                   textShadow: "0 0 20px rgba(108,99,255,0.3)",
                 }}

--- a/components/blog/AuthorPageTemplate.tsx
+++ b/components/blog/AuthorPageTemplate.tsx
@@ -15,16 +15,52 @@ const TrustIconPaths: Record<string, string> = {
   featured: "/authors/Logos/Featured.png",
 };
 
-// Social Icons
+// Social Icons (decorative — the wrapping <a> carries the accessible label)
 const SocialIcons = {
   twitter: (
-    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
     </svg>
   ),
   linkedin: (
-    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  ),
+  instagram: (
+    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path fillRule="evenodd" d="M12.315 2c2.43 0 2.784.013 3.808.06 1.064.049 1.791.218 2.427.465a4.902 4.902 0 011.772 1.153 4.902 4.902 0 011.153 1.772c.247.636.416 1.363.465 2.427.048 1.067.06 1.407.06 4.123v.08c0 2.643-.012 2.987-.06 4.043-.049 1.064-.218 1.791-.465 2.427a4.902 4.902 0 01-1.153 1.772 4.902 4.902 0 01-1.772 1.153c-.636.247-1.363.416-2.427.465-1.067.048-1.407.06-4.123.06h-.08c-2.643 0-2.987-.012-4.043-.06-1.064-.049-1.791-.218-2.427-.465a4.902 4.902 0 01-1.772-1.153 4.902 4.902 0 01-1.153-1.772c-.247-.636-.416-1.363-.465-2.427-.047-1.024-.06-1.379-.06-3.808v-.63c0-2.43.013-2.784.06-3.808.049-1.064.218-1.791.465-2.427a4.902 4.902 0 011.153-1.772A4.902 4.902 0 015.45 2.525c.636-.247 1.363-.416 2.427-.465C8.901 2.013 9.256 2 11.685 2h.63zm-.081 1.802h-.468c-2.456 0-2.784.011-3.807.058-.975.045-1.504.207-1.857.344-.467.182-.8.398-1.15.748-.35.35-.566.683-.748 1.15-.137.353-.3.882-.344 1.857-.047 1.023-.058 1.351-.058 3.807v.468c0 2.456.011 2.784.058 3.807.045.975.207 1.504.344 1.857.182.466.399.8.748 1.15.35.35.683.566 1.15.748.353.137.882.3 1.857.344 1.054.048 1.37.058 4.041.058h.08c2.597 0 2.917-.01 3.96-.058.976-.045 1.505-.207 1.858-.344.466-.182.8-.398 1.15-.748.35-.35.566-.683.748-1.15.137-.353.3-.882.344-1.857.048-1.055.058-1.37.058-4.041v-.08c0-2.597-.01-2.917-.058-3.96-.045-.976-.207-1.505-.344-1.858a3.097 3.097 0 00-.748-1.15 3.098 3.098 0 00-1.15-.748c-.353-.137-.882-.3-1.857-.344-1.023-.047-1.351-.058-3.807-.058zM12 6.865a5.135 5.135 0 110 10.27 5.135 5.135 0 010-10.27zm0 1.802a3.333 3.333 0 100 6.666 3.333 3.333 0 000-6.666zm5.338-3.205a1.2 1.2 0 110 2.4 1.2 1.2 0 010-2.4z" clipRule="evenodd" />
+    </svg>
+  ),
+  youtube: (
+    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path fillRule="evenodd" d="M19.812 5.418c.861.23 1.538.907 1.768 1.768C21.998 8.746 22 12 22 12s0 3.255-.418 4.814a2.504 2.504 0 0 1-1.768 1.768c-1.56.419-7.814.419-7.814.419s-6.255 0-7.814-.419a2.505 2.505 0 0 1-1.768-1.768C2 15.255 2 12 2 12s0-3.255.417-4.814a2.507 2.507 0 0 1 1.768-1.768C5.744 5 11.998 5 11.998 5s6.255 0 7.814.418ZM15.194 12 10 15V9l5.194 3Z" clipRule="evenodd" />
+    </svg>
+  ),
+  facebook: (
+    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path fillRule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" clipRule="evenodd" />
+    </svg>
+  ),
+  website: (
+    <svg
+      className="w-5 h-5"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3.6 9h16.8M3.6 15h16.8M12 3a15 15 0 010 18M12 3a15 15 0 000 18"
+      />
     </svg>
   ),
   email: (
@@ -34,6 +70,7 @@ const SocialIcons = {
       stroke="currentColor"
       viewBox="0 0 24 24"
       strokeWidth="2"
+      aria-hidden="true"
     >
       <path
         strokeLinecap="round"
@@ -43,6 +80,14 @@ const SocialIcons = {
     </svg>
   ),
 };
+
+// Convert a human "Month DD, YYYY" date into an ISO 8601 date (YYYY-MM-DD) for
+// the <time> dateTime attribute. " UTC" forces UTC parsing (no day shift).
+function toIsoDate(human?: string): string | undefined {
+  if (!human) return undefined;
+  const d = new Date(`${human} UTC`);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString().slice(0, 10);
+}
 
 interface AuthorPageTemplateProps {
   author: AuthorEntry;
@@ -62,13 +107,13 @@ export default function AuthorPageTemplate({
   const displayRecentArticles = recentArticles ?? author.recentArticles ?? [];
 
   return (
-    <main className="min-h-screen bg-white">
-      {/* Breadcrumb */}
+    // <article> (not <main>) — the blog layout already provides the <main> landmark.
+    <article className="min-h-screen bg-white">
+      {/* Breadcrumb — mirrors the BreadcrumbList JSON-LD (Blog › Name) */}
       <div className="max-w-4xl mx-auto px-4 pt-[16px]">
         <Breadcrumb
           items={[
             { label: "Blog", href: "/blogs" },
-            { label: "Author", href: "/blogs" },
             { label: author.name },
           ]}
         />
@@ -130,6 +175,50 @@ export default function AuthorPageTemplate({
                 aria-label="LinkedIn"
               >
                 {SocialIcons.linkedin}
+              </a>
+            )}
+            {author.socialLinks.instagram && (
+              <a
+                href={author.socialLinks.instagram}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                aria-label="Instagram"
+              >
+                {SocialIcons.instagram}
+              </a>
+            )}
+            {author.socialLinks.youtube && (
+              <a
+                href={author.socialLinks.youtube}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                aria-label="YouTube"
+              >
+                {SocialIcons.youtube}
+              </a>
+            )}
+            {author.socialLinks.facebook && (
+              <a
+                href={author.socialLinks.facebook}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                aria-label="Facebook"
+              >
+                {SocialIcons.facebook}
+              </a>
+            )}
+            {author.socialLinks.website && (
+              <a
+                href={author.socialLinks.website}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                aria-label="Website"
+              >
+                {SocialIcons.website}
               </a>
             )}
             {author.socialLinks.email && (
@@ -305,7 +394,7 @@ export default function AuthorPageTemplate({
                 key={index}
                 className="flex items-start gap-2 text-[14px] md:text-[16px] font-normal text-[#999999]"
               >
-                <span className="text-[#999999] mt-1">✓</span>
+                <span className="text-[#999999] mt-1" aria-hidden="true">✓</span>
                 <span>{highlight}</span>
               </li>
             ))}
@@ -392,6 +481,7 @@ export default function AuthorPageTemplate({
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
+                    aria-hidden="true"
                   >
                     <path
                       strokeLinecap="round"
@@ -470,6 +560,7 @@ export default function AuthorPageTemplate({
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"
@@ -556,6 +647,14 @@ export default function AuthorPageTemplate({
           )}
         </div>
       </section>
-    </main>
+
+      {/* Profile freshness signal */}
+      {author.lastUpdated && (
+        <p className="text-center text-[12px] md:text-sm font-normal text-[#999999] pb-[16px]">
+          Profile last updated on{" "}
+          <time dateTime={toIsoDate(author.lastUpdated)}>{author.lastUpdated}</time>
+        </p>
+      )}
+    </article>
   );
 }

--- a/components/creator/earn/AdvantageSection.tsx
+++ b/components/creator/earn/AdvantageSection.tsx
@@ -36,6 +36,27 @@ const PROMO_ADVANTAGE_ICONS = [
   "/promo/landing-promo/CA-ready.png",
 ];
 
+// Renders a comma-headline ("Hamesha free, 4 invoices.") as two balanced lines
+// on laptop/desktop — breaking right after the first comma — while keeping it
+// inline (natural wrap) on mobile. Titles without a comma render unchanged.
+function TitleWithLaptopBreak({ title }: { title: string }) {
+  const commaIdx = title.indexOf(",");
+  if (commaIdx === -1 || commaIdx >= title.trimEnd().length - 1) {
+    return <>{title}</>;
+  }
+  const first = title.slice(0, commaIdx + 1); // keep the comma on line 1
+  const rest = title.slice(commaIdx + 1).trimStart();
+  return (
+    <>
+      {first}{" "}
+      {/* md+ only: forces the break after the comma. Hidden on mobile, where
+          the trailing space above keeps the headline a single inline run. */}
+      <br className="hidden md:block" />
+      {rest}
+    </>
+  );
+}
+
 // Promo-variant card. Inline because the layout (rounded backgrounded row)
 // differs from AdvantageFeature's bare-with-bottom-border earn layout.
 function PromoAdvantageCard({ index, title, description, iconUrl }: AdvantageItem & { index: number; iconUrl: string }) {
@@ -52,7 +73,7 @@ function PromoAdvantageCard({ index, title, description, iconUrl }: AdvantageIte
           <Image src={iconUrl} alt="" fill sizes="79px" className="object-contain" />
         </div>
         <div className="flex-1 min-w-0 md:flex-none md:flex md:flex-col md:items-center md:gap-3.5 md:max-w-[247px]">
-          <h3 className="text-white font-bold text-lg md:text-2xl md:font-semibold leading-tight md:leading-normal">{title}</h3>
+          <h3 className="text-white font-bold text-lg md:text-2xl md:font-semibold leading-tight md:leading-normal"><TitleWithLaptopBreak title={title} /></h3>
           <p className="mt-1 md:mt-0 text-white text-sm leading-snug md:text-center">{description}</p>
         </div>
       </div>

--- a/components/creator/earn/BenefitsSection.tsx
+++ b/components/creator/earn/BenefitsSection.tsx
@@ -51,7 +51,7 @@ export default function BenefitsSection() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.6 }}
-          className="text-center mb-12 md:mb-16"
+          className="text-center mb-12 md:mb-6"
         >
           <h2 className="text-2xl md:text-[52px] font-bold text-white">
             {t("benefits.title")}

--- a/components/creator/earn/FAQSection.tsx
+++ b/components/creator/earn/FAQSection.tsx
@@ -69,7 +69,7 @@ export default function FAQSection({
       >
         <div className="w-full mx-auto">
           {/* Compliance Badges */}
-          <div className="flex items-center justify-center gap-6 mb-12">
+          <div className="flex items-center justify-center gap-6 mb-10">
             <Image
               src="/logos/GDPR_White.png"
               alt="GDPR"
@@ -94,7 +94,7 @@ export default function FAQSection({
           </div>
 
           {/* Section Header */}
-          <h2 className="text-[40px] md:text-[40px] font-bold text-white mb-6 md:mb-12">
+          <h2 className="text-[40px] md:text-[40px] font-bold text-white leading-none md:leading-tight mb-1 md:mb-12">
             {t("faq.title")}
           </h2>
 

--- a/components/creator/earn/FloatingCTA.tsx
+++ b/components/creator/earn/FloatingCTA.tsx
@@ -3,14 +3,12 @@
 import { Suspense, useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Trans, useTranslation } from "react-i18next";
-import { useSearchParams } from "next/navigation";
-import Image from "next/image";
 import { ValidatedPhoneInput } from "./ValidatedPhoneInput";
+import FlippingCoin from "./FlippingCoin";
 import { useSignup } from "@/components/creator/promo/SignupContext";
 import GiftCardStackAnimation from "@/components/creator/promo/GiftCardStackAnimation";
 import { PROMO_CONFIG } from "@/lib/promo/config";
 import { track } from "@/lib/analytics/track";
-import { appendUtmTo, readUtmParams } from "@/lib/utm";
 
 // Module-level rAF id so overlapping clicks cancel the previous scroll
 // instead of fighting it (each animation re-reads window.scrollY at start).
@@ -67,15 +65,26 @@ export default function FloatingCTA({
   trackingPrefix = "earn",
   triggerElementId,
 }: FloatingCTAProps = {}) {
-  const { t, i18n } = useTranslation(namespace);
-  const searchParams = useSearchParams();
+  const { t } = useTranslation(namespace);
   const [isVisible, setIsVisible] = useState(false);
+  // Gate visibility on the hero card having been seen at least once. The
+  // observer's initial callback fires synchronously on observe(), so without
+  // this guard the bar pops up on first paint whenever the card starts below
+  // the fold (e.g. /creator/earn, where the story carousel pushes it down).
+  const hasBeenSeenRef = useRef(false);
 
   useEffect(() => {
     const target = triggerElementId ? document.getElementById(triggerElementId) : null;
     if (target) {
       const observer = new IntersectionObserver(
-        ([entry]) => setIsVisible(!entry.isIntersecting),
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            hasBeenSeenRef.current = true;
+            setIsVisible(false);
+          } else {
+            setIsVisible(hasBeenSeenRef.current);
+          }
+        },
         { threshold: 0 },
       );
       observer.observe(target);
@@ -92,74 +101,162 @@ export default function FloatingCTA({
   return variant === "promo" ? (
     <PromoFloatingCTA isVisible={isVisible} t={t} trackingPrefix={trackingPrefix} />
   ) : (
-    <EarnFloatingCTA
-      isVisible={isVisible}
-      t={t}
-      i18n={i18n}
-      searchParams={searchParams}
-      trackingPrefix={trackingPrefix}
-    />
+    <EarnFloatingCTA isVisible={isVisible} t={t} trackingPrefix={trackingPrefix} />
   );
 }
 
 // ---------- Earn variant ---------------------------------------------------
+// Sticky bottom bar mirroring the hero card's Win-Gold-Coin pitch: dark
+// gradient surface, FlippingCoin peeking out of the top-right corner, the
+// shared voucher heading (white + gold script), an inline 3-up checks row,
+// the same white phone input pill, and the Terms/Privacy disclaimer. Submit
+// hands the phone number off to the hero card via SignupContext (same path
+// as the promo variant) so the OTP step happens inline on the card.
 
 interface EarnVariantProps {
   isVisible: boolean;
-  t: (key: string) => string;
-  i18n: { language?: string };
-  searchParams: ReturnType<typeof useSearchParams>;
+  t: ReturnType<typeof useTranslation>["t"];
   trackingPrefix: string;
 }
 
-function EarnFloatingCTA({ isVisible, t, i18n, searchParams, trackingPrefix }: EarnVariantProps) {
-  const [phone, setPhone] = useState("");
+function EarnFloatingCTA({ isVisible, t, trackingPrefix }: EarnVariantProps) {
+  const { phone, setPhone, sendOtp, stage } = useSignup();
+  const prefersReducedMotion = useReducedMotion();
 
-  const referralCode = searchParams.get("ref");
-  const currentLang = i18n.language?.startsWith("hi") ? "hi-Latn" : "en";
+  const checks = (() => {
+    const raw = t("hero.card.checks", { returnObjects: true });
+    return Array.isArray(raw) ? (raw as string[]) : [];
+  })();
 
-  const handleSignup = () => {
-    const url = new URL("https://beta.creator.sparkonomy.com/auth?service=earn");
-    url.searchParams.set("lang", currentLang);
-    if (referralCode) url.searchParams.set("ref", referralCode);
-    if (phone) url.searchParams.set("phone", phone);
-    appendUtmTo(url, readUtmParams(new URLSearchParams(searchParams.toString())));
-    track(`${trackingPrefix}_cta_click`, {
-      cta: "floating_beta_signup",
-      has_phone: Boolean(phone),
-      referral_code: referralCode ?? null,
-    });
-    if (phone) {
-      track(`${trackingPrefix}_floating_cta_phone_submit`, { referral_code: referralCode ?? null });
+  const handleSubmit = async () => {
+    track(`${trackingPrefix}_floating_cta_phone_submit`, { has_phone: Boolean(phone) });
+    const target = document.getElementById("promo-hero-card");
+
+    if (target) {
+      if (prefersReducedMotion) {
+        target.scrollIntoView({ block: "center" });
+      } else {
+        await smoothScrollToCenter(target, 1200);
+      }
     }
-    window.location.href = url.toString();
+
+    if (!phone || stage !== "phone") return;
+
+    await new Promise((r) => window.setTimeout(r, 350));
+    void sendOtp();
   };
 
   return (
     <AnimatePresence>
       {isVisible && (
+        // -bottom-px on the fixed wrapper (and the matching +1px on the
+        // inner pb) overshoots the viewport by 1px to cover the sub-pixel
+        // gap left by framer-motion's translateY(0) on fractional-DPR screens.
         <motion.div
           initial={{ opacity: 0, y: 100 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: 100 }}
-          transition={{ duration: 0.5, ease: [0.4, 0, 0.2, 1] }}
-          className="fixed bottom-4 left-0 right-0 z-50 flex justify-center items-center px-4"
+          transition={{ duration: 0.4, ease: [0.4, 0, 0.2, 1] }}
+          className="fixed -bottom-px left-0 right-0 z-40"
         >
-          <div className="flex items-center w-full max-w-md rounded-full bg-white/10 backdrop-blur-[16px] backdrop-brightness-[100%] shadow-[0_8px_32px_rgba(221,42,123,0.3),inset_0_1px_0_rgba(255,255,255,0.2)] border border-white/20 px-3 py-2 gap-2">
-            <Suspense fallback={null}>
-              <ValidatedPhoneInput
-                id="floating-cta-phone"
-                value={phone}
-                onChange={setPhone}
-                placeholder={t("floatingCta.placeholder")}
+          <div
+            className="relative w-full md:max-w-md md:mx-auto rounded-t-[20px] px-4 pt-3 pb-[max(calc(0.5rem+1px),calc(env(safe-area-inset-bottom)+1px))] shadow-[0_-10px_30px_rgba(0,0,0,0.45),0_-2px_8px_rgba(221,42,123,0.2)]"
+            style={{
+              background:
+                "linear-gradient(180deg, #000000 0%, rgba(221, 42, 123, 0.09) 100%)",
+              backdropFilter: "blur(20px)",
+              WebkitBackdropFilter: "blur(20px)",
+            }}
+          >
+            {/* Top-right coin peeks above the bar edge — sibling of the
+                content column so it pins to the outer surface rather than
+                being affected by the inner padding. */}
+            <div className="absolute -top-5 right-3 z-20 pointer-events-none">
+              <FlippingCoin size={48} />
+            </div>
+
+            {/* Heading — "Send free invoice —" white, "Win Gold Coin" gold
+                Solitreo script. Right padding clears the coin. */}
+            <h3 className="pr-12 text-[18px] font-semibold tracking-[-0.04em] text-white leading-tight">
+              <Trans
+                i18nKey="hero.card.voucherHeading"
+                t={t}
+                components={[
+                  <span
+                    key="gold"
+                    className="italic"
+                    style={{
+                      color: "#FFCC00",
+                      fontFamily:
+                        "var(--font-solitreo), 'Brush Script MT', 'Snell Roundhand', cursive",
+                      fontWeight: 700,
+                      fontSize: "1.15em",
+                      paddingLeft: "0.1em",
+                    }}
+                  />,
+                ]}
               />
-            </Suspense>
-            <button
-              onClick={handleSignup}
-              className="flex-shrink-0 px-5 py-2.5 rounded-full text-white text-sm font-semibold whitespace-nowrap bg-[linear-gradient(162deg,rgba(221,42,123,0.8)_0%,rgba(151,71,255,0.8)_64%)] hover:bg-[linear-gradient(162deg,rgba(221,42,123,1)_0%,rgba(151,71,255,1)_64%)] transition-all duration-200"
-            >
-              {t("floatingCta.signup")}
-            </button>
+            </h3>
+
+            {/* Inline checks — single row mirroring the hero card's earn
+                layout. 10.5px so all three fit on a 360px viewport. */}
+            {checks.length > 0 && (
+              <ul className="mt-1.5 flex items-center text-[10.5px] font-normal text-white whitespace-nowrap gap-x-3.5">
+                {checks.map((label, i) => (
+                  <li key={i} className="flex items-center gap-1">
+                    <span aria-hidden="true">✅</span>
+                    <span>{label}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {/* Phone input + Win Now — hands off to the hero card */}
+            <div className="mt-2.5 flex items-center w-full rounded-[16px] bg-white border border-black/10 p-[6px] pl-3 gap-2">
+              <Suspense fallback={null}>
+                <ValidatedPhoneInput
+                  id="earn-floating-phone"
+                  value={phone}
+                  onChange={setPhone}
+                  placeholder={t("hero.card.phonePlaceholder")}
+                  theme="light"
+                  inputClassName="bg-transparent border-none outline-none text-base placeholder:text-[#999999] focus:outline-none focus:ring-0 w-full text-[#212529]"
+                />
+              </Suspense>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={stage === "otpSending"}
+                aria-label={t("floatingCta.ariaLabel")}
+                className="flex-shrink-0 px-4 py-2 rounded-[8px] text-white text-sm font-bold whitespace-nowrap bg-[linear-gradient(180.27deg,#DD2A7B_-46.92%,#9747FF_80.1%)] hover:brightness-110 transition-[filter,opacity] duration-200 disabled:opacity-60 disabled:cursor-not-allowed shadow-[0_2px_8px_rgba(151,71,255,0.4)]"
+              >
+                {stage === "otpSending" ? t("otp.sending") : t("hero.card.sendOtp")}
+              </button>
+            </div>
+
+            {/* Disclaimer */}
+            <p className="mt-1.5 text-[8.5px] text-white/90 text-center leading-snug px-1">
+              <Trans
+                i18nKey="hero.card.disclaimer"
+                t={t}
+                components={[
+                  <a
+                    key="terms"
+                    href="/legal/terms"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline underline-offset-2 font-medium"
+                  />,
+                  <a
+                    key="privacy"
+                    href="/legal/privacy-policy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline underline-offset-2 font-medium"
+                  />,
+                ]}
+              />
+            </p>
           </div>
         </motion.div>
       )}
@@ -329,6 +426,7 @@ function PromoFloatingCTA({ isVisible, t, trackingPrefix }: PromoVariantProps) {
                     value={phone}
                     onChange={setPhone}
                     placeholder={t("floatingCta.placeholder")}
+                    theme="light"
                     inputClassName="bg-transparent border-none outline-none text-base placeholder:text-[#999999] focus:outline-none focus:ring-0 w-full text-[#212529]"
                   />
                 </Suspense>

--- a/components/creator/earn/HeroSection.tsx
+++ b/components/creator/earn/HeroSection.tsx
@@ -1,241 +1,66 @@
 "use client";
 
-import { Suspense } from "react";
-import { motion } from "framer-motion";
-import Image from "next/image";
-import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
-import { useSearchParams } from "next/navigation";
-import CTAButton from "./CTAButton";
+import { useRef } from "react";
+import { Trans, useTranslation } from "react-i18next";
+import PromoSignupCard from "@/components/creator/promo/PromoSignupCard";
+import HeroStoryCarousel from "./HeroStoryCarousel";
 import { useSectionViewTracking } from "@/lib/hooks/useSectionViewTracking";
-import { useIsPromoActive } from "@/lib/hooks/useIsPromoActive";
-import { PROMO_CONFIG } from "@/lib/promo/config";
-import { track } from "@/lib/analytics/track";
-import { appendUtmTo, readUtmParams } from "@/lib/utm";
+
+// Script styling for the second line of the title ("Jaldi payment paayein!" /
+// "Get paid faster!"). Solitreo at the spec'd 40px / weight 400 / -4% tracking.
+// Kept as its own style object so the regular Roboto bold line above it stays
+// untouched.
+const TITLE_SCRIPT_STYLE: React.CSSProperties = {
+  fontFamily: "var(--font-solitreo), 'Brush Script MT', 'Snell Roundhand', cursive",
+  fontWeight: 400,
+  fontSize: "40px",
+  letterSpacing: "-0.04em",
+  lineHeight: 1.1,
+  color: "#FFFFFF",
+  display: "inline-block",
+};
 
 export default function HeroSection() {
-  const { t, i18n } = useTranslation("creatorEarn");
-  const [scrollProgress, setScrollProgress] = useState(0);
+  const { t } = useTranslation("creatorEarn");
   const sectionRef = useRef<HTMLElement>(null);
   useSectionViewTracking(sectionRef, "earn_hero", { event: "earn_hero_view" });
 
-  const isPromoActive = useIsPromoActive();
-  const searchParams = useSearchParams();
-  const referralCode = searchParams.get("ref");
-  // UTM appending touches sessionStorage, so gate on hydration to avoid
-  // SSR/client href mismatch (same pattern as CTAButton).
-  const [hydrated, setHydrated] = useState(false);
-  useEffect(() => setHydrated(true), []);
-  const promoSignupHref = (() => {
-    const url = new URL("https://beta.creator.sparkonomy.com/auth");
-    url.searchParams.set("service", "earn");
-    url.searchParams.set("lang", i18n.language?.startsWith("hi") ? "hi-Latn" : "en");
-    if (referralCode) url.searchParams.set("ref", referralCode);
-    if (hydrated) {
-      appendUtmTo(url, readUtmParams(new URLSearchParams(searchParams.toString())));
-    }
-    return url.toString();
-  })();
-
-  // rAF-throttled scroll handler — prevents a setState + forced reflow on every
-  // wheel event, which Lighthouse flagged as a major TBT contributor on mobile.
-  useEffect(() => {
-    let ticking = false;
-    const handleScroll = () => {
-      if (ticking) return;
-      ticking = true;
-      requestAnimationFrame(() => {
-        const progress = Math.min(window.scrollY / (window.innerHeight * 0.4), 1);
-        setScrollProgress(progress);
-        ticking = false;
-      });
-    };
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
-
   return (
-    <section ref={sectionRef} className="relative pt-8 md:pt-16 pb-12 md:pb-20 px-5 md:px-20 overflow-hidden">
-      <motion.div
-        initial={{ opacity: 0, y: 30 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.8, delay: 0.2 }}
-        className="max-w-[1440px] mx-auto"
-      >
-        {/* Heading */}
-        <h1 className="text-[32px] md:text-[52px] font-bold text-white text-center leading-tight mb-8 md:mb-12 max-w-[350px] md:max-w-[620px] mx-auto whitespace-pre-line">
-          {t("hero.title")}
+    <section
+      ref={sectionRef}
+      className="relative pt-6 md:pt-0 pb-8 md:pb-12 px-5 md:px-20 overflow-hidden"
+    >
+      <div className="max-w-[760px] mx-auto">
+        {/* Headline — plain text leading line + yellow-highlighted script tail.
+            i18nKey "hero.title" uses <0/> for the mobile line break and
+            <1>...</1> to mark the portion that should get the highlight. */}
+        <h1 className="text-[25px] font-bold text-white text-center leading-[1.8] tracking-[-0.04em] mb-1.5 max-w-[640px] mx-auto">
+          <Trans
+            i18nKey="hero.title"
+            t={t}
+            components={[
+              <br key="brk" />,
+              <span key="hl" style={TITLE_SCRIPT_STYLE} />,
+            ]}
+          />
         </h1>
 
-        {/* Glassmorphic Section */}
-        <motion.div
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.8, delay: 0.4 }}
-          className="relative w-[340px] md:w-[784px] h-[273px] md:h-[630px] mx-auto"
-        >
-          {/* Glass Layer */}
-          <div className="absolute -bottom-[10px] left-1/2 -translate-x-1/2 w-[356px] md:w-[800px] h-[227px] md:h-[520px]">
-            <div className="rounded-[32px] p-[10px] bg-gradient-to-br from-white/20 via-white/0 to-black/10 border border-white/20 backdrop-blur-lg shadow-[10px_10px_30px_rgba(0,0,0,0.2),-10px_-10px_30px_rgba(255,255,255,0.1)] h-full">
-              <div
-                className="rounded-[26px] w-full h-full transition-all duration-300"
-                style={{
-                  background: `linear-gradient(to bottom,
-                    rgba(255, 255, 255, 0.15) 0%,
-                    rgba(255, 255, 255, 0.15) ${scrollProgress * 100}%,
-                    rgba(221, 42, 123, 0.3) ${scrollProgress * 100}%,
-                    rgba(151, 71, 255, 0.3) 100%)`,
-                }}
-              />
-            </div>
-          </div>
+        {/* Auto-rotating story preview — cycles through the 4 Instagram-style
+            stories every 2 seconds in a loop. Uses the same StoryContent1-4
+            components as the full-screen onboarding so the chrome (avatar,
+            handle, like/send) matches across both surfaces. */}
+        <HeroStoryCarousel />
 
-          {/* Image with Margin */}
-          <div className="relative w-full h-full z-10 m-3 md:m-6">
-            <Image
-              src="/images/creator/earn/hero-illustration-2.png"
-              alt="Happy woman pointing at phone showing invoice"
-              fill
-              sizes="(max-width: 768px) 340px, 784px"
-              className="object-contain"
-              priority
-              fetchPriority="high"
-            />
-          </div>
-        </motion.div>
-
-        {/* Promo banner — copy comes from i18n (`promo.*`), T&C URL from PROMO_CONFIG. */}
-        {isPromoActive && (
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.5 }}
-            className="relative mt-[30px] md:mt-10 mx-auto w-full max-w-[420px] md:max-w-[560px]"
-          >
-            <div
-              className="relative overflow-hidden rounded-[24px] px-5 py-5 md:px-7 md:py-6 border border-white/20 backdrop-blur-lg"
-              style={{
-                background:
-                  "linear-gradient(90deg, rgba(61, 88, 219, 0.12) 2.15%, rgba(129, 52, 175, 0.6) 48.84%, rgba(61, 88, 219, 0.12) 96.24%)",
-              }}
-            >
-              <span
-                aria-hidden
-                className="pointer-events-none absolute -inset-y-8 w-[60%] mix-blend-screen animate-shimmer-sweep"
-                style={{
-                  background:
-                    "linear-gradient(115deg, transparent 0%, rgba(255,255,255,0.06) 35%, rgba(255,255,255,0.22) 50%, rgba(255,255,255,0.06) 65%, transparent 100%)",
-                  filter: "blur(24px)",
-                }}
-              />
-
-              <h2 className="relative text-white font-bold text-[32px] leading-tight text-center">
-                {t("promo.heading")}
-              </h2>
-
-              <div className="relative mt-2 flex items-center gap-4">
-                <Image
-                  src="/promo/icon.png"
-                  alt=""
-                  width={72}
-                  height={72}
-                  className="shrink-0 w-[72px] h-[72px] object-contain opacity-90"
-                />
-                <div className="flex-1 min-w-0">
-                  <p className="text-white text-[16px] font-normal leading-snug">
-                    {t("promo.subheading")}
-                  </p>
-                  <p className="mt-2 text-white text-[12px] font-normal leading-snug">
-                    {t("promo.tagline")}
-                  </p>
-                  {PROMO_CONFIG.terms.url ? (
-                    <a
-                      href={PROMO_CONFIG.terms.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="mt-1 inline-block text-white/90 text-[10px] font-normal underline hover:text-white"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {t("promo.terms")}
-                    </a>
-                  ) : (
-                    <span className="mt-1 inline-block text-white/90 text-[10px] font-normal underline">
-                      {t("promo.terms")}
-                    </span>
-                  )}
-                </div>
-              </div>
-
-              <Link
-                href={promoSignupHref}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() =>
-                  track("earn_cta_click", {
-                    cta: "beta_signup",
-                    label: t("promo.cta"),
-                    referral_code: referralCode ?? null,
-                  })
-                }
-                className="relative overflow-hidden mt-5 flex items-center justify-center w-full rounded-full bg-white px-6 py-3 text-[#9747FF] font-bold text-[16px] shadow-[0_8px_20px_rgba(0,0,0,0.18)] hover:bg-white/95 transition-colors"
-              >
-                <span
-                  aria-hidden
-                  className="pointer-events-none absolute inset-y-0 w-[60%] animate-shimmer-sweep"
-                  style={{
-                    background:
-                      "linear-gradient(115deg, transparent 0%, rgba(151, 71, 255, 0.18) 35%, rgba(129, 52, 175, 0.45) 50%, rgba(151, 71, 255, 0.18) 65%, transparent 100%)",
-                    filter: "blur(8px)",
-                    // Same keyframe as the card shimmer, but lagged so the beam
-                    // appears to travel from the top of the card down onto the
-                    // button — mimicking one continuous diagonal sweep.
-                    animationDelay: "0.2s",
-                  }}
-                />
-                <span className="relative">{t("promo.cta")}</span>
-              </Link>
-            </div>
-          </motion.div>
-        )}
-
-        {/* Default CTA — hidden while a promo banner is showing. */}
-        {!isPromoActive && (
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.6 }}
-            className="flex justify-center mt-8 md:mt-12"
-          >
-            <Suspense fallback={<div className="h-12" />}>
-              <CTAButton buttonText={t("nav.getEarlyAccess")} />
-            </Suspense>
-          </motion.div>
-        )}
-
-        {/* Partner Logos */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.8 }}
-          className="flex items-center justify-center mt-12"
-        >
-          <Image
-            src="/logos/Meta_White.png"
-            alt="Meta"
-            height={40}
-            width={120}
-            className="h-[40px] w-auto object-contain pr-4 border-r border-white"
-          />
-          <Image
-            src="/logos/Yt_White.png"
-            alt="YouTube"
-            height={40}
-            width={120}
-            className="h-[40px] w-auto object-contain pl-4"
-          />
-        </motion.div>
-      </motion.div>
+        {/* Signup card — earn variant draws gold coin + Win Now button + 3
+            checks from the creatorEarn namespace. Static paint (no fade-in
+            wrapper) so the card qualifies as the LCP element.
+            Negative side-margins on mobile (-13px) cancel the section's
+            px-5 (20px) so the card sits 7px from the screen edges; desktop
+            keeps the original max-w-[420px] mx-auto centering. */}
+        <div className="-mx-[13px] md:mx-0">
+          <PromoSignupCard variant="earn" namespace="creatorEarn" />
+        </div>
+      </div>
     </section>
   );
 }

--- a/components/creator/earn/TestimonialCard.tsx
+++ b/components/creator/earn/TestimonialCard.tsx
@@ -2,7 +2,6 @@
 
 import {motion} from "framer-motion";
 import Image from "next/image";
-import {Check} from "lucide-react";
 
 interface TestimonialCardProps {
   quote: string;
@@ -39,34 +38,29 @@ export default function TestimonialCard({
     <motion.div
       {...motionProps}
       className={`
-        px-3 py-6 rounded-[32px] bg-gradient-to-br from-white/10 via-white/0 to-black/10 border border-white/20 backdrop-blur-[2px]
+        p-3 rounded-[24px] bg-gradient-to-br from-white/10 via-white/0 to-black/10 border border-[#FFFFFF33] backdrop-blur-[2px]
         ${highlighted ? "bg-white/10" : "bg-transparent"}
-        min-w-[315px] md:max-w-[364px]
+        min-w-[315px] md:max-w-[364px] flex flex-col gap-4
       `}
     >
       {/* Quote */}
-      <p className="text-white text-[15px] leading-normal text-center mb-3 h-[124px] flex items-center justify-center italic">
+      <p className="text-white text-base leading-[1.2] text-center italic min-h-[77px] flex items-center justify-center">
         &ldquo;{quote}&rdquo;
       </p>
 
       {/* User Info */}
-      <div className="flex items-center gap-3 px-0 pt-3">
+      <div className="flex items-center justify-center gap-3">
         {/* Avatar */}
-        <div className="relative w-10 h-10 rounded-full overflow-hidden flex-shrink-0">
+        <div className="relative w-12 h-12 rounded-full overflow-hidden flex-shrink-0">
           <Image src={avatarUrl} alt={name} fill className="object-cover" />
         </div>
 
         {/* Name and Handle */}
-        <div className="flex flex-col flex-1">
-          <div className="flex items-center gap-1">
-            <span className="text-white font-medium text-[14px] leading-normal">
-              {name}
-            </span>
-            <div className="w-4 h-4 rounded-full bg-blue-500 flex items-center justify-center">
-              <Check className="w-3 h-3 text-white" strokeWidth={3} />
-            </div>
-          </div>
-          <span className="text-white leading-5 text-[12px]">{handle}</span>
+        <div className="flex flex-col">
+          <span className="text-white font-medium text-base leading-normal">
+            {name}
+          </span>
+          <span className="text-white font-normal leading-5 text-sm">{handle}</span>
         </div>
       </div>
     </motion.div>

--- a/components/creator/earn/ValueProposition.tsx
+++ b/components/creator/earn/ValueProposition.tsx
@@ -1,58 +1,44 @@
 "use client";
 
-import {Suspense, useState, useEffect, useRef} from "react";
-import {motion} from "framer-motion";
+import { useRef } from "react";
+import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
-import CTAButton from "./CTAButton";
-import {useSectionViewTracking} from "@/lib/hooks/useSectionViewTracking";
+import { useSectionViewTracking } from "@/lib/hooks/useSectionViewTracking";
 
 export default function ValueProposition() {
-  const { t, ready } = useTranslation("creatorEarn");
-  const [mounted, setMounted] = useState(false);
+  const { t } = useTranslation("creatorEarn");
   const sectionRef = useRef<HTMLElement>(null);
-  useSectionViewTracking(sectionRef, "value_proposition");
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  if (!mounted || !ready) {
-    return null;
-  }
+  useSectionViewTracking(sectionRef, "earn_pitch");
 
   return (
-    <section ref={sectionRef} className="relative pt-0 pb-12 md:pt-0 md:pb-20 px-5 md:px-20">
+    <section
+      ref={sectionRef}
+      className="relative pt-2 pb-10 md:pt-4 md:pb-16 px-5 md:px-20"
+    >
       <motion.div
-        initial={{ opacity: 0, y: 30 }}
+        initial={{ opacity: 0, y: 24 }}
         whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true, margin: "-100px" }}
-        transition={{ duration: 0.8 }}
-        className="max-w-[1440px] mx-auto text-center"
+        viewport={{ once: true, margin: "-80px" }}
+        transition={{ duration: 0.6 }}
+        className="max-w-[760px] mx-auto text-center space-y-3"
       >
-        <div className="max-w-[321px] md:max-w-[931px] mx-auto space-y-6 md:space-y-8">
-          {/* Main Heading */}
-          <h2 className="text-[40px] md:text-[52px] font-bold text-white leading-tight">
-            <span className="block">{t("valueProposition.heading1")}</span>
-            <span className="block">{t("valueProposition.heading2")}</span>
-          </h2>
-
-          {/* Description */}
-          <p className="text-base md:text-base text-white leading-normal max-w-[321px] md:max-w-full mx-auto">
-            {t("valueProposition.description")}
-          </p>
-
-          {/* CTA Button */}
-          <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
-            whileInView={{ opacity: 1, scale: 1 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.6, delay: 0.2 }}
-          >
-              <Suspense fallback={null}>
-                <CTAButton buttonText={t("valueProposition.cta")}/>
-              </Suspense>
-          </motion.div>
-        </div>
+        <h2 className="text-[32px] md:text-[44px] font-bold text-white leading-tight">
+          {(() => {
+            const [before, after] = t("pitch.heading").split(" — ");
+            return after === undefined ? (
+              before
+            ) : (
+              <>
+                {before} —
+                <br />
+                {after}
+              </>
+            );
+          })()}
+        </h2>
+        <p className="text-base md:text-lg text-white/90 leading-relaxed max-w-[640px] mx-auto">
+          {t("pitch.description")}
+        </p>
       </motion.div>
     </section>
   );

--- a/components/creator/earn/stories/FloatingHearts.tsx
+++ b/components/creator/earn/stories/FloatingHearts.tsx
@@ -38,15 +38,17 @@ export default function FloatingHearts({ triggerCount }: FloatingHeartsProps) {
   }, [triggerCount]);
 
   return (
-    <div className="absolute bottom-[54px] right-[86px] pointer-events-none z-50">
-      {hearts.map((heart) => (
-        <FloatingHeart
-          key={heart.id}
-          id={heart.id}
-          delay={heart.delay}
-          onComplete={handleHeartComplete}
-        />
-      ))}
+    <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-full max-w-[390px] pointer-events-none z-50">
+      <div className="absolute bottom-[40px] right-[85px]">
+        {hearts.map((heart) => (
+          <FloatingHeart
+            key={heart.id}
+            id={heart.id}
+            delay={heart.delay}
+            onComplete={handleHeartComplete}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/creator/earn/stories/StoryContent1.tsx
+++ b/components/creator/earn/stories/StoryContent1.tsx
@@ -13,7 +13,7 @@ export default function StoryContent1({ imageSrc = "/images/creator/earn/story-1
   return (
     <div className="relative w-full h-full">
       {/* Header */}
-      <div className="absolute top-[41px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
+      <div className="absolute top-[16px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
         <div className="flex items-center gap-2">
           {/*<div className="w-9 h-9 rounded-full bg-white overflow-hidden flex items-center justify-center">*/}
           {/*  <span className="text-lg">🐶</span>*/}
@@ -33,7 +33,7 @@ export default function StoryContent1({ imageSrc = "/images/creator/earn/story-1
       </div>
 
       {/* Main Image */}
-      <div className="absolute top-[15%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-3xl overflow-hidden ">
+      <div className="absolute top-[12%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-xl overflow-hidden ">
         <Image
           src={imageSrc}
           alt={"Story"}
@@ -64,7 +64,7 @@ export default function StoryContent1({ imageSrc = "/images/creator/earn/story-1
 
       {/* Bottom Navigation */}
       <div className="absolute bottom-4 left-1/2 -translate-x-1/2 w-full max-w-[390px] px-2 flex items-center gap-4">
-          <div className="flex-1 border border-white/50 rounded-full px-5 py-1 flex items-center justify-start">
+          <div className="flex-1 min-w-0 overflow-hidden border border-white/50 rounded-full px-5 py-1 flex items-center justify-start">
             <AnimatedEmojis
               emojis={["🙋🏼‍♂️", "🙋🏼‍♀️", "🙋🏻‍♂️", "🙋🏻‍♀️", "🙋🏾‍♀️", "🙋🏽", "🙋🏽‍♀️", "🙋‍♂️"]}
               className="text-xl"

--- a/components/creator/earn/stories/StoryContent2.tsx
+++ b/components/creator/earn/stories/StoryContent2.tsx
@@ -14,7 +14,7 @@ export default function StoryContent2({ imageSrc = "/images/creator/earn/story-4
     return (
         <div className="relative w-full h-full ">
             {/* Header */}
-            <div className="absolute top-[41px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
+            <div className="absolute top-[16px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
                 <div className="flex items-center gap-2">
                     {/*<div className="w-9 h-9 rounded-full bg-white overflow-hidden flex items-center justify-center">*/}
                     {/*  <span className="text-lg">🐶</span>*/}
@@ -34,7 +34,7 @@ export default function StoryContent2({ imageSrc = "/images/creator/earn/story-4
             </div>
 
             {/* Main Image */}
-            <div className="absolute top-[15%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-3xl overflow-hidden ">
+            <div className="absolute top-[12%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-xl overflow-hidden ">
                 <Image
                     src={imageSrc}
                     alt={"Story"}
@@ -64,7 +64,7 @@ export default function StoryContent2({ imageSrc = "/images/creator/earn/story-4
 
             {/* Bottom Navigation */}
             <div className="absolute bottom-4 left-1/2 -translate-x-1/2 w-full max-w-[390px] px-2 flex items-center gap-4">
-                <div className="flex-1 border border-white/50 rounded-full px-5 py-1 flex items-center justify-start">
+                <div className="flex-1 min-w-0 overflow-hidden border border-white/50 rounded-full px-5 py-1 flex items-center justify-start">
                     <AnimatedEmojis
                         emojis={["💔", "💔", "💔", "💔", "💔", "💔", "💔", "💔"]}
                         className="text-xl"

--- a/components/creator/earn/stories/StoryContent3.tsx
+++ b/components/creator/earn/stories/StoryContent3.tsx
@@ -12,9 +12,9 @@ interface StoryContent3Props {
 export default function StoryContent3({ imageSrc = "/images/creator/earn/story-3.png", priority = false }: StoryContent3Props) {
 
     return (
-        <div className="relative w-full h-full bg-[#212529]">
+        <div className="relative w-full h-full">
             {/* Header */}
-            <div className="absolute top-[41px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
+            <div className="absolute top-[16px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
                 <div className="flex items-center gap-2">
                     {/*<div className="w-9 h-9 rounded-full bg-white overflow-hidden flex items-center justify-center">*/}
                     {/*  <span className="text-lg">🐶</span>*/}
@@ -34,7 +34,7 @@ export default function StoryContent3({ imageSrc = "/images/creator/earn/story-3
             </div>
 
             {/* Main Image */}
-            <div className="absolute top-[15%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-3xl overflow-hidden">
+            <div className="absolute top-[12%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-xl overflow-hidden">
                 <Image
                     src={imageSrc}
                     alt={"Story"}
@@ -63,7 +63,7 @@ export default function StoryContent3({ imageSrc = "/images/creator/earn/story-3
 
             {/* Bottom Navigation */}
             <div className="absolute bottom-4 left-1/2 -translate-x-1/2 w-full max-w-[390px] px-2 flex items-center gap-4">
-                <div className="flex-1 border border-white/50 rounded-full px-5 py-1 flex items-center justify-start">
+                <div className="flex-1 min-w-0 overflow-hidden border border-white/50 rounded-full px-5 py-1 flex items-center justify-start">
                     <AnimatedEmojis
                         emojis={["😤", "🤯", "😤", "🤯", "😤", "🤯", "😤", "🤯", "😤", "😫"]}
                         className="text-xl"

--- a/components/creator/earn/stories/StoryContent4.tsx
+++ b/components/creator/earn/stories/StoryContent4.tsx
@@ -30,7 +30,7 @@ export default function StoryContent4({ imageSrc = "/images/creator/earn/story-2
   return (
     <div className="relative w-full h-full">
       {/* Header */}
-      <div className="absolute top-[41px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
+      <div className="absolute top-[16px] left-1/2 -translate-x-1/2 w-full max-w-[390px] px-3 flex items-center justify-between z-40">
         <div className="flex items-center gap-2">
           <Image src={"/images/creator/earn/story-avatar.png"} alt={"Avatar"} width={36} height={36}/>
           <div className="flex flex-col">
@@ -47,7 +47,7 @@ export default function StoryContent4({ imageSrc = "/images/creator/earn/story-2
       </div>
 
       {/* Main Image */}
-      <div className="absolute top-[15%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-3xl overflow-hidden ">
+      <div className="absolute top-[12%] left-1/2 -translate-x-1/2 w-[90vw] sm:w-[362px] max-w-[362px] max-h-[calc(100%-150px)] aspect-[362/595] rounded-xl overflow-hidden ">
         <Image
           src={imageSrc}
           alt={"Story"}
@@ -94,7 +94,7 @@ export default function StoryContent4({ imageSrc = "/images/creator/earn/story-2
 
       {/* Bottom Navigation */}
       <div className="absolute bottom-4 left-1/2 -translate-x-1/2 w-full max-w-[390px] px-2 flex items-center gap-4 z-40">
-        <div className="flex-1 border border-white/50 rounded-full px-5 py-1.5 flex items-center justify-start">
+        <div className="flex-1 min-w-0 overflow-hidden border border-white/50 rounded-full px-5 py-1.5 flex items-center justify-start">
           <AnimatedEmojis
             emojis={["❤️", "❤️", "❤️", "❤️", "❤️", "❤️", "❤️", "❤️", "❤️", "❤️"]}
             className="text-base"

--- a/components/creator/earn/stories/StoryPanel.tsx
+++ b/components/creator/earn/stories/StoryPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {motion} from "framer-motion";
+import {AnimatePresence, motion} from "framer-motion";
 import {StoryPanelProps} from "./types";
 // import StoryProgressBar from "./StoryProgressBar";
 import {useEffect, useRef} from "react";
@@ -71,10 +71,21 @@ export default function StoryPanel({
       exit={{ opacity: 0 }}
       transition={{ duration: 0.3 }}
     >
-      {children}
+      <AnimatePresence mode="sync">
+        <motion.div
+          key={currentIndex}
+          className="absolute inset-0"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.3 }}
+        >
+          {children}
+        </motion.div>
+      </AnimatePresence>
       {/* Close button overlay - positioned to match the X icon in story content */}
       <button
-        className="absolute top-[41px] right-3 z-50 text-white text-3xl p-2"
+        className="absolute top-[16px] right-3 z-50 text-white text-3xl p-2"
         onClick={handleCloseClick}
         onMouseDown={(e) => e.stopPropagation()}
         onTouchStart={(e) => e.stopPropagation()}

--- a/data/authors.ts
+++ b/data/authors.ts
@@ -58,8 +58,6 @@ export interface AuthorEntry {
   // SEO metadata
   metaTitle?: string;
   metaDescription?: string;
-  canonicalPath?: string;
-
   // WordPress matching - use ONE of these to match WordPress author to our data
   wordpressSlug?: string; // WordPress author slug (e.g., "dev-sparkonomy") - PREFERRED
   wordpressAuthorId?: number; // WordPress author ID (e.g., 1) - Alternative
@@ -120,8 +118,6 @@ export const authors: AuthorEntry[] = [
     // SEO metadata
     metaTitle: "Guneet Singh: Product, Tech Leader and Mentor at Sparkonomy",
     metaDescription: "Guneet Singh worked at Google and Microsoft. Now, he helps creators use technology to build real businesses. Read his guides on growth and AI.",
-    canonicalPath: "/authors/guneet-singh",
-
     // WordPress matching
     wordpressSlug: "cap-guneet",
     wordpressAuthorId: 5,
@@ -353,8 +349,6 @@ export const authors: AuthorEntry[] = [
     // SEO metadata
     metaTitle: "Binny Agarwal: CA and Business Guide at Sparkonomy",
     metaDescription: "Binny Agarwal is a Chartered Accountant and writer. She helps creators use AI and smart tools to build real businesses.",
-    canonicalPath: "/authors/binny-agarwal",
-
     // WordPress matching (Co-Authors Plus uses "cap-" prefix)
     wordpressSlug: "cap-binny",
     wordpressAuthorId: 7,
@@ -453,8 +447,6 @@ export const authors: AuthorEntry[] = [
     // SEO metadata
     metaTitle: "Saurabh Mongia, CA | VP Finance & Creator Payment Expert at Sparkonomy",
     metaDescription: "Saurabh Mongia bridges institutional finance and creator payouts. CA, VP at Morgan Stanley. Read invoicing & payment workflow guides.",
-    canonicalPath: "/authors/saurabh-mongia",
-
     // WordPress matching (Co-Authors Plus uses "cap-" prefix)
     wordpressSlug: "cap-saurabh",
     wordpressAuthorId: 8,
@@ -548,8 +540,6 @@ export const authors: AuthorEntry[] = [
     metaTitle: "Megha Thareja Tyagi: AI Strategy and Creator Economy Leader at Sparkonomy",
     metaDescription:
       "Meet Megha Thareja Tyagi, Co-Founder at Sparkonomy. Expert in AI strategy, creator economy infrastructure, growth, and commercialization. Explore her background across Google, PayPal, and American Express, and read her Sparkonomy insights.",
-    canonicalPath: "/authors/megha-thareja-tyagi",
-
     // WordPress matching (Co-Authors Plus uses "cap-" prefix)
     wordpressSlug: "cap-megha",
 
@@ -665,8 +655,6 @@ export const authors: AuthorEntry[] = [
     metaTitle: "Rachit Jain: Growth, partnerships, and GTM leader at Sparkonomy",
     metaDescription:
       "Meet Rachit Jain, growth and partnerships leader at Sparkonomy. He brings 20+ years across Meta, Google, SAP, and IBM to write about growth, GTM, and creator businesses.",
-    canonicalPath: "/authors/rachit-jain",
-
     // WordPress matching (Co-Authors Plus uses "cap-" prefix)
     wordpressSlug: "cap-rachit",
 
@@ -776,8 +764,6 @@ export const authors: AuthorEntry[] = [
     metaTitle: "Vipasha Joshi: Co-Founder & Creator Economy Veteran at Sparkonomy",
     metaDescription:
       "Meet Vipasha Joshi, Co-Founder at Sparkonomy. Former Googler and Jellysmack India lead with 16+ years building creator and brand businesses. LinkedIn Top Voice.",
-    canonicalPath: "/authors/vipasha-joshi",
-
     // WordPress matching (Co-Authors Plus uses "cap-" prefix)
     wordpressSlug: "cap-vipasha",
 
@@ -899,8 +885,6 @@ export const authors: AuthorEntry[] = [
     metaTitle: "The Sparkonomy Founding Team",
     metaDescription:
       "Meet the Sparkonomy founding team — Guneet Singh, Megha Thareja Tyagi, Vipasha Joshi, and Rachit Jain — building AI infrastructure for the creator economy.",
-    canonicalPath: "/authors/founding-team",
-
     // No WordPress slug — this is a synthetic author used to collapse multi-author posts
     // where all four co-founders appear together.
 

--- a/lib/urls.ts
+++ b/lib/urls.ts
@@ -1,0 +1,20 @@
+// Single source of truth for site URLs.
+//
+// The host and each route's path live here ONCE so that canonicals, JSON-LD,
+// the sitemap, and internal links all derive from the same place and cannot
+// drift apart. (A hand-typed per-author `canonicalPath` once pointed authors at
+// a non-existent `/authors/<slug>` URL — deriving from `slug` makes that class
+// of bug unrepresentable.)
+//
+// SITE_URL is for navigable URLs (canonical, OG, sitemap). Schema `@id` values
+// are intentionally kept as stable production literals elsewhere.
+
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.sparkonomy.com"
+).replace(/\/+$/, "");
+
+/** Relative path to an author page — use for canonicals (resolved by metadataBase). */
+export const authorPath = (slug: string): string => `/blogs/author/${slug}`;
+
+/** Absolute URL to an author page — use where an absolute URL is required (JSON-LD, sitemap). */
+export const authorUrl = (slug: string): string => `${SITE_URL}${authorPath(slug)}`;

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -18,6 +18,17 @@ api: No public API currently available
 - [Blog: Brands](https://www.sparkonomy.com/blogs/brand) — Insights and updates for brands working with creators and influencers.
 - [Blog: Company](https://www.sparkonomy.com/blogs/company) — Company news and updates from Sparkonomy.
 
+## Authors / Experts
+The Sparkonomy blog is written by named domain experts. Each has a profile (ProfilePage + Person structured data) at the URL below.
+- [Guneet Singh](https://www.sparkonomy.com/blogs/author/guneet-singh) — Founder; global tech leader, startup mentor & venture builder with 20+ years across Google, Microsoft and Samsung. Writes on the creator economy, AI productivity, platform ecosystems and business growth.
+- [Megha Thareja Tyagi](https://www.sparkonomy.com/blogs/author/megha-thareja-tyagi) — Co-Founder; AI strategy and creator-economy infrastructure leader, ex-Google, PayPal and American Express. Writes on go-to-market strategy, commercialization and payments.
+- [Vipasha Joshi](https://www.sparkonomy.com/blogs/author/vipasha-joshi) — Co-Founder & Global Head of Creator Business; creator-economy veteran and LinkedIn Top Voice, ex-Google and Jellysmack. Writes on creator business, AI content strategy and community.
+- [Rachit Jain](https://www.sparkonomy.com/blogs/author/rachit-jain) — Growth, partnerships and GTM leader with 20+ years across Meta, Google, SAP and IBM. Writes on growth strategy, monetization and partnerships.
+- [Binny Agarwal](https://www.sparkonomy.com/blogs/author/binny-agarwal) — Chartered Accountant (CA) and content strategist. Writes simple guides on creator money, pricing, getting paid and AI workflows.
+- [Saurabh Mongia](https://www.sparkonomy.com/blogs/author/saurabh-mongia) — Chartered Accountant and VP (Legal Entity Control) at Morgan Stanley. Writes on creator invoicing, payment workflows and cross-border taxation.
+- [Dev Sparkonomy](https://www.sparkonomy.com/blogs/author/dev-sparkonomy) — The Sparkonomy content team; guides on creator payments, monetization, taxation and growth.
+- [The Sparkonomy Founding Team](https://www.sparkonomy.com/blogs/author/founding-team) — Collective byline for deep dives co-written by all four co-founders.
+
 ## Product / Offering
 - **What it does:** Sparkonomy provides an AI Agent Team built specifically for creators, influencers, YouTubers, Instagrammers and social media influencers. These agents act as a "business team" that handles Content strategy, Commerce (brand deals), and Company Operations (legal and finance). These agents are powered by Sparkonomy’s proprietary Creator Genome, which uses AI to understand a creator’s unique persona & style.
 - **Creator Earn:** AI-powered invoicing tool for creators and influencers — handles GST-compliant invoicing, payment tracking, and professional billing so influencers, YouTubers and Instagrammers can get paid faster without messy spreadsheets.

--- a/public/locales/en/creatorEarn.json
+++ b/public/locales/en/creatorEarn.json
@@ -3,215 +3,159 @@
     "getEarlyAccess": "Get Early Access"
   },
   "hero": {
-    "title": "India's 1st, invoicing AI exclusively for Creators. Now in Private Beta.⚡️"
+    "title": "Earn more. Stress less.<0/><1>Get paid faster!</1>",
+    "features": [
+      "<0>Easy</0> invoices with AI: Voice, chat, or photo",
+      "<0>Error-free</0>: Instant-tax calculations",
+      "<0>Faster</0> payments: Auto-reminders on email & Whatsapp"
+    ],
+    "card": {
+      "livePromo": "LIVE PROMO",
+      "voucherHeading": "Send free invoice — <0>Win Gold Coin</0>",
+      "voucherBody": "4 invoices/mo free forever. The first 5 signups each day win a Gold Coin.",
+      "voucherTerms": "T&Cs apply",
+      "ctaLabel": "Get started — completely free!",
+      "checks": ["4 invoices/mo free forever", "No card needed", "30-sec signup"],
+      "phonePlaceholder": "XXXX XXXXXX",
+      "sendOtp": "Win Now",
+      "edit": "Edit",
+      "changeNumber": "Change Number",
+      "otpSentTo": "OTP sent to <0>{{phone}}</0>",
+      "verify": "Verify",
+      "verifying": "Verifying",
+      "verified": "Verified",
+      "disclaimer": "By tapping, you agree to create an account and Sparkonomy's <0>Terms</0> and <1>Privacy Policy</1>."
+    }
   },
-  "promo": {
-    "heading": "Apni Boli, Apna Bill",
-    "subheading": "Ab Hinglish mein banayein, perfect English invoices.",
-    "tagline": "Sign up. Win Amazon vouchers daily!",
-    "terms": "T&Cs apply",
-    "cta": "Sign up & Win!"
+  "pitch": {
+    "heading": "The world's first AI — built just for creators.",
+    "description": "Late payments, endless follow-ups and tax headaches — it all ends here! The first AI built for creators, starting with smart payments. You create the content, we'll handle the follow-ups."
   },
-  "valueProposition": {
-    "heading1": "Earn More. Stress Less.",
-    "heading2": "Get Paid Faster!",
-    "description": "Late payments, endless reminders, messy tax calculations —gone! Meet the first AI built for creators, starting with smart payments that help you earn more, faster. We handle the headache, you spark the content.",
-    "cta": "Send Invoices For Free"
-  },
-  "benefits": {
-    "title": "Benefits",
-    "cta": "Don't Wait Try For Free",
+  "threeStep": {
+    "title": "3 simple steps. That's it.",
+    "subtitle": "So easy you'll get it on the first try.",
     "items": [
       {
-        "title": "Send a Chat. Get an Invoice.",
-        "description": "Upload a WhatsApp message, email, or PO — or just type \"Make me an invoice for…\" and our AI does the rest. Perfect pro formatting, GST/PAN handled, no typos, no approval tension.",
-        "highlight": "You create content, we create cash flow."
+        "title": "Speak, type, or screenshot",
+        "description": "Upload a WhatsApp message, email, or brand chat screenshot — or just say/type \"make an invoice.\"",
+        "tags": ["Voice", "Type", "Screenshot", "Duplicate"]
       },
       {
-        "title": "You Create. We Chase.",
-        "description": "No more painful \"Hey, just checking on the payment?\" reminder follow-ups. Our AI sends polite, friendly payment reminders so you don't have to.",
-        "highlight": "You build relationships, we get payments."
+        "title": "AI builds your invoice",
+        "description": "AI builds your invoice in the proper format, typo-free. GST/PAN added automatically. You can review and edit.",
+        "tags": ["Auto-format", "GST/ PAN", "Typo-free"]
       },
       {
-        "title": "Go Pro. With your Pocket CFO.",
-        "description": "Get weekly, 5-minute updates of your cash flow, overdue payments, and income growth. We keep your records organised and help your business stay tax compliant.",
-        "highlight": "You go Pro, we get you there."
-      }
-    ]
-  },
-  "advantage": {
-    "title": "Your Advantage",
-    "subtitle": "Invoices that get you paid faster, and make you look good!",
-    "cta": "Get Paid Faster",
-    "items": [
-      {
-        "title": "Payment Ready",
-        "description": "GST auto‑calculated, payment integrated."
-      },
-      {
-        "title": "Tax‑Compliant",
-        "description": "GST Barters and other taxes managed."
-      },
-      {
-        "title": "WhatsApp Alerts",
-        "description": "Your money tracked!"
-      },
-      {
-        "title": "Proof Of Work",
-        "description": "Auto-fetched, no more screenshots."
+        "title": "We handle the follow-ups",
+        "description": "No more sending \"Hi, payment?\". Sparkonomy's AI sends polite, professional reminders on WhatsApp / email.",
+        "tags": ["WhatsApp + Email", "Auto-reminders"]
       }
     ]
   },
   "testimonials": {
-    "title": "What People Say",
+    "title": "What creators are saying",
+    "subtitle": "Faster payments, and you look like a Pro.",
     "items": [
       {
-        "quote": "And I have to reach out so many times to get paid in 3 months, and still it hasn't happened 15-20 times! I want you to do my payment reminders",
-        "name": "Food YouTuber",
-        "handle": "700K Followers"
+        "quote": "It's been 3 months and I've followed up 15-20 times for payment — still nothing! Please handle reminders for me, I'm done.",
+        "name": "Lifestyle Instagrammer",
+        "handle": "1M Followers"
       },
       {
-        "quote": "I raise invoices once a month mostly. I don't get time… and it delays my payments. I want you help me raise instant invoices in under 5 mins from my phone",
+        "quote": "I usually raise invoices once a month — I just don't get the time, and payments get delayed. Please help me send invoices in 5 minutes from my phone.",
         "name": "Tech Instagrammer",
         "handle": "1M Followers"
       },
       {
-        "quote": "I don't have time to write down and track all payments in Excel and become my own accountant! I want you to track & remind me of my money matters",
-        "name": "Lifestyle Instagrammer",
-        "handle": "320K Followers"
+        "quote": "Who has time to track payments in Excel? I don't want to be my own accountant! You track them, you remind — please.",
+        "name": "Food YouTuber",
+        "handle": "700K Followers"
       }
     ]
   },
-  "cta": {
-    "title": "Ready to get paid faster?",
-    "button": "Make your first Invoice Now"
+  "advantage": {
+    "title": "What else do you get?",
+    "items": [
+      {
+        "title": "Proof of Work, automatic.",
+        "description": "Insta and YouTube screenshots auto-attach. You don't have to do a thing."
+      },
+      {
+        "title": "Forever free, 4 invoices.",
+        "description": "4 free invoices every month — no card, no hidden charges."
+      },
+      {
+        "title": "Tax calculations, AI does it.",
+        "description": "GST or no GST, AI calculates everything. TDS, barter, multi-rate — all handled."
+      },
+      {
+        "title": "CA-ready, year-end report.",
+        "description": "Export all data in one click. Send it to your CA, file ITR — no more Excel mess."
+      }
+    ]
   },
   "faq": {
     "title": "Frequently Asked Questions",
     "viewAll": "View All",
-    "categories": [
-      { "key": "all", "label": "All" },
-      { "key": "getting-started", "label": "Getting Started" },
-      { "key": "invoice", "label": "Invoice" },
-      { "key": "payment-reminders", "label": "Payment Reminders" },
-      { "key": "pocket-cfo", "label": "Pocket CFO" },
-      { "key": "pricing", "label": "Pricing" },
-      { "key": "taxation", "label": "Taxation" }
-    ],
+    "viewLess": "Show Less",
     "items": [
       {
-        "question": "How do I sign up?",
-        "answer": "Give your phone number - that is it! After that, share your social handles, answer a couple of easy questions on your billing info, and you'll be sending invoices using Sparkonomy's AI quicker than a collab DM reply! "
+        "question": "Q1: How do I sign up?",
+        "answer": "Give your phone number — that's it! After that, share your social handles, answer a couple of easy questions on your billing info, and you'll be sending invoices using Sparkonomy's AI quicker than a collab DM reply!"
       },
       {
-        "question": "How is this AI for creators and its smart payment useful for me?",
-        "answer": "Sparkonomy's AI was designed exclusively to help creators manage their businesses like a pro. The smart payments feature helps you send invoices fast and easy. Just share your chat or brand collab details, and we'll make a GST-ready invoice with no math, no stress, no chasing brands. Our Pocket CFO AI tracks your payments and cash flow, sending 5-minute weekly updates to keep you informed. And the best of all, Sparkonomy automatically tracks & sends friendly reminders for your payments on WhatsApp/email. You are always in control of who gets what, with quick 1-tap actions like - STOP, DELAY, or PAYMENT DONE. Earn More. Stress Less.",
-        "category": "getting-started"
+        "question": "Q2: How is this AI for creators and its smart payment useful for me?",
+        "answer": "Sparkonomy's AI was designed exclusively to help creators manage their businesses like a pro. The smart payments feature helps you send invoices fast and easy. Just share your chat or brand collab details, and we'll make a GST-ready invoice with no math, no stress, no chasing brands. Our Pocket CFO AI tracks your payments and cash flow, sending 5-minute weekly updates to keep you informed. And the best of all, Sparkonomy automatically tracks & sends friendly reminders for your payments on WhatsApp/email. You are always in control of who gets what, with quick 1-tap actions like - STOP, DELAY, or PAYMENT DONE. Earn More. Stress Less."
       },
       {
-        "question": "What information do I need to add to my profile to start invoicing?",
-        "answer": "Just share your name, address, PAN and payment details (UPI/Bank account). If you have a separate billing organization, add its PAN and registration like CIN or GSTIN. And, we know you are busy, so no typing is needed, just snap or upload a pic of the document. It takes less than 5 minutes and you have to do it only once!",
-        "category": "invoice"
+        "question": "Q3: What information do I need to add to my profile to start invoicing?",
+        "answer": "Just share your name, address, PAN and payment details (UPI/Bank account). If you have a separate billing organization, add its PAN and registration like CIN or GSTIN. And, we know you are busy, so no typing is needed, just snap or upload a pic of the document. It takes less than 5 minutes and you have to do it only once!"
       },
       {
-        "question": "How do I create my first invoice?",
-        "answer": "Sparkonomy's creator AI helps you make an invoice in under 3-minutes with a few taps - and all from your phone! Our smart payments feature helps you get started fast. Duplicate an old invoice, upload a WhatsApp or email screenshot with billing instructions, or just type \"I need an invoice for...\" and watch one get built in for you. It's that easy to spark your invoice. Send a chat - get an invoice. Now, you will never be delayed in sending one!",
-        "category": "invoice"
+        "question": "Q4: How do I create my first invoice?",
+        "answer": "Sparkonomy's creator AI helps you make an invoice in under 3-minutes with a few taps - and all from your phone! Our smart payments feature helps you get started fast. Duplicate an old invoice, upload a WhatsApp or email screenshot with billing instructions, or just type \"I need an invoice for...\" and watch one get built in for you. It's that easy to spark your invoice. Send a chat - get an invoice. Now, you will never be delayed in sending one!"
       },
       {
-        "question": "How will Sparkonomy make payment reminders on my behalf?",
-        "answer": "We know how frustrating it is to keep following up for the money you deserve! When you make your invoice, Sparkonomy asks how many reminders to send and how often. We'll send them to your client on WhatsApp and email. On the day of the reminder we ping you at 10AM and ask if you still want to send it and if you say yes, it goes at 3 PM. We only send four friendly nudges: a check-in, a soft poke, a late fee alert, and a final notice. You stay in control with quick replies like STOP, DELAY, or PAYMENT DONE. We chase, you create.",
-        "category": "payment-reminders"
+        "question": "Q5: How will Sparkonomy make payment reminders on my behalf?",
+        "answer": "We know how frustrating it is to keep following up for the money you deserve! When you make your invoice, Sparkonomy asks how many reminders to send and how often. We'll send them to your client on WhatsApp and email. On the day of the reminder we ping you at 10AM and ask if you still want to send it and if you say yes, it goes at 3 PM. We only send four friendly nudges: a check-in, a soft poke, a late fee alert, and a final notice. You stay in control with quick replies like STOP, DELAY, or PAYMENT DONE. We chase, you create."
       },
       {
-        "question": "What is a pocket CFO and what will it do?",
-        "answer": "We know you don't want to be your creator business accountant, and yet you end up being one! Invoices made in Excel, Canva, or Word are impossible to manage and track. Sparkonomy's Pocket CFO AI agent analyses your payments & cash flows every week. Then it sends you quick weekly 5-minute updates on cash flow, overdue payments, and income growth. It keeps your records tidy and your business tax-ready. You go Pro, we get you there!",
-        "category": "pocket-cfo"
+        "question": "Q6: What is a pocket CFO and what will it do?",
+        "answer": "We know you don't want to be your creator business accountant, and yet you end up being one! Invoices made in Excel, Canva, or Word are impossible to manage and track. Sparkonomy's Pocket CFO AI agent analyses your payments & cash flows every week. Then it sends you quick weekly 5-minute updates on cash flow, overdue payments, and income growth. It keeps your records tidy and your business tax-ready. You go Pro, we get you there!"
       },
       {
-        "question": "How much do I have to pay?",
-        "answer": "You can make up to 4 new invoices every month, send unlimited reminders, and get your own Pocket CFO - perfect for most creators. As your needs grow, you can switch to Pro by referring a few friends or for less than the price of a cup of coffee.",
-        "category": "pricing"
+        "question": "Q7: How much do I have to pay?",
+        "answer": "You can make up to 4 new invoices every month, send unlimited reminders, and get your own Pocket CFO - perfect for most creators. As your needs grow, you can switch to Pro by referring a few friends or for less than the price of a cup of coffee."
       },
       {
-        "question": "How will I calculate taxes on the invoice?",
-        "answer": "You don't want to keep doing back & forth with the brand on tax errors or worse meet the tax-man! If you are GST registered, Sparkonomy's AI takes care of it by picking the right GST code, splitting CGST/SGST/IGST, and making your invoice GST-ready automatically. We do the tax calculations & keep you compliance-ready, you do creation!",
-        "category": "taxation"
+        "question": "Q8: How will I calculate taxes on the invoice?",
+        "answer": "You don't want to keep doing back & forth with the brand on tax errors or worse meet the tax-man! If you are GST registered, Sparkonomy's AI takes care of it by picking the right GST code, splitting CGST/SGST/IGST, and making your invoice GST-ready automatically. We do the tax calculations & keep you compliance-ready, you do creation!"
       },
       {
-        "question": "Does the AI help calculate GST?",
-        "answer": "Yes! Sparkonomy's AI knows the GST system inside out. It automatically picks the right service codes and best of all - our invoice template follows the GST requirements to the tee! Let Sparkonomy do the hard work while you sparkle!",
-        "category": "taxation"
+        "question": "Q9: Does the AI help calculate GST?",
+        "answer": "Yes! Sparkonomy's AI knows the GST system inside out. It automatically picks the right service codes and best of all - our invoice template follows the GST requirements to the tee! Let Sparkonomy do the hard work while you sparkle!"
       },
       {
-        "question": "What is the GST rate I must charge on my brand services?",
-        "answer": "You don't have to worry—Sparkonomy's AI takes care of GST for you! It automatically matches your service to the right HSN code, splits GST into IGST, SGST, or CGST, and makes sure every invoice is correct. If you're not GST-registered, Sparkonomy won't let you add GST, so there are no mistakes. Every invoice you make and send is error-free and compliant, saving you time and stress.",
-        "category": "taxation"
+        "question": "Q10: How do I send an invoice to a brand?",
+        "answer": "The way you like it! After you finish your invoice, send it to the brand within Sparkonomy or download it and send a PDF personally over email/Whatsapp. No chasing, no hassle, just fast cash!"
       },
       {
-        "question": "How do I send an invoice to a brand?",
-        "answer": "The way you like it! After you finish your invoice, send it to the brand within Sparkonomy or download it and send a PDF personally over email/Whatsapp. No chasing, no hassle, just fast cash!",
-        "category": "invoice"
-      },
-      {
-        "question": "Can I add my own logo to my invoices?",
-        "answer": "Yes! We know your invoices should reflect your unique brand. Upload a business logo, profile picture or just share your social accounts and we'll pull your profile photo to personalize your invoices—so they look just like yours! 1-tap to give every invoice that shiny, pro look.",
-        "category": "invoice"
-      },
-      {
-        "question": "Can I use a Purchase Order (PO) to quickly create an invoice?",
-        "answer": "Absolutely. We know speed is everything. Instead of manually entering all the project details, you can upload the brand's Purchase Order (PO) when you tap \"Create Invoice.\" Our smart system will instantly break down the document and pre-fill all the basic details like the brand name, contact info, and sometimes even the rate - so you can verify the details and send the invoice even faster.",
-        "category": "invoice"
-      },
-      {
-        "question": "I often delay sending my invoices because it feels like a chore, or I worry I'll make a mistake. Is this a big deal?",
-        "answer": "Yes! Delayed invoices mean brands start processing your payment later, which can push your payment cycle anywhere from 45 to 180 days—that's up to 6 months of waiting. We hate that delay too, so we made invoicing with Sparkonomy super simple and fast. Our 'Tap-to-Invoice' design and AI create 100% accurate, professional invoices in seconds. This means no errors or missing info that can hold up payments. By removing invoice mistakes and delays, we help you get paid faster, so you can focus fully on creating!",
-        "category": "invoice"
-      },
-      {
-        "question": "Do your invoices support tax and service codes for my country?",
-        "answer": "Yes, absolutely! Sparkonomy's AI automatically fills in all the mandatory details, including the correct tax and service codes, for your service according to your country. This ensures every invoice is fully compliant, correctly classified, and meets all legal requirements for both your filing and your client's Input Tax Credit. With Sparkonomy, you don't have to worry about errors - our AI handles it all seamlessly!",
-        "category": "invoice"
-      },
-      {
-        "question": "I believe there is an error on my invoice. What should I do?",
-        "answer": "If your invoice hasn't been sent yet, no worries—just go to your dashboard and use the edit option to make changes. If the invoice has been sent and you are not GST-registered, you can edit the invoice, but it's better practice to cancel the old one and send a new invoice to keep things clean. If you are GST-registered, you should cancel the existing invoice and create a fresh one. This helps keep your invoice serial numbers and dates correct. You can speed things up by duplicating the old invoice and making the necessary changes before sending. This approach helps with compliance and keeps your records tidy!",
-        "category": "invoice"
-      },
-      {
-        "question": "I just changed my Payment Method. Will this affect my current invoice?",
-        "answer": "All invoices sent before your payment change will reflect the old payment details. Your updated payout information is saved and will be used for all future invoices and payouts, but make sure your new bank details are fully verified before the next payment date. If the old payment system no longer accepts money, you'll need to send a quick update to the brands where payment is still pending to avoid delays.",
-        "category": "invoice"
-      },
-      {
-        "question": "What are the Sparkonomy steps for final collection and public disclosure of non-paying brands?",
-        "answer": "A brand ghosting your payment is not cool. We don't provide legal support for collections yet, but we've got some smart hacks to help you get paid. We'll suggest ways to draft strong follow-up messages and professional steps to encourage payment—without any drama. You stay in control, and we help you keep it smooth and professional.",
-        "category": "payment-reminders"
-      },
-      {
-        "question": " Do I need to pay taxes on free products and sponsored trips I receive from brands?",
-        "answer": "Yes, The law considers any payment in exchange for your services as taxable income, whether it is cash, products, or experiences. If a brand sends you gifts worth more than a particular amount as part of a sponsored collaboration, you must declare the full value as income. Only small one-off tokens are exempt. This means you need to keep records of all products and perks you receive, noting their retail value, so you can report them accurately during tax filing.",
-        "category": "taxation"
-      },
-      {
-        "question": "How do I track and manage multiple brand deals at the same time?",
-        "answer": "When your deals are scattered across WhatsApp, email, and Instagram DMs, chaos is inevitable. The simple rule is: track everything in one place. For every deal, always note these 4 things: Brand name, Payment amount, Due date, and Payment status. With Sparkonomy's AI tools, all of this becomes effortless. From vendor registration to invoicing, payment tracking, and income management - we handle it all, so you can focus on creating.",
-        "category": "invoice"
-      },
-      {
-        "question": "Can I claim expenses like camera equipment and software as tax deductions?",
-        "answer": "Yes, if you are operating as a self-employed creator or registered business, you can deduct legitimate business expenses from your income to reduce your taxable profit. This includes camera gear, editing software subscriptions, props, studio rental, and even a portion of your home internet if you work from home. Keep receipts and records for all your expenses, and only claim items that are genuinely used for your content creation work.",
-        "category": "taxation"
+        "question": "Q11: Can I add my own logo to my invoices?",
+        "answer": "Yes! We know your invoices should reflect your unique brand. Upload a business logo, profile picture or just share your social accounts and we'll pull your profile photo to personalize your invoices—so they look just like yours! 1-tap to give every invoice that shiny, pro look."
       }
     ]
   },
-  "video": {
-    "cta": "Completely Free, Start Now"
-  },
   "floatingCta": {
-    "button": "Try For Free",
     "placeholder": "Your mobile number",
-    "signup": "Sign Up"
+    "sendOtp": "Win Now",
+    "staticPrefix": "Win",
+    "primaryLabel": "Now",
+    "swapLabel": "Gold Coin",
+    "heading": "<0>Gold Coin</0> for the first 5 signups today.",
+    "body": "Don't miss out.",
+    "terms": "T&C apply",
+    "ariaLabel": "Sign up to win a Gold Coin",
+    "modalTitle": "Start sending invoices in your own boli"
   },
   "footer": {
     "tagline": "sparking the creator economy",
@@ -224,5 +168,48 @@
     "defaultName": "Chulbuli",
     "message": "says this is the easiest app for creator work — and wants you to try it.",
     "signUp": "Sign Up today!"
+  },
+  "otp": {
+    "title": "Enter the 4-digit OTP",
+    "sentTo": "Sent to {{phone}}",
+    "verify": "Verify OTP",
+    "resendIn": "Resend in {{seconds}}s",
+    "resend": "Resend OTP",
+    "resendViaPrefix": "Resend OTP via",
+    "smsChannel": "SMS",
+    "whatsappChannel": "WhatsApp",
+    "changeNumber": "Change number",
+    "errorInvalid": "Invalid OTP. Please try again.",
+    "errorNetwork": "Something went wrong. Please try again.",
+    "sending": "Sending…",
+    "verifying": "Verifying…"
+  },
+  "signupCard": {
+    "otpSentOverWhatsapp": "OTP sent over WhatsApp",
+    "verified": "Verified",
+    "notVerified": "Not verified",
+    "verifying": "Verifying…",
+    "invalid": "Incorrect OTP",
+    "firstNameLabel": "First Name*",
+    "firstNamePlaceholder": "E.g. Chulbuli",
+    "lastNameLabel": "Last Name*",
+    "lastNamePlaceholder": "E.g. Dixit",
+    "emailLabel": "Email",
+    "emailPlaceholder": "E.g. yourname@email.com",
+    "createAccount": "Create my account!",
+    "creating": "Creating…",
+    "done": "Done!",
+    "builtWith": "Built with",
+    "developedWith": "Developed with",
+    "emailInUse": "This email is already linked to another account."
+  },
+  "errors": {
+    "INVALID_OTP": "Invalid OTP. Please try again.",
+    "OTP_EXPIRED": "OTP expired. Please request a new one.",
+    "EMAIL_ALREADY_IN_USE": "This email is already linked to another account.",
+    "PHONE_ALREADY_IN_USE": "This phone number is already linked to another account.",
+    "USER_NOT_FOUND": "We couldn't find that account. Please start again.",
+    "NETWORK_ERROR": "Something went wrong. Please try again.",
+    "_default": "Something went wrong. Please try again."
   }
 }

--- a/public/locales/hi-Latn/creatorEarn.json
+++ b/public/locales/hi-Latn/creatorEarn.json
@@ -3,216 +3,159 @@
     "getEarlyAccess": "Early access paayein"
   },
   "hero": {
-    "title": "Duniya ka pehla AI — sirf creators ke liye.\nAb private beta mein. ⚡️"
+    "title": "Zyada kamaayein. Stress Less.<0/><1>Jaldi payment paayein!</1>",
+    "features": [
+      "<0>Easy</0> invoices with AI: Voice, chat, or photo",
+      "<0>Error-free</0>: Instant-tax calculations",
+      "<0>Faster</0> payments: Auto-reminders on email & Whatsapp"
+    ],
+    "card": {
+      "livePromo": "LIVE PROMO",
+      "voucherHeading": "Send free invoice — <0>Win Gold Coin</0>",
+      "voucherBody": "4 invoices/mo free forever. Pehle 5 signups ko har roz Gold Coin.",
+      "voucherTerms": "T&Cs apply",
+      "ctaLabel": "Get started — bilkul free!",
+      "checks": ["4 invoices/mo free forever", "No card needed", "30-sec signup"],
+      "phonePlaceholder": "XXXX XXXXXX",
+      "sendOtp": "Win Now",
+      "edit": "Edit",
+      "changeNumber": "Change Number",
+      "otpSentTo": "OTP sent to <0>{{phone}}</0>",
+      "verify": "Verify",
+      "verifying": "Verifying",
+      "verified": "Verified",
+      "disclaimer": "By tapping, you agree to create an account and Sparkonomy's <0>Terms</0> and <1>Privacy Policy</1>."
+    }
   },
-  "promo": {
-    "heading": "Apni Boli, Apna Bill",
-    "subheading": "Ab Hinglish mein banayein, perfect English invoices.",
-    "tagline": "Sign up. Win Amazon vouchers daily!",
-    "terms": "T&Cs apply",
-    "cta": "Sign up & Win!"
+  "pitch": {
+    "heading": "Duniya ka pehla AI — sirf Creators ke liye.",
+    "description": "Late payments, baar-baar follow-ups aur tax ka jhanjhat — ab khatam! Creators ke liye banaya pehla AI — jo smart payments se shuru hota hai. Aap content banayein, Follow-ups hum sambhal lenge."
   },
-  "valueProposition": {
-    "heading1": "Zyada kamaayein. Stress kam lein.",
-    "heading2": "Jaldi payment paayein!",
-    "description": "Late payments, baar-baar follow-ups aur tax ka jhanjhat — ab khatam! Creators ke liye banaya pehla AI — jo smart payments se shuru hota hai. Aap content  banayein, Follow-ups hum sambhal lenge.",
-    "cta": "Invoice bhejna shuru karein. Bilkul free"
-  },
-  "benefits": {
-    "title": "Fayde",
-    "cta": "Bilkul free. Abhi start karein.",
+  "threeStep": {
+    "title": "3 simple steps. Bas itna.",
+    "subtitle": "Itna easy ki pehli baar mein hi ho jayega.",
     "items": [
       {
-        "title": "Chat bhejein. Invoice paayein.",
-        "description": "WhatsApp message, email ya brand chat ka screenshot upload karein — ya bas likhein: “Iska invoice bana do.” Fir jaadu dekhiye, humara AI invoice ko proper format mein banata hai, typo-free.GST/PAN details apne aap add ho jayengi.",
-        "highlight": "Aap bas content banao, Cashflow hum banayenge!"
+        "title": "Bolo, type, ya screenshot",
+        "description": "WhatsApp message, email, brand chat ka screenshot upload karein — ya bas bolein/ likhein \"invoice banao.\"",
+        "tags": ["Voice", "Type", "Screenshot", "Duplicate"]
       },
       {
-        "title": "Aap content  banao. Follow-ups hum sambhal lenge.",
-        "description": "Ab “Hey, just checking on the payment?” bhejne ki zarurat nahi. Sparkonomy ka AI WhatsApp aur email par polite, professional reminders bhejta hai. Aap reminders ko manage kar sakte hain, Hum bas process easy banate hain.",
-        "highlight": "Aap rishte banayein. Follow-ups hum sambhal lenge."
+        "title": "AI invoice banayega",
+        "description": "AI proper format mein invoice banata hai, typo-free. GST/ PAN apne aap add. Aap check kar sakte ho, edit kar sakte ho.",
+        "tags": ["Auto-format", "GST/ PAN", "Typo-free"]
       },
       {
-        "title": "Pocket CFO ke saath Pro banein",
-        "description": "Apne cash flow, overdue payments aur income growth ka weekly update paayein, sirf 5 minute mein. Hum aapke records organize rakhte hain aur aapke business ko tax-compliant rehne mein help karte hain. ",
-        "highlight": "Aap pro banein, ham aapki help karenge."
-      }
-    ]
-  },
-  "advantage": {
-    "title": "Aapka Advantage",
-    "subtitle": "Aise invoices jo jaldi payment dilayein aur aapki professional image banayein!",
-    "cta": "Jaldi payment paayein",
-    "items": [
-      {
-        "title": "Payment Ready",
-        "description": "GST auto calculate ho jayega aur payment process integrated rahega"
-      },
-      {
-        "title": "Tax-Compliant",
-        "description": "GSTIN, HSN, aur barter deals manage karna easy ho jayega."
-      },
-      {
-        "title": "WhatsApp Alerts",
-        "description": "WhatsApp par payment status aur reminders milte rahenge"
-      },
-      {
-        "title": "Proof Of Work",
-        "description": "Aapka work auto-fetch ho jayega. Screenshots ki zarurat nahi."
+        "title": "Follow-ups hum karenge",
+        "description": "\"Hi, payment?\" bhejne ki zarurat nahi. Sparkonomy ka AI WhatsApp / email pe polite, professional reminders bhejta hai.",
+        "tags": ["WhatsApp + Email", "Auto-reminders"]
       }
     ]
   },
   "testimonials": {
     "title": "Creators kya bol rahe hain",
+    "subtitle": "Payments jaldi, aur aap Pro lagein.",
     "items": [
       {
-        "quote": "And I have to reach out so many times to get paid in 3 months, and still it hasn't happened 15-20 times! I want you to do my payment reminders",
-        "name": "Food YouTuber",
-        "handle": "700K Followers"
-      },
-      {
-        "quote": "I raise invoices once a month mostly. I don't get time… and it delays my payments. I want you help me raise instant invoices in under 5 mins from my phone",
-        "name": "Tech Instagrammer",
+        "quote": "3 months ho gaye, payment ke liye 15-20 baar reach out kar chuki hoon — still nothing! Reminders aap karo please, I'm done.",
+        "name": "Lifestyle Instagrammer",
         "handle": "1M Followers"
       },
       {
-        "quote": "I don't have time to write down and track all payments in Excel and become my own accountant! I want you to track & remind me of my money matters",
-        "name": "Lifestyle Instagrammer",
-        "handle": "320K Followers"
+        "quote": "Mostly month mein ek baar invoice raise karta hoon — time hi nahi milta, payments delay ho jaate hain. Phone se 5 minute mein invoice dilao please.",
+        "name": "Tech Instagramer",
+        "handle": "1M Followers"
+      },
+      {
+        "quote": "Excel mein payments track karne ka time kahaan hai? Mujhe apna khud ka accountant nahi banna! Aap track karo, remind karo — please.",
+        "name": "Food Youtuber",
+        "handle": "700K Followers"
       }
     ]
   },
-  "cta": {
-    "title": "Kya aap fast payments ke liye ready ho?",
-    "button": "Apna pehla invoice banayein"
+  "advantage": {
+    "title": "Aur kya milta hai?",
+    "items": [
+      {
+        "title": "Proof of Work, automatic.",
+        "description": "Insta, YouTube ke screenshots khud attach ho jayenge. Aapko nahi karna padega."
+      },
+      {
+        "title": "Hamesha free, 4 invoices.",
+        "description": "Har mahine 4 invoices free — koi card nahi, koi hidden charge nahi."
+      },
+      {
+        "title": "Tax calculations, AI karta hai.",
+        "description": "GST ho ya na ho, AI sab calculate kar leta hai. TDS, barter, multi-rate — sab handle."
+      },
+      {
+        "title": "CA-ready, year-end report.",
+        "description": "Saara data ek click pe export. CA ko bheje, ITR file karein — ab Excel ka jhanjhat band."
+      }
+    ]
   },
   "faq": {
     "title": "Frequently Asked Questions",
-    "viewAll": "Poora Dekhein",
-    "categories": [
-      { "key": "all", "label": "Sab" },
-      { "key": "getting-started", "label": "Shuru karna" },
-      { "key": "invoice", "label": "Invoice" },
-      { "key": "payment-reminders", "label": "Payment reminders" },
-      { "key": "pocket-cfo", "label": "Pocket CFO" },
-      { "key": "pricing", "label": "Plans & pricing" },
-      { "key": "taxation", "label": "Tax & GST" }
-    ],
+    "viewAll": "View All",
+    "viewLess": "Show Less",
     "items": [
       {
-        "question": "Main sign up kaise karu?",
-        "answer": "Apna phone number ya email id dein - bas! Uske baad, apne social handles share karein aur billing se related 2–3 easy questions answer karein. Sparkonomy ke AI ke saath, collaboration DMs ka reply dene se bhi zyada fast aap invoices bhej sakenge.",
-        "category": "getting-started"
+        "question": "Q1: Main sign up kaise karu?",
+        "answer": "Apna phone number ya email id dein - bas! Uske baad, apne social handles share karein aur billing se related 2–3 easy questions answer karein. Sparkonomy ke AI ke saath, collaboration DMs ka reply dene se bhi zyada fast aap invoices bhej sakenge."
       },
       {
-        "question": "Creators ke liye yeh AI aur smart payment kaise useful hain?",
-        "answer": "Sparkonomy ka AI creators ko apna business ek pro tarah manage karne mein help karta hai. Aap chat ya collab details share karein, aur system GST-ready invoice proper format mein bana dega. Pocket CFO aapke payments aur cash flow track karta hai aur har week 5 minutes ka update bhejta hai. WhatsApp/Email reminders se follow-ups easy ho jaate hain. Aap decide karte hain kisko reminder bhejna hai, with 1-tap actions: Stop, Delay, ya Payment Done.",
-        "category": "getting-started"
+        "question": "Q2: Creators ke liye yeh AI aur smart payment kaise useful hain?",
+        "answer": "Sparkonomy ka AI creators ko apna business ek pro tarah manage karne mein help karta hai. Aap chat ya collab details share karein, aur system GST-ready invoice proper format mein bana dega. Pocket CFO aapke payments aur cash flow track karta hai aur har week 5 minutes ka update bhejta hai. WhatsApp/Email reminders se follow-ups easy ho jaate hain. Aap decide karte hain kisko reminder bhejna hai, with 1-tap actions: Stop, Delay, ya Payment Done."
       },
       {
-        "question": "Invoicing start karne ke liye kya information profile mein add Karna important hai?",
-        "answer": "Apna naam, address, PAN, aur payment details (UPI ya bank account) add karein. Agar aapka separate billing organisation hai, toh uska PAN aur registration details (CIN/GSTIN) bhi add karein. Typing ki zarurat nahi—document ki photo upload karein. Ye 5 minutes se kam time leta hai, aur sirf ek baar karna hota hai.",
-        "category": "invoice"
+        "question": "Q3: Invoicing start karne ke liye kya information profile mein add karna important hai?",
+        "answer": "Apna naam, address, PAN, aur payment details (UPI ya bank account) add karein. Agar aapka separate billing organisation hai, toh uska PAN aur registration details (CIN/GSTIN) bhi add karein. Typing ki zarurat nahi—document ki photo upload karein. Ye 5 minutes se kam time leta hai, aur sirf ek baar karna hota hai."
       },
       {
-        "question": "Main apna pehla invoice kaise banau?",
-        "answer": "Creator AI aapko phone par sirf kuch taps mein, 3 minutes se bhi kam time mein invoice bana deta hai. Aap purana invoice duplicate kar sakte hain, WhatsApp/email ka screenshot upload kar sakte hain, ya bas likh dijiye: “Mujhe iske liye invoice chahiye.” Invoice turant ready ho jayega, aur edits bhi aasaani se ho jaayenge.",
-        "category": "invoice"
+        "question": "Q4: Main apna pehla invoice kaise banau?",
+        "answer": "Creator AI aapko phone par sirf kuch taps mein, 3 minutes se bhi kam time mein invoice bana deta hai. Aap purana invoice duplicate kar sakte hain, WhatsApp/email ka screenshot upload kar sakte hain, ya bas likh dijiye: \"Mujhe iske liye invoice chahiye.\" Invoice turant ready ho jayega, aur edits bhi aasaani se ho jaayenge."
       },
       {
-        "question": "Sparkonomy meri taraf se payment reminders kaise bhejhega?",
-        "answer": "Humein pata hai payment ke liye baar-baar follow-up karna kitna frustrating hota hai. Invoice banate time aap choose karte hain ki reminders kitne bhejne hain, kitni frequency par, aur WhatsApp/email par bhejne hain ya nahi. Reminder send hone se pehle aapko confirmation milta hai. Aap 1-tap actions se control rakhte hain: Stop, Delay, ya Payment Done. Aap content banayein, follow-ups hum sambhal lenge.",
-        "category": "payment-reminders"
+        "question": "Q5: Sparkonomy meri taraf se payment reminders kaise bhejhega?",
+        "answer": "Humein pata hai payment ke liye baar-baar follow-up karna kitna frustrating hota hai. Invoice banate time aap choose karte hain ki reminders kitne bhejne hain, kitni frequency par, aur WhatsApp/email par bhejne hain ya nahi. Reminder send hone se pehle aapko confirmation milta hai. Aap 1-tap actions se control rakhte hain: Stop, Delay, ya Payment Done. Aap content banayein, follow-ups hum sambhal lenge."
       },
       {
-        "question": "Pocket CFO kya hai aur yeh kya kaam karega?",
-        "answer": "Hum jaante hain ki aap apne creator business ke accountant nahi banna chahte. Phir bhi invoices, payments, aur follow-ups manage karna time le leta hai. Sparkonomy ka Pocket CFO AI agent har week aapke payments aur cash flow ka summary banata hai. Phir yeh aapko 5-minute ka weekly update bhejta hai—cash flow, overdue payments, aur income growth par. Isse aapke records clean rehte hain aur aapka business tax-ready rehne mein help milti hai. Aap pro banein. Hum aapki help karenge.",
-        "category": "pocket-cfo"
+        "question": "Q6: Pocket CFO kya hai aur yeh kya kaam karega?",
+        "answer": "Hum jaante hain ki aap apne creator business ke accountant nahi banna chahte. Phir bhi invoices, payments, aur follow-ups manage karna time le leta hai. Sparkonomy ka Pocket CFO AI agent har week aapke payments aur cash flow ka summary banata hai. Phir yeh aapko 5-minute ka weekly update bhejta hai—cash flow, overdue payments, aur income growth par. Isse aapke records clean rehte hain aur aapka business tax-ready rehne mein help milti hai. Aap pro banein. Hum aapki help karenge."
       },
       {
-        "question": "Mujhe kitna payment karna hoga?",
-        "answer": "Basic plan mein aap har month maximum 4 naye invoices bana sakte hain, unlimited reminders bhej sakte hain, aur Pocket CFO updates pa sakte hain. Agar aapko zyada invoices ya extra features chahiye, toh aap Pro plan par upgrade kar sakte hain. Aap referrals ke through benefits bhi unlock kar sakte hain.",
-        "category": "pricing"
+        "question": "Q7: Mujhe kitna payment karna hoga?",
+        "answer": "Basic plan mein aap har month maximum 4 naye invoices bana sakte hain, unlimited reminders bhej sakte hain, aur Pocket CFO updates pa sakte hain. Agar aapko zyada invoices ya extra features chahiye, toh aap Pro plan par upgrade kar sakte hain. Aap referrals ke through benefits bhi unlock kar sakte hain."
       },
       {
-        "question": "Mere invoices par tax calculate kaise hoga?",
-        "answer": " GST-registered creators ke liye, Sparkonomy aapki invoice details ke basis par GST fields fill karne mein help karta hai. System relevant tax details add karta hai aur CGST/SGST/IGST breakup generate karta hai, taaki invoice GST-ready format mein rahe. Aap final invoice send karne se pehle details review kar sakte hain.",
-        "category": "taxation"
+        "question": "Q8: Mere invoices par tax calculate kaise hoga?",
+        "answer": "GST-registered creators ke liye, Sparkonomy aapki invoice details ke basis par GST fields fill karne mein help karta hai. System relevant tax details add karta hai aur CGST/SGST/IGST breakup generate karta hai, taaki invoice GST-ready format mein rahe. Aap final invoice send karne se pehle details review kar sakte hain."
       },
       {
-        "question": "Kya AI GST calculate karne mein help karta hai?",
-        "answer": " Haan. Sparkonomy ka AI GST-related invoice fields fill karne mein help karta hai. Yeh service category ke hisaab se relevant details add karta hai aur GST-ready invoice template follow karta hai. Aap send karne se pehle sab details verify kar sakte hain.",
-        "category": "taxation"
+        "question": "Q9: Kya AI GST calculate karne mein help karta hai?",
+        "answer": "Haan. Sparkonomy ka AI GST-related invoice fields fill karne mein help karta hai. Yeh service category ke hisaab se relevant details add karta hai aur GST-ready invoice template follow karta hai. Aap send karne se pehle sab details verify kar sakte hain."
       },
       {
-        "question": "Mujhe meri brand services par kitna GST charge karna chahiye?",
-        "answer": " Agar aap GST-registered hain, toh invoice par applicable GST charge karna hota hai. Sparkonomy aapke invoice setup ke basis par GST fields aur CGST/SGST/IGST breakup set karne mein help karta hai. Agar aap GST-registered nahi hain, toh aap GST add nahi kar sakte. Final rate aur classification ke liye aap apni GST registration details ke hisaab se confirm karein.",
-        "category": "taxation"
+        "question": "Q10: Main ek brand ko invoice kaise bheju?",
+        "answer": "Invoice complete karne ke baad, aap Sparkonomy ke through brand ko direct bhej sakte hain. Ya phir PDF download karke email/WhatsApp par send karein. Aap chahein toh send history bhi maintain rahegi, taaki follow-ups easy ho jaayein."
       },
       {
-        "question": "Main Ek brand ko invoice kaise bheju?",
-        "answer": "Invoice complete karne ke baad, aap Sparkonomy ke through brand ko direct bhej sakte hain. Ya phir PDF download karke email/WhatsApp par send karein. Aap chahein toh send history bhi maintain rahegi, taaki follow-ups easy ho jaayein.",
-        "category": "invoice"
-      },
-      {
-        "question": "Kya invoice mein apna logo add kar sakte hain?",
-        "answer": "Haan. Aap apna business logo upload kar sakte hain aur invoices ko apne brand ke hisaab se personalise kar sakte hain. Aap chahein toh profile picture bhi use ho sakti hai. Isse har invoice ko clean, professional look milta hai—without extra effort.",
-        "category": "invoice"
-      },
-      {
-        "question": "Kya Purchase Order (PO) use karke jaldi invoice create kar sakte hain?",
-        "answer": "Haan. “Create Invoice” par tap karke aap brand ka Purchase Order (PO) upload kar sakte hain. System document se key details (brand name, contact info, line items) extract karke pre-fill kar deta hai. Aap bas details verify karein aur invoice jaldi bhej dein.",
-        "category": "invoice"
-      },
-      {
-        "question": "Mujhse invoices bhejne mein delay hota hai... Is it a big deal?",
-        "answer": "Haan, iska impact hota hai. Invoice late bhejne se brand ka payment process late start hota hai, aur payment aur delay ho sakta hai. Sparkonomy ke saath invoicing simple ho jaati hai—AI aapko invoice fast create karne, review karne, aur time par bhejne mein help karta hai, taaki aap content creation par focus kar sakein.",
-        "category": "invoice"
-      },
-      {
-        "question": "Kya aapke invoices meri country ke tax aur service codes ko support karte hain?",
-        "answer": "Haan. Sparkonomy aapki country aur profile settings ke hisaab se relevant tax fields aur service details add karne mein help karta hai. Aap final invoice send karne se pehle sab details review kar sakte hain, taaki classification aur compliance clear rahe.",
-        "category": "invoice"
-      },
-      {
-        "question": "Mujhe lagta hai ki mere invoice mein galti hai. Mujhe kya karna chahiye?",
-        "answer": "Agar invoice abhi tak send nahi hua hai, toh dashboard se “Edit” karke changes karein. Agar invoice send ho chuka hai, toh best practice yeh hai ki purana invoice cancel karke naya invoice create karein, taaki records clean rahein. Agar aap GST-registered hain, toh cancel karke fresh invoice banana zyada safe hota hai. Aap time bachane ke liye purane invoice ko duplicate karke changes kar sakte hain.",
-        "category": "invoice"
-      },
-      {
-        "question": "Maine abhi apna Payment Method change kiya. Kya iska effect mere current invoice par padega?",
-        "answer": "Jo invoices aapne payment method change karne se pehle bheje hain, unmein purane payment details dikhenge. Updated payout details save ho jaati hain aur future invoices ke liye use hoti hain. Agar kisi brand ka payment pending hai, toh unko updated details share karein, taaki delay na ho.",
-        "category": "invoice"
-      },
-      {
-        "question": "Non-paying brands ke final collection aur public disclosure ke liye Sparkonomy ke steps kya hain?",
-        "answer": "Agar koi brand payment ignore kar raha hai, toh Sparkonomy aapko professional escalation follow karne mein help karta hai—reminder sequence, strong follow-up templates, aur proof-of-work/invoice details ek saath ready rakhna. Hum legal support provide nahi karte, aur public shaming/disclosure recommend nahi karte. Agar payment phir bhi pending rahe, toh aap formal written communication karein aur zarurat ho toh legal professional se advice lein.",
-        "category": "payment-reminders"
-      },
-      {
-        "question": "Kya mujhe brands se milne wale free products aur sponsored trips par tax dena hoga?",
-        "answer": "Haan, kai cases mein non-cash benefits bhi taxable ho sakte hain. Agar aapko products, gifts, ya sponsored trips collaboration ke under milte hain, toh unki value ko income/benefit ke taur par report karna pad sakta hai. Best practice: har benefit ka record rakhein aur approximate market value note karein, taaki filing ke time sahi reporting ho sake.",
-        "category": "taxation"
-      },
-      {
-        "question": "Main ek hi time par multiple brand deals kaise manage karun?",
-        "answer": " Agar deals WhatsApp, email, aur Instagram DMs mein scattered hain, toh tracking tough ho jaati hai. Simple rule: sab kuch ek jagah track karein. Har deal ke liye 4 cheezein note karein—brand name, amount, due date, aur payment status. Sparkonomy aapko invoices, payment status, aur income tracking ek dashboard mein manage karne mein help karta hai.",
-        "category": "invoice"
-      },
-      {
-        "question": "Kya camera equipment aur software ke kharche tax deduction ke liye claim kiye ja sakte hain?",
-        "answer": "Haan. Agar aap self-employed creator ya registered business hain, toh aap genuine business expenses ko income se deduct kar sakte hain, subject to rules. Isme camera gear, editing software, props, studio rent, aur work-related internet ka portion include ho sakta hai. Sirf wahi expenses claim karein jo actual work ke liye use hote hain, aur invoices/receipts save rakhein.",
-        "category": "taxation"
+        "question": "Q11: Kya invoice mein apna logo add kar sakte hain?",
+        "answer": "Haan. Aap apna business logo upload kar sakte hain aur invoices ko apne brand ke hisaab se personalise kar sakte hain. Aap chahein toh profile picture bhi use ho sakti hai. Isse har invoice ko clean, professional look milta hai—without extra effort."
       }
     ]
   },
-  "video": {
-    "cta": "Bilkul free, Abhi start karein!"
-  },
   "floatingCta": {
-    "button": "Free mein try karein",
     "placeholder": "Apna mobile number",
-    "signup": "Sign Up"
+    "sendOtp": "Win Now",
+    "staticPrefix": "Win",
+    "primaryLabel": "Now",
+    "swapLabel": "Gold Coin",
+    "heading": "<0>Gold Coin</0> jaa raha hai — aaj ke pehle 5 ko.",
+    "body": "Miss mat karna.",
+    "terms": "T&C apply",
+    "ariaLabel": "Sign up to win a Gold Coin",
+    "modalTitle": "Apni boli mein invoice bhejna shuru karein"
   },
   "footer": {
     "tagline": "sparking the creator economy",
@@ -225,5 +168,48 @@
     "defaultName": "Chulbuli",
     "message": "ka maan na hai ki yeh app creators ke liye sabse easy hai — aap bhi ise try karke dekho.",
     "signUp": "Aaj hi Sign Up karo!"
+  },
+  "otp": {
+    "title": "4-digit OTP daalein",
+    "sentTo": "{{phone}} par bheja gaya",
+    "verify": "OTP Verify karein",
+    "resendIn": "{{seconds}}s mein dobara bhejein",
+    "resend": "OTP dobara bhejein",
+    "resendViaPrefix": "OTP dobara bhejo via",
+    "smsChannel": "SMS",
+    "whatsappChannel": "WhatsApp",
+    "changeNumber": "Number badlein",
+    "errorInvalid": "Galat OTP. Phir se try karein.",
+    "errorNetwork": "Kuch gadbad ho gayi. Phir se try karein.",
+    "sending": "Bhej rahe hain…",
+    "verifying": "Verify ho raha hai…"
+  },
+  "signupCard": {
+    "otpSentOverWhatsapp": "OTP WhatsApp par bheja gaya hai",
+    "verified": "Verified",
+    "notVerified": "Not verified",
+    "verifying": "Verifying…",
+    "invalid": "Incorrect OTP",
+    "firstNameLabel": "First Name*",
+    "firstNamePlaceholder": "E.g. Chulbuli",
+    "lastNameLabel": "Last Name*",
+    "lastNamePlaceholder": "E.g. Dixit",
+    "emailLabel": "Email",
+    "emailPlaceholder": "E.g. yourname@email.com",
+    "createAccount": "Mera Account Banao!",
+    "creating": "Bana rahe hain…",
+    "done": "Ho gaya!",
+    "builtWith": "Built with",
+    "developedWith": "Developed with",
+    "emailInUse": "Yeh email kisi aur account se linked hai."
+  },
+  "errors": {
+    "INVALID_OTP": "Galat OTP. Phir se try karein.",
+    "OTP_EXPIRED": "OTP expire ho gaya. Naya OTP mangwayein.",
+    "EMAIL_ALREADY_IN_USE": "Yeh email kisi aur account se linked hai.",
+    "PHONE_ALREADY_IN_USE": "Yeh number kisi aur account se linked hai.",
+    "USER_NOT_FOUND": "Account nahi mila. Phir se shuru karein.",
+    "NETWORK_ERROR": "Kuch gadbad ho gayi. Phir se try karein.",
+    "_default": "Kuch gadbad ho gayi. Phir se try karein."
   }
 }


### PR DESCRIPTION
## Why

Author pages (`/blogs/author/<slug>`) were not surfacing in search. Root cause: every author's `canonicalPath` pointed at a **non-existent `/authors/<slug>` URL (404)**, so the `<link rel="canonical">`, `Person` JSON-LD, and OpenGraph URLs all canonicalized to a dead page — which de-indexes the real pages. Discovery and entity signals were also weak.

## What changed

- **Fix the canonical (the indexing bug).** Canonical is now derived from `slug` via a single source of truth (`lib/urls.ts`), so it always equals the served URL. Removed the `canonicalPath` field (type + all 7 entries) and the now-dead `/authors/` breadcrumb branch, so the bug class can't recur.
- **Discovery.** Added author pages to the blog sitemap (`app/blogs/sitemap.ts`).
- **Entity signals.** Wrapped the author `Person` schema in `ProfilePage` (Google's recommended author-page shape) and expanded `sameAs`.
- **Brand entity.** Added a site-wide `Organization` + `WebSite` JSON-LD graph and `metadataBase` in the root layout, so author `worksFor` references resolve to a real node.

## Files
`data/authors.ts`, `app/blogs/author/[slug]/page.tsx`, `app/blogs/sitemap.ts`, `app/layout.tsx`, `lib/urls.ts` (new).

## Verification
- `npx tsc --noEmit` passes.
- After deploy: view-source an author page → canonical points to `/blogs/author/<slug>` (200, not `/authors/...`); `ProfilePage`+`Person` validate in the Rich Results Test; `/blogs/sitemap.xml` lists the author pages. Then Request Indexing in Search Console.

## Note
This makes the pages **eligible** to rank; winning a competitive personal-name SERP also needs off-site entity work (consistent LinkedIn/Crunchbase that link back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
