### PR TITLE
copy: capitalize "Creator" across site copy and metadata

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -163,10 +163,10 @@ const AboutPage = () => {
                 passion into thriving businesses.</strong>
               </p>
               <p className="text-gray-300 leading-relaxed text-lg">
-                As we build the foundational infrastructure for the $300B creator economy, we are also
+                As we build the foundational infrastructure for the $300B Creator economy, we are also
                 bringing to life the &apos;economic equality engine&apos; for the entire ecosystem. This is a system
-                that ensures every creator is represented by the true substance of their craft—unlocking a
-                fair and flourishing future for 250M creators and the brands that partner with them
+                that ensures every Creator is represented by the true substance of their craft—unlocking a
+                fair and flourishing future for 250M Creators and the brands that partner with them
                 worldwide.
               </p>
             </motion.div>
@@ -197,12 +197,12 @@ const AboutPage = () => {
               </p>
               <p className="text-gray-300 leading-relaxed text-lg mb-4">
                 Our proprietary <strong>Creator Genome</strong> leverages native multi-modality (powered by Google&apos;s Gemini
-                Models) to analyze the &quot;Creative DNA&quot; of a creator&apos;s work across video, audio, image, and
-                text—powering a personalized AI Agent Force that turns a creator&apos;s raw talent into a
+                Models) to analyze the &quot;Creative DNA&quot; of a Creator&apos;s work across video, audio, image, and
+                text—powering a personalized AI Agent Force that turns a Creator&apos;s raw talent into a
                 structured venture.
               </p>
               <p className="text-gray-300 leading-relaxed text-lg">
-                We bridge the gap between being a &apos;content creator&apos; and a &apos;company founder&apos; by building the
+                We bridge the gap between being a &apos;content Creator&apos; and a &apos;company founder&apos; by building the
                 essential business rails - strategic, financial, and legal - that allow passion to become a
                 profession and influence to become an institution.
               </p>
@@ -228,20 +228,20 @@ const AboutPage = () => {
                 <h2 className="text-2xl sm:text-3xl font-bold text-white">The team building the future of the Creator economy</h2>
               </div>
               <p className="text-gray-300 leading-relaxed text-lg mb-4">
-                Sparkonomy is built by creators, brand leaders, and AI technologists who have sat on every
+                Sparkonomy is built by Creators, brand leaders, and AI technologists who have sat on every
                 side of the table.
               </p>
               <p className="text-gray-300 leading-relaxed text-lg mb-4">
                 Our team has spent decades building and scaling platforms like YouTube, Google, Meta, and
                 Paypal that power the modern internet. We&apos;ve managed billion-dollar brand budgets,
-                engineered global AI creative tools, and led growth for the world&apos;s largest creator
+                engineered global AI creative tools, and led growth for the world&apos;s largest Creator
                 platforms.
               </p>
               <p className="text-gray-300 leading-relaxed text-lg mb-4">
                 But we&apos;ve also lived the Creator hustle.
               </p>
               <p className="text-gray-300 leading-relaxed text-lg mb-4">
-                This unique vantage point - combining institutional rigor with first-hand creator empathy -
+                This unique vantage point - combining institutional rigor with first-hand Creator empathy -
                 is why Sparkonomy exists. We aren&apos;t just building another tool; we are applying the same
                 zero-to-one operating discipline and technical excellence used by the world&apos;s tech giants to
                 solve the most human challenges for the individual Creator-founder.

--- a/app/blogs/author/[slug]/page.tsx
+++ b/app/blogs/author/[slug]/page.tsx
@@ -62,7 +62,7 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
   const title = author.metaTitle || `${author.name} - Author at Sparkonomy`;
   // Build description with expertise keywords for better SEO keyword consistency
   const expertiseText =
-    author.areasOfExpertise?.slice(0, 3).join(", ") || "creator economy, content monetization";
+    author.areasOfExpertise?.slice(0, 3).join(", ") || "Creator economy, content monetization";
   const description =
     author.metaDescription ||
     author.shortBio ||

--- a/app/blogs/creators/page.tsx
+++ b/app/blogs/creators/page.tsx
@@ -8,7 +8,7 @@ const config = CATEGORY_CONFIGS.creators;
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.sparkonomy.com/"),
   title: "Creators & Influencers | Sparkonomy Blog - Tips for YouTubers, Instagrammers & Social Media Influencers",
-  description: "Insights, tips and updates for creators, influencers, YouTubers, Instagrammers and social media influencers. Grow your audience and monetize your content with Sparkonomy.",
+  description: "Insights, tips and updates for Creators, influencers, YouTubers, Instagrammers and social media influencers. Grow your audience and monetize your content with Sparkonomy.",
   keywords: [
     "creators",
     "influencers",
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
     siteName: "Sparkonomy",
     url: "https://sparkonomy.com/blogs/creators",
     title: "Creators & Influencers | Sparkonomy Blog - YouTubers, Instagrammers & More",
-    description: "Insights, tips and updates for creators, influencers, YouTubers, Instagrammers and social media influencers on Sparkonomy.",
+    description: "Insights, tips and updates for Creators, influencers, YouTubers, Instagrammers and social media influencers on Sparkonomy.",
     images: [
       {
         url: "/sparkonomy.png",
@@ -53,7 +53,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "Creators & Influencers | Sparkonomy Blog",
-    description: "Tips and insights for creators, influencers, YouTubers & Instagrammers on Sparkonomy.",
+    description: "Tips and insights for Creators, influencers, YouTubers & Instagrammers on Sparkonomy.",
     images: ["/sparkonomy.png"],
     site: "@sparkonomy",
     creator: "@sparkonomy",

--- a/app/blogs/page.tsx
+++ b/app/blogs/page.tsx
@@ -13,7 +13,7 @@ export const revalidate = 300;
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.sparkonomy.com/"),
   title: "Blog | Sparkonomy - Tips for Creators, Influencers, YouTubers & Instagrammers",
-  description: "Discover the latest insights, tips, and strategies for creators, influencers, YouTubers & Instagrammers to monetize content, grow their audience, and succeed in the creator economy. Expert guides from Sparkonomy.",
+  description: "Discover the latest insights, tips, and strategies for Creators, influencers, YouTubers & Instagrammers to monetize content, grow their audience, and succeed in the Creator economy. Expert guides from Sparkonomy.",
   keywords: [
     "creator economy",
     "content monetization",
@@ -49,7 +49,7 @@ export const metadata: Metadata = {
   openGraph: {
     siteName: "Sparkonomy",
     title: "Blog | Sparkonomy - Tips for Creators, Influencers & YouTubers",
-    description: "Insights, tips & strategies for creators, influencers, YouTubers & Instagrammers to monetize content and succeed in the creator economy.",
+    description: "Insights, tips & strategies for Creators, influencers, YouTubers & Instagrammers to monetize content and succeed in the Creator economy.",
     url: "https://sparkonomy.com/blogs",
     type: "website",
     locale: "en_US",
@@ -65,7 +65,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "Blog | Sparkonomy - Tips for Creators, Influencers & YouTubers",
-    description: "Insights, tips & strategies for creators, influencers, YouTubers & Instagrammers to monetize content and succeed in the creator economy.",
+    description: "Insights, tips & strategies for Creators, influencers, YouTubers & Instagrammers to monetize content and succeed in the Creator economy.",
     images: ["https://sparkonomy.com/sparkonomy.png"],
     creator: "@sparkonomy",
     site: "@sparkonomy",
@@ -227,7 +227,7 @@ export default function Home() {
     "@context": "https://schema.org",
     "@type": "Blog",
     name: "Sparkonomy Blog - For Creators, Influencers, YouTubers & Instagrammers",
-    description: "Insights, tips, and strategies for creators, influencers, YouTubers, Instagrammers and social media influencers to monetize content and succeed in the creator economy.",
+    description: "Insights, tips, and strategies for Creators, influencers, YouTubers, Instagrammers and social media influencers to monetize content and succeed in the creator economy.",
     url: "https://sparkonomy.com/blogs",
     publisher: {
       "@type": "Organization",

--- a/app/creator/earn/layout.tsx
+++ b/app/creator/earn/layout.tsx
@@ -63,17 +63,17 @@ export const metadata: Metadata = {
   openGraph: {
     siteName: "Sparkonomy",
     url: "https://sparkonomy.com/creator/earn",
-    title: "Get paid faster — like your friend! Join them for FREE on Sparkonomy, the 1st AI for creators.",
+    title: "Get paid faster — like your friend! Join them for FREE on Sparkonomy, the 1st AI for Creators.",
     description:
-      "Say NO to messy spreadsheets and manual invoices. Run your creator business like a pro. Join 100% free before early access ends!",
+      "Say NO to messy spreadsheets and manual invoices. Run your Creator business like a pro. Join 100% free before early access ends!",
     locale: "en_IN",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Get paid faster — like your friend! Join them for FREE on Sparkonomy, the 1st AI for creators.",
+    title: "Get paid faster — like your friend! Join them for FREE on Sparkonomy, the 1st AI for Creators.",
     description:
-      "Say NO to messy spreadsheets and manual invoices. Run your creator business like a pro. Join 100% free before early access ends!",
+      "Say NO to messy spreadsheets and manual invoices. Run your Creator business like a pro. Join 100% free before early access ends!",
   },
 };
 

--- a/app/creator/earn/page.tsx
+++ b/app/creator/earn/page.tsx
@@ -43,12 +43,12 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
   const ogAlt = isHindi ? "Sparkonomy AI - Hindi" : "Sparkonomy AI";
 
   const title = isHindi
-    ? "Fast payments paayein — bilkul aapke creator friends ki tarah. Unhe Sparkonomy par join karein — creators ke liye banaya gaya pehla AI. 100% FREE."
-    : "Get paid faster — like your friend! Join them for FREE on Sparkonomy, the 1st AI for creators.";
+    ? "Fast payments paayein — bilkul aapke Creator friends ki tarah. Unhe Sparkonomy par join karein — Creators ke liye banaya gaya pehla AI. 100% FREE."
+    : "Get paid faster — like your friend! Join them for FREE on Sparkonomy, the 1st AI for Creators.";
 
   const description = isHindi
-    ? "Messy spreadsheets aur manual invoices ko bolein NO. Apna creator business ek Pro ki tarah run karein. Early access khatam hone se pehle 100% FREE join karein!"
-    : "Say NO to messy spreadsheets and manual invoices. Run your creator business like a pro. Join 100% free before early access ends!";
+    ? "Messy spreadsheets aur manual invoices ko bolein NO. Apna Creator business ek Pro ki tarah run karein. Early access khatam hone se pehle 100% FREE join karein!"
+    : "Say NO to messy spreadsheets and manual invoices. Run your Creator business like a pro. Join 100% free before early access ends!";
 
   return {
     title,

--- a/app/creator/promo-w/layout.tsx
+++ b/app/creator/promo-w/layout.tsx
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   openGraph: {
     siteName: "Sparkonomy",
     url: "https://sparkonomy.com/creator/promo-w",
-    title: "Apni Boli, Apna Bill — Hinglish invoicing for creators | Sparkonomy",
+    title: "Apni Boli, Apna Bill — Hinglish invoicing for Creators | Sparkonomy",
     description:
       "Talk in Hinglish, get perfect English invoices. Sign up free and win Amazon vouchers daily. T&Cs apply.",
     locale: "en_IN",
@@ -41,13 +41,13 @@ export const metadata: Metadata = {
     images: [
       {
         url: "/promo/landing-promo/OG_promo_landing.png",
-        alt: "Sparkonomy — Hinglish invoicing for creators",
+        alt: "Sparkonomy — Hinglish invoicing for Creators",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Apni Boli, Apna Bill — Hinglish invoicing for creators | Sparkonomy",
+    title: "Apni Boli, Apna Bill — Hinglish invoicing for Creators | Sparkonomy",
     description:
       "Talk in Hinglish, get perfect English invoices. Sign up free and win Amazon vouchers daily. T&Cs apply.",
     images: ["/promo/landing-promo/OG_promo_landing.png"],

--- a/app/creator/promo/layout.tsx
+++ b/app/creator/promo/layout.tsx
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   openGraph: {
     siteName: "Sparkonomy",
     url: "https://sparkonomy.com/creator/promo",
-    title: "Apni Boli, Apna Bill — Hinglish invoicing for creators | Sparkonomy",
+    title: "Apni Boli, Apna Bill — Hinglish invoicing for Creators | Sparkonomy",
     description:
       "Talk in Hinglish, get perfect English invoices. Sign up free and win Amazon vouchers daily. T&Cs apply.",
     locale: "en_IN",
@@ -41,13 +41,13 @@ export const metadata: Metadata = {
     images: [
       {
         url: "/promo/landing-promo/OG_promo_landing.png",
-        alt: "Sparkonomy — Hinglish invoicing for creators",
+        alt: "Sparkonomy — Hinglish invoicing for Creators",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Apni Boli, Apna Bill — Hinglish invoicing for creators | Sparkonomy",
+    title: "Apni Boli, Apna Bill — Hinglish invoicing for Creators | Sparkonomy",
     description:
       "Talk in Hinglish, get perfect English invoices. Sign up free and win Amazon vouchers daily. T&Cs apply.",
     images: ["/promo/landing-promo/OG_promo_landing.png"],

--- a/app/creator/promo/page.tsx
+++ b/app/creator/promo/page.tsx
@@ -15,11 +15,11 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
 
   const isHindi = lang !== "en";
   const ogImage = "/promo/landing-promo/OG_promo_landing.png";
-  const ogAlt = "Sparkonomy — Hinglish invoicing for creators";
+  const ogAlt = "Sparkonomy — Hinglish invoicing for Creators";
 
   const title = isHindi
     ? "Apni Boli, Apna Bill — Hinglish mein invoice banayein. Daily Amazon vouchers jeetein!"
-    : "Apni Boli, Apna Bill — Hinglish invoicing for creators. Win Amazon vouchers daily!";
+    : "Apni Boli, Apna Bill — Hinglish invoicing for Creators. Win Amazon vouchers daily!";
 
   const description = isHindi
     ? "Hinglish mein baat karein, perfect English invoices paayein. 100% free sign up karein aur har din Amazon vouchers jeetein. T&Cs apply."

--- a/app/gold-promo/terms/page.tsx
+++ b/app/gold-promo/terms/page.tsx
@@ -29,9 +29,9 @@ export default function GoldPromoTermsPage() {
         <h2 className="text-xl font-semibold mt-8 mb-4">1. The Promo</h2>
         <p className="mb-4">
           We believe every invoice you send is a step toward building your
-          creator business. To celebrate that, Sparkonomy is running &ldquo;Gold
+          Creator business. To celebrate that, Sparkonomy is running &ldquo;Gold
           Shagun&rdquo; (the &ldquo;Promo&rdquo;), a lucky draw where eligible
-          creators who send an invoice through Sparkonomy get a chance to win
+          Creators who send an invoice through Sparkonomy get a chance to win
           a 0.5 gram gold coin. One lucky winner is selected at the end of the
           draw period.
         </p>
@@ -60,7 +60,7 @@ export default function GoldPromoTermsPage() {
             draw.
           </li>
           <li>
-            <strong>One entry per creator.</strong> Whether you send one
+            <strong>One entry per Creator.</strong> Whether you send one
             invoice or twenty during the Promo Period, you get one entry.
             Quality over quantity.
           </li>
@@ -115,7 +115,7 @@ export default function GoldPromoTermsPage() {
           5. Invoice Verification
         </h2>
         <p className="mb-4">
-          We want this Promo to reward creators who are genuinely building
+          We want this Promo to reward Creators who are genuinely building
           their businesses. To that end, we reserve the right to verify that
           any qualifying invoice was sent to a legitimate business contact for
           a genuine commercial purpose. This may include, but is not limited
@@ -131,8 +131,8 @@ export default function GoldPromoTermsPage() {
             email address or phone number;
           </li>
           <li>
-            The invoice was sent to the creator&apos;s own contact details or
-            to a contact controlled by the creator;
+            The invoice was sent to the Creator&apos;s own contact details or
+            to a contact controlled by the Creator;
           </li>
           <li>
             The invoice does not represent a genuine commercial transaction;
@@ -188,7 +188,7 @@ export default function GoldPromoTermsPage() {
           </li>
           <li>
             Talent agencies, intermediaries, or any third party participating
-            on behalf of a creator; and
+            on behalf of a Creator; and
           </li>
           <li>
             Anyone who doesn&apos;t meet the eligibility criteria listed

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import {Metadata} from "next";
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.sparkonomy.com/"),
   title: "Sparkonomy",
-  description: "Sparking the creator economy with the world's first AI - made exclusively for creators, influencers, YouTubers & Instagrammers!",
+  description: "Sparking the Creator economy with the world's first AI - made exclusively for creators, influencers, YouTubers & Instagrammers!",
     keywords: [
         "sparkonomy",
         "landing page",

--- a/data/authors.ts
+++ b/data/authors.ts
@@ -1151,7 +1151,7 @@ export const authors: AuthorEntry[] = [
     linkedinSubscribe: "https://www.linkedin.com/in/naad/",
     ctaButtonLabel: "Connect on LinkedIn",
     responseTime:
-      "Building something thoughtful in AI, software, or the creator economy? I am always interested in conversations with people who care about systems, coherence, and technology that feels useful in the real world. Connect with me on LinkedIn.",
+      "Building something thoughtful in AI, software, or the Creator economy? I am always interested in conversations with people who care about systems, coherence, and technology that feels useful in the real world. Connect with me on LinkedIn.",
 
     lastUpdated: "June 1, 2026",
     profileId: "authors/naad-dantale",
@@ -1165,7 +1165,7 @@ export const authors: AuthorEntry[] = [
     // SEO metadata
     metaTitle: "The Sparkonomy Founding Team",
     metaDescription:
-      "Meet the Sparkonomy founding team — Guneet Singh, Megha Thareja Tyagi, Vipasha Joshi, and Rachit Jain — building AI infrastructure for the creator economy.",
+      "Meet the Sparkonomy founding team — Guneet Singh, Megha Thareja Tyagi, Vipasha Joshi, and Rachit Jain — building AI infrastructure for the Creator economy.",
     // No WordPress slug — this is a synthetic author used to collapse multi-author posts
     // where all four co-founders appear together.
 
@@ -1173,7 +1173,7 @@ export const authors: AuthorEntry[] = [
     role: "Co-Founders, Sparkonomy",
     avatarUrl: "/sparkonomy.png",
     shortBio:
-      "We are the co-founders of Sparkonomy — Guneet Singh, Megha Thareja Tyagi, Vipasha Joshi, and Rachit Jain. Together we bring 70+ years across Google, Meta, Microsoft, PayPal, American Express, Samsung, Jellysmack, SAP, and IBM to building AI infrastructure for the creator economy.",
+      "We are the co-founders of Sparkonomy — Guneet Singh, Megha Thareja Tyagi, Vipasha Joshi, and Rachit Jain. Together we bring 70+ years across Google, Meta, Microsoft, PayPal, American Express, Samsung, Jellysmack, SAP, and IBM to building AI infrastructure for the Creator economy.",
 
     socialLinks: {
       linkedin: "https://www.linkedin.com/company/sparkonomy",
@@ -1198,22 +1198,22 @@ export const authors: AuthorEntry[] = [
       "But the same patterns kept repeating. Creators were running real businesses without the operating support that every traditional business takes for granted. Pricing, contracts, payments, taxes, partnerships — the back-office work was eating the creative work.",
     ],
     highlightQuote:
-      "The creator economy doesn't have a content problem. It has an infrastructure problem.",
+      "The Creator economy doesn't have a content problem. It has an infrastructure problem.",
     storyConclusion: [
-      "Sparkonomy is our answer. We are building AI infrastructure for the creator economy — so creators can spend less time wrestling with operations and more time building durable, profitable businesses.",
+      "Sparkonomy is our answer. We are building AI infrastructure for the Creator economy — so creators can spend less time wrestling with operations and more time building durable, profitable businesses.",
     ],
 
     aboutTitle: "About the Founding Team",
     aboutContent: [
-      "The Sparkonomy founding team brings together leadership across product, growth, payments, partnerships, and the creator economy. Guneet Singh leads tech and platform strategy after 20+ years across Google, Microsoft, and Samsung. Megha Thareja Tyagi leads commercial and AI strategy after two decades at Google, PayPal, and American Express. Vipasha Joshi leads creator business after 16+ years at Google and Jellysmack. Rachit Jain leads growth and partnerships after 20+ years at Meta, Google, SAP, and IBM.",
+      "The Sparkonomy founding team brings together leadership across product, growth, payments, partnerships, and the Creator economy. Guneet Singh leads tech and platform strategy after 20+ years across Google, Microsoft, and Samsung. Megha Thareja Tyagi leads commercial and AI strategy after two decades at Google, PayPal, and American Express. Vipasha Joshi leads Creator business after 16+ years at Google and Jellysmack. Rachit Jain leads growth and partnerships after 20+ years at Meta, Google, SAP, and IBM.",
       "Posts published under \"The Sparkonomy Founding Team\" are co-written by all four — usually deep dives on the strategy, market, or product direction we are taking together.",
     ],
 
     careerHighlights: [
       "70+ combined years across Google, Meta, Microsoft, PayPal, American Express, Samsung, Jellysmack, SAP, and IBM",
-      "Co-founded Sparkonomy to build AI infrastructure for the creator economy",
-      "Operator backgrounds across product, growth, payments, partnerships, and creator business",
-      "Hands-on with the creator economy since the earliest YouTube and platform-scale waves",
+      "Co-founded Sparkonomy to build AI infrastructure for the Creator economy",
+      "Operator backgrounds across product, growth, payments, partnerships, and Creator business",
+      "Hands-on with the Creator economy since the earliest YouTube and platform-scale waves",
     ],
 
     trustItems: [
@@ -1244,7 +1244,7 @@ export const authors: AuthorEntry[] = [
     speakingEmail: "events@sparkonomy.com",
     linkedinSubscribe: "https://www.linkedin.com/company/sparkonomy",
     responseTime:
-      "Building in the creator economy and want to talk to the founding team? Reach us on LinkedIn or by email.",
+      "Building in the Creator economy and want to talk to the founding team? Reach us on LinkedIn or by email.",
 
     lastUpdated: "May 6, 2026",
     profileId: "authors/founding-team",

--- a/data/faqs.ts
+++ b/data/faqs.ts
@@ -36,7 +36,7 @@ export const allFAQs: FAQ[] = [
   {
     question: "How do I create my first invoice?",
     answer:
-      "Sparkonomy's creator AI helps you make an invoice in under 3-minutes with a few taps - and all from your phone! Our smart payments feature helps you get started fast. Duplicate an old invoice, upload a WhatsApp or email screenshot with billing instructions, or just type \"I need an invoice for...\" and watch one get built in for you. It's that easy to spark your invoice. Send a chat - get an invoice. Now, you will never be delayed in sending one!",
+      "Sparkonomy's Creator AI helps you make an invoice in under 3-minutes with a few taps - and all from your phone! Our smart payments feature helps you get started fast. Duplicate an old invoice, upload a WhatsApp or email screenshot with billing instructions, or just type \"I need an invoice for...\" and watch one get built in for you. It's that easy to spark your invoice. Send a chat - get an invoice. Now, you will never be delayed in sending one!",
     category: "Invoice",
   },
   {
@@ -48,7 +48,7 @@ export const allFAQs: FAQ[] = [
   {
     question: "What is a pocket CFO and what will it do?",
     answer:
-      "We know you don't want to be your creator business accountant, and yet you end up being one! Invoices made in Excel, Canva, or Word are impossible to manage and track. Sparkonomy's Pocket CFO AI agent analyses your payments & cash flows every week. Then it sends you quick weekly 5-minute updates on cash flow, overdue payments, and income growth. It keeps your records tidy and your business tax-ready. You go Pro, we get you there!",
+      "We know you don't want to be your Creator business accountant, and yet you end up being one! Invoices made in Excel, Canva, or Word are impossible to manage and track. Sparkonomy's Pocket CFO AI agent analyses your payments & cash flows every week. Then it sends you quick weekly 5-minute updates on cash flow, overdue payments, and income growth. It keeps your records tidy and your business tax-ready. You go Pro, we get you there!",
     category: "Pocket CFO",
   },
   {

--- a/public/about.md
+++ b/public/about.md
@@ -13,15 +13,15 @@ Sparkonomy exists to change that — by building the intelligence infrastructure
 
 **Our vision is to elevate Creator livelihoods and success globally, transforming creative passion into thriving businesses.**
 
-As we build the foundational infrastructure for the $300B creator economy, we are also bringing to life the "economic equality engine" for the entire ecosystem. This is a system that ensures every creator is represented by the true substance of their craft — unlocking a fair and flourishing future for 250M creators and the brands that partner with them worldwide.
+As we build the foundational infrastructure for the $300B Creator economy, we are also bringing to life the "economic equality engine" for the entire ecosystem. This is a system that ensures every Creator is represented by the true substance of their craft — unlocking a fair and flourishing future for 250M creators and the brands that partner with them worldwide.
 
 ## The intelligence infrastructure for the Creator economy
 
 At Sparkonomy, we believe that being a Creator shouldn't just be a hustle — it should be a thriving, sustainable business. We are building the "engine room" for this new economy, replacing manual chaos with purpose-built AI that acts as a true thinking partner.
 
-Our proprietary **Creator Genome** leverages native multi-modality (powered by Google's Gemini Models) to analyze the "Creative DNA" of a creator's work across video, audio, image, and text — powering a personalized AI Agent Force that turns a creator's raw talent into a structured venture.
+Our proprietary **Creator Genome** leverages native multi-modality (powered by Google's Gemini Models) to analyze the "Creative DNA" of a Creator's work across video, audio, image, and text — powering a personalized AI Agent Force that turns a Creator's raw talent into a structured venture.
 
-We bridge the gap between being a "content creator" and a "company founder" by building the essential business rails — strategic, financial, and legal — that allow passion to become a profession and influence to become an institution.
+We bridge the gap between being a "content Creator" and a "company founder" by building the essential business rails — strategic, financial, and legal — that allow passion to become a profession and influence to become an institution.
 
 ## The team building the future of the Creator economy
 
@@ -31,7 +31,7 @@ Our team has spent decades building and scaling platforms like YouTube, Google, 
 
 But we've also lived the Creator hustle.
 
-This unique vantage point — combining institutional rigor with first-hand creator empathy — is why Sparkonomy exists. We aren't just building another tool; we are applying the same zero-to-one operating discipline and technical excellence used by the world's tech giants to solve the most human challenges for the individual Creator-founder.
+This unique vantage point — combining institutional rigor with first-hand Creator empathy — is why Sparkonomy exists. We aren't just building another tool; we are applying the same zero-to-one operating discipline and technical excellence used by the world's tech giants to solve the most human challenges for the individual Creator-founder.
 
 Our team has advised governments on AI adoption and helped thousands of Creators turn influence into enterprise. We've seen where the systems are broken, and we have the blueprint to fix them.
 


### PR DESCRIPTION
## Summary
Standardizes the casing of "creator" → "Creator" across marketing copy, SEO metadata, author bios, FAQs, and promo/terms pages for a consistent brand voice.

## Files touched
- `app/about/page.tsx`, `app/page.tsx`
- `app/blogs/*` (listing, creators category, author metadata)
- `app/creator/earn/*`, `app/creator/promo*/`
- `app/gold-promo/terms/page.tsx`
- `data/authors.ts`, `data/faqs.ts`
- `public/about.md`

Copy-only changes — no logic or behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)