### PR TITLE
fix(wordpress): retry + fail-soft so a transient CMS error can't abort the build

### DIFF
--- a/lib/wordpress-improved.ts
+++ b/lib/wordpress-improved.ts
@@ -36,6 +36,46 @@ export interface WordPressResponse<T> {
 }
 
 /**
+ * Retryable transient statuses: 5xx (server errors) and 429 (rate limit) are
+ * worth retrying; 4xx are deterministic and returned to the caller as-is.
+ */
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+/**
+ * fetch() with a small exponential backoff. A momentary WordPress 5xx or a
+ * dropped connection is common during a full static build and would otherwise
+ * abort the entire export; retrying recovers from the transient case.
+ *
+ * Retry attempts append a throwaway query param so Next's per-render fetch
+ * memoization doesn't simply replay the first (failed) response.
+ */
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  retries = 2,
+  baseDelayMs = 300
+): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
+    const attemptUrl =
+      attempt === 0
+        ? url
+        : `${url}${url.includes("?") ? "&" : "?"}__retry=${attempt}`;
+    try {
+      const response = await fetch(attemptUrl, options);
+      if (!isRetryableStatus(response.status) || attempt >= retries) {
+        return response;
+      }
+    } catch (error) {
+      if (attempt >= retries) throw error;
+    }
+    const delay = baseDelayMs * 2 ** attempt + Math.floor(Math.random() * 100);
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+}
+
+/**
  * Generic WordPress fetch function with error handling and caching
  */
 async function wordpressFetch<T>(
@@ -45,7 +85,7 @@ async function wordpressFetch<T>(
   const url = `${WORDPRESS_URL}${endpoint}`;
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchWithRetry(url, {
       ...options,
       next: { revalidate: 300, tags: ['wp'] },
     });
@@ -78,17 +118,21 @@ async function wordpressFetchWithPagination<T>(
   const url = `${WORDPRESS_URL}${endpoint}`;
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchWithRetry(url, {
       ...options,
       next: { revalidate: 300, tags: ['wp'] },
     });
 
     if (!response.ok) {
-      throw new WordPressAPIError(
-        `WordPress API error: ${response.statusText}`,
-        response.status,
-        endpoint
+      // Fail soft: pagination endpoints feed category/search/listing pages that
+      // are statically pre-rendered at build time. After retries are exhausted,
+      // return an empty page instead of throwing — one transient upstream error
+      // must not abort the whole production build. revalidate:300 restores real
+      // data within ~5 min of the CMS recovering.
+      console.error(
+        `WordPress API error after retries (${endpoint}): ${response.status} ${response.statusText}`
       );
+      return { data: [] as unknown as T, total: 0, totalPages: 0 };
     }
 
     const data = await response.json();
@@ -97,9 +141,6 @@ async function wordpressFetchWithPagination<T>(
 
     return { data, total, totalPages };
   } catch (error) {
-    if (error instanceof WordPressAPIError) {
-      throw error;
-    }
     console.error(`Error fetching from WordPress API (${endpoint}):`, error);
     return { data: [] as unknown as T, total: 0, totalPages: 0 };
   }


### PR DESCRIPTION
## Problem

Category, search, and listing blog pages are statically pre-rendered and fetch the WordPress REST API at build time. `wordpressFetchWithPagination` re-threw on any non-2xx response, so a single momentary upstream **500** (observed on `/posts?categories=6,86&_embed&page=1&per_page=5`) aborted the **entire** `next build` — making deploys hostage to the CMS being healthy at that exact second.

This is pre-existing and intermittent: the same endpoint returned 500 during a build and **200 ~1s later** on a direct probe.

## Fix (`lib/wordpress-improved.ts`)

1. **`fetchWithRetry()`** — exponential backoff (with jitter) for transient failures: 5xx, 429, and network errors. Retry attempts append a throwaway query param so Next's per-render fetch **memoization** doesn't simply replay the first failed response. Used by both fetch helpers. This alone recovers from the common transient case.
2. **Fail-soft backstop** — after retries are exhausted, `wordpressFetchWithPagination` returns an empty page (`{ data: [], total: 0, totalPages: 0 }`) instead of throwing, matching its existing behaviour for network errors. A single transient upstream error can no longer abort the production build; `revalidate: 300` restores real data within ~5 min of the CMS recovering.

Single-resource fetches (`getPostBySlug`, etc.) already fail soft in their callers, so this targets the unprotected pagination/listing path.

## Testing

- `tsc --noEmit`: clean.
- `next build` (healthy CMS): 41/41 pages, `/blogs/company` builds.
- **Resilience test** — `next build` against a deliberately-broken WP host (every blog fetch failing) **completes cleanly** instead of aborting; listing pages render empty and recover on next revalidate.

## Scope

Independent of #226 (SEO) — different files, no conflicts. Behaviour change is limited to error paths; the happy path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)