### PR TITLE
copy: capitalize "Creator" in hero/banner subtext

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -428,7 +428,7 @@ const HeroSection = () => {
                 transform: subtextVisible ? "translateY(0)" : "translateY(20px)",
               }}
             >
-              Developing AI to spark creator livelihoods
+              Developing AI to spark Creator livelihoods
             </p>
 
             <div className="flex justify-center pointer-events-auto">

--- a/components/home/MainBanner.tsx
+++ b/components/home/MainBanner.tsx
@@ -97,7 +97,7 @@ export default function MainBanner({
           transform: subtextVisible ? "translateY(0)" : "translateY(20px)",
         }}
       >
-        Developing AI to spark creator livelihoods
+        Developing AI to spark Creator livelihoods
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
Capitalizes "creator" → "Creator" in the homepage hero and main banner subtext ("Developing AI to spark Creator livelihoods") for consistent brand voice.

This branch is cut directly from `main` and contains **only** this copy change (cherry-picked) — no other in-flight `dev` work is included.

## Files touched
- `components/HeroSection.tsx`
- `components/home/MainBanner.tsx`

Copy-only change — no logic or behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)