### PR TITLE
perf(contact/about): cut LCP work on contact & about pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -89,15 +89,11 @@ const AboutPage = () => {
 
       <div className="relative z-10 px-4 sm:px-6 lg:px-8 pb-20 pt-8">
         <div className="max-w-4xl mx-auto">
-          {/* Hero Section */}
-          <motion.div
-            initial="hidden"
-            animate="visible"
-            variants={staggerContainer}
-            className="text-center mb-8"
-          >
-            <motion.h1
-              variants={fadeInVariants}
+          {/* Hero Section — rendered statically (no entrance animation) so the
+              LCP heading paints with the SSR HTML instead of waiting for the JS
+              bundle to download, hydrate, and run Framer Motion. */}
+          <div className="text-center mb-8">
+            <h1
               className="text-4xl sm:text-5xl md:text-6xl font-bold mb-6 tracking-tight"
               style={{
                 background: "linear-gradient(135deg, #ffffff 0%, #6C63FF 100%)",
@@ -107,21 +103,15 @@ const AboutPage = () => {
               }}
             >
               About Us
-            </motion.h1>
-          </motion.div>
+            </h1>
+          </div>
 
-          {/* Our Story Section */}
-          <motion.section
-            initial="hidden"
-            whileInView="visible"
-            viewport={{ once: true, margin: "-100px" }}
-            variants={staggerContainer}
-            className="mb-8"
-          >
-            <motion.div
-              variants={fadeInVariants}
-              className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-8 hover:bg-white/8 transition-all duration-300"
-            >
+          {/* Our Story Section — first screenful below the hero; rendered
+              statically so its body copy (the largest above-the-fold text block,
+              and thus the likely LCP element on mobile) paints immediately
+              instead of fading in only after hydration. */}
+          <section className="mb-8">
+            <div className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-8 hover:bg-white/8 transition-all duration-300">
               <div className="flex items-start space-x-3 mb-6">
                 <div className="w-8 h-8 mt-1 flex-shrink-0 bg-purple-500/20 rounded-full flex items-center justify-center">
                   <Sparkles className="w-4 h-4 text-purple-400" />
@@ -137,8 +127,8 @@ const AboutPage = () => {
                 foundations. Sparkonomy exists to change that - by building the intelligence infrastructure
                 Creators need to succeed.
               </p>
-            </motion.div>
-          </motion.section>
+            </div>
+          </section>
 
           {/* Mission Section */}
           <motion.section

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -153,15 +153,11 @@ const ContactPage = () => {
 
       <div className="relative z-10 px-4 sm:px-6 lg:px-8 pb-20 pt-4">
         <div className="max-w-4xl mx-auto">
-          {/* Hero Section */}
-          <motion.div
-            initial="hidden"
-            animate="visible"
-            variants={staggerContainer}
-            className="text-center mb-20 mt-8"
-          >
-            <motion.h1
-              variants={fadeInVariants}
+          {/* Hero Section — rendered statically (no entrance animation) so the
+              LCP <h1> paints with the SSR HTML instead of waiting for the JS
+              bundle to download, hydrate, and run Framer Motion. */}
+          <div className="text-center mb-20 mt-8">
+            <h1
               className="text-4xl sm:text-5xl md:text-6xl font-bold mb-6 tracking-tight"
               style={{
                 background: "linear-gradient(135deg, #ffffff 0%, #6C63FF 100%)",
@@ -171,33 +167,29 @@ const ContactPage = () => {
               }}
             >
               Contact Us
-            </motion.h1>
-            <motion.div
-              variants={fadeInVariants}
-              className="flex justify-center items-center space-x-2 text-purple-400"
-            >
+            </h1>
+            <div className="flex justify-center items-center space-x-2 text-purple-400">
               <Sparkles className="w-5 h-5" />
               <span className="text-lg">Get in Touch</span>
               <Sparkles className="w-5 h-5" />
-            </motion.div>
-          </motion.div>
+            </div>
+          </div>
 
-          {/* Main Content */}
-          <motion.div
-            initial="hidden"
-            whileInView="visible"
-            viewport={{ once: true, margin: "-100px" }}
-            variants={staggerContainer}
-            className="relative z-[60] mb-8"
-          >
-            <motion.p
-              variants={fadeInVariants}
-              className="text-center text-gray-300 text-lg mb-16 max-w-3xl mx-auto leading-relaxed"
-            >
+          {/* Main Content — outer wrapper and intro copy render statically
+              (first screenful, LCP-safe). The scroll-reveal stagger now lives on
+              the cards grid below, so the card animation is unchanged. */}
+          <div className="relative z-[60] mb-8">
+            <p className="text-center text-gray-300 text-lg mb-16 max-w-3xl mx-auto leading-relaxed">
               We&apos;re currently in our early stages but are always eager to connect with creators, brands, and potential partners. Here&apos;s how to reach us.
-            </motion.p>
+            </p>
 
-            <div className="grid lg:grid-cols-2 gap-12">
+            <motion.div
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true, margin: "-100px" }}
+              variants={staggerContainer}
+              className="grid lg:grid-cols-2 gap-12"
+            >
               {/* Contact Information */}
               <motion.div
                 variants={fadeInVariants}
@@ -422,8 +414,8 @@ const ContactPage = () => {
                   </motion.div>
                 )}
               </motion.div>
-            </div>
-          </motion.div>
+            </motion.div>
+          </div>
 
         </div>
       </div>

--- a/app/legal/refund-policy/page.tsx
+++ b/app/legal/refund-policy/page.tsx
@@ -7,12 +7,7 @@ export default function RefundPolicyPage() {
         <>
             <div className="max-w-4xl mx-auto px-4 py-10 text-gray-800">
                 <LegalHeader
-                    title={
-                        <>
-                            <div>Sparkonomy Refund</div>
-                            <div> & Cancellation Policy</div>
-                        </>
-                    }
+                    title="Sparkonomy Refund & Cancellation Policy"
                     effectiveDate="November 10, 2025"
                     lastUpdated="November 10, 2025"
                     homeHref="/"

--- a/app/root-layout-client.tsx
+++ b/app/root-layout-client.tsx
@@ -35,6 +35,12 @@ export function RootLayoutClient({
   const isPreviewPage = pathname.startsWith("/preview");
   const isHomePage = pathname === "/";
 
+  // /contact and /about render a fully opaque bg-black over the fixed WebGL
+  // canvas, so the fluid sim is never actually visible there — it only costs the
+  // webgl-fluid-enhanced chunk download + GPU/main-thread work during the LCP
+  // window. Skip mounting it on those routes (Footer still renders).
+  const showWebGLBackground = pathname !== "/contact" && pathname !== "/about";
+
   // i18n is only used on /creator routes — avoid loading i18next/react-i18next
   // chunks on blog/legal/home/etc.
   const withI18n = (node: React.ReactNode) =>
@@ -104,9 +110,11 @@ export function RootLayoutClient({
       <ClarityInit />
       {toasterNode}
       <div className={`relative min-h-[100dvh] w-full flex flex-col overflow-x-hidden ${isHomePage ? "touch-pan-y md:touch-none" : "touch-pan-y"} md:overflow-hidden`}>
-        <div className="fixed inset-0 z-0">
-          <WebGLFluidBackground />
-        </div>
+        {showWebGLBackground && (
+          <div className="fixed inset-0 z-0">
+            <WebGLFluidBackground />
+          </div>
+        )}
         {children}
         <Footer minimal={!isHomePage} />
       </div>


### PR DESCRIPTION
## Summary

Performance optimizations targeting Largest Contentful Paint (LCP) on the `/contact` and `/about` pages.

- **Static above-the-fold rendering** — the hero headings and first screenful body copy on `/contact` and `/about` previously faded in via Framer Motion entrance animations, which meant the LCP element only painted *after* the JS bundle downloaded, hydrated, and ran. These blocks now render statically so they paint with the SSR HTML. Scroll-reveal animations further down the page are unchanged.
- **Skip WebGL fluid background on `/contact` and `/about`** — both pages render a fully opaque background over the fixed WebGL canvas, so the fluid sim is never actually visible there. It only cost the `webgl-fluid-enhanced` chunk download plus GPU/main-thread work during the LCP window. It's now skipped on those routes (Footer still renders).
- **Simplify refund-policy header** — `LegalHeader` title reduced from a JSX fragment to a plain string.

## Test plan

- [ ] Verify `/contact` and `/about` render correctly with hero/intro visible immediately
- [ ] Confirm card/section scroll animations still work below the fold
- [ ] Confirm refund-policy header renders unchanged
- [ ] Check Lighthouse/LCP improvement on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)