### PR TITLE
feat(earn): hand off to social-auth after OTP verify

### DIFF
--- a/app/creator/earn/CreatorEarnPage.tsx
+++ b/app/creator/earn/CreatorEarnPage.tsx
@@ -39,7 +39,7 @@ function CreatorEarnPageContent() {
   // and LCP element paint from the SSR HTML rather than waiting on hydration.
 
   return (
-    <SignupProvider>
+    <SignupProvider socialAuthAfterVerify>
       <main className="relative min-h-screen bg-black overflow-hidden">
         {/* Background Gradients — tuned to reach the end of the FAQ
             (the "View All" / "Show Less" toggle), so bg-black only

--- a/components/creator/promo/PromoSignupCard.tsx
+++ b/components/creator/promo/PromoSignupCard.tsx
@@ -103,6 +103,7 @@ export default function PromoSignupCard({
     submitProfile,
     changeNumber,
     verifyOtp,
+    goToSocialAuth,
   } = useSignup();
 
   // Pretty-print the entered E.164 phone for the earn-variant OTP header
@@ -164,7 +165,13 @@ export default function PromoSignupCard({
   })();
 
   const otpVisible =
-    stage === "otp" || stage === "profile" || stage === "submitting" || stage === "submitted";
+    stage === "otp" ||
+    stage === "profile" ||
+    stage === "submitting" ||
+    stage === "submitted" ||
+    // Earn flow post-verify panel — keeps the OTP row (with the green
+    // "Verified" pill) visible above the social-auth CTA.
+    stage === "social";
   // Returning users (requires_basic_info=false) skip the profile sheet entirely;
   // /verify runs straight from the OTP stage with no name/email payload.
   const profileVisible =
@@ -669,6 +676,43 @@ export default function PromoSignupCard({
                 disabled={verifyStatus === "verifying"}
                 t={t}
               />
+            </div>
+          )}
+
+          {/* Post-verify social handoff — replaces the profile form + app
+              redirect for the earn flow. Heading + "3 steps" subtext sit above
+              a white gradient-bordered CTA (mirrors the promo "Create account"
+              button) that hands off to social-auth, with the Meta/YouTube
+              partner footer beneath. */}
+          {stage === "social" && (
+            <div className="mt-4 flex flex-col items-center px-2 text-center">
+              <p className="text-white text-[15px] font-semibold leading-tight">
+                {t("hero.card.socialTitle")}
+              </p>
+              <p className="mt-1 text-white/80 text-[12px] leading-snug">
+                {t("hero.card.socialSubtitle")}
+              </p>
+
+              <button
+                type="button"
+                onClick={goToSocialAuth}
+                className="relative mt-3 w-full inline-flex items-center justify-center overflow-hidden rounded-full p-[1px] shadow-[0_4px_12px_rgba(129,52,165,0.18)] transition-[opacity] duration-200"
+              >
+                <span
+                  aria-hidden="true"
+                  className="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#ffffff_0%,rgba(221,42,123,1)_10%,rgba(151,71,255,1)_50%,rgba(221,42,123,0.5)_90%,#ffffff_100%)]"
+                />
+                <span className="relative z-10 inline-flex w-full items-center justify-center rounded-full bg-white py-3 text-sm font-semibold">
+                  <span className="bg-[linear-gradient(162.34deg,#DD2A7B_4.78%,#9747FF_89.95%)] bg-clip-text text-transparent">
+                    {t("hero.card.socialCta")}
+                  </span>
+                </span>
+              </button>
+
+              {/* Unlabeled: the Meta/YouTube PNGs already bake in the
+                  "Built with" / "Developed with" wordmarks, so passing labels
+                  here would render the text twice. */}
+              <PartnerFooter />
             </div>
           )}
         </div>

--- a/components/creator/promo/SignupContext.tsx
+++ b/components/creator/promo/SignupContext.tsx
@@ -18,7 +18,7 @@ import {
   verify,
 } from "@/lib/auth/api";
 import { AuthApiError, type MessageCode } from "@/lib/auth/errors";
-import { redirectToApp } from "@/lib/auth/redirect";
+import { redirectToApp, redirectToSocialAuth } from "@/lib/auth/redirect";
 import { getCurrentLang } from "@/lib/i18n";
 import { track } from "@/lib/analytics/track";
 import { clearStoredUtm, readUtmParams } from "@/lib/utm";
@@ -29,7 +29,11 @@ export type SignupStage =
   | "otp"
   | "profile"
   | "submitting"
-  | "submitted";
+  | "submitted"
+  // Earn flow only (socialAuthAfterVerify). Reached straight from a successful
+  // OTP verify — the profile form and app redirect are skipped; the card shows
+  // a "Verify your social account" panel whose CTA hands off to social-auth.
+  | "social";
 
 export type VerifyStatus = "idle" | "verifying" | "verified" | "error";
 
@@ -68,6 +72,9 @@ interface SignupContextValue {
   // for explicit "Verify" buttons (e.g. /creator/earn Stage 2). Re-entry is
   // guarded by verifyingRef so double calls are safe.
   verifyOtp: () => Promise<void>;
+  // Hand off to the social-account verification host. Only meaningful in the
+  // earn flow (stage === "social"); wired to the "Verify Social & Continue" CTA.
+  goToSocialAuth: () => void;
 }
 
 const SignupContext = createContext<SignupContextValue | null>(null);
@@ -86,7 +93,16 @@ const OTP_EXPIRY_MS = 290_000;
 const DEFAULT_CHANNELS: Array<"whatsapp"> = ["whatsapp"];
 const REFERRAL_STORAGE_KEY = "promo_ref";
 
-export function SignupProvider({ children }: { children: React.ReactNode }) {
+export function SignupProvider({
+  children,
+  socialAuthAfterVerify = false,
+}: {
+  children: React.ReactNode;
+  // When true (earn page), a successful OTP verify lands on the "social" stage
+  // instead of the profile form / app redirect. Other promo pages omit this and
+  // keep the original new-user→profile, returning-user→app behaviour.
+  socialAuthAfterVerify?: boolean;
+}) {
   const { t, i18n } = useTranslation("creatorPromo");
 
   const [phone, setPhone] = useState("");
@@ -405,6 +421,23 @@ export function SignupProvider({ children }: { children: React.ReactNode }) {
         setVerifyStatus("verified");
         track("promo_otp_verified", { creator_id: creatorId });
 
+        if (socialAuthAfterVerify) {
+          // Earn flow: skip the profile form and the app redirect entirely.
+          // The card swaps to the "Verify your social account" panel, whose
+          // CTA hands off to social-auth via goToSocialAuth.
+          //
+          // No VERIFIED_HOLD here: flipping to "social" in the SAME synchronous
+          // batch as verifyStatus="verified" makes the resend-row removal and
+          // the panel mount net out to a single grow. With the hold, the two
+          // landed in separate renders 150ms apart — the layout animation
+          // shrank (resend row gone) then expanded (panel in), reading as a
+          // mid-collapse bounce. The green "Verified" pill above the panel is
+          // still visible, so we don't lose the success beat.
+          clearStoredUtm();
+          setStage((current) => (current === "otp" ? "social" : current));
+          return;
+        }
+
         await new Promise((r) => setTimeout(r, VERIFIED_HOLD_MS));
 
         if (requiresBasicInfo) {
@@ -460,12 +493,18 @@ export function SignupProvider({ children }: { children: React.ReactNode }) {
       utmSource,
       utmMedium,
       requiresBasicInfo,
+      socialAuthAfterVerify,
       i18n,
       clearExpiryTimer,
       reportSignupError,
       t,
     ],
   );
+
+  const goToSocialAuth = useCallback(() => {
+    track("promo_social_auth_continue", { creator_id: creatorId });
+    redirectToSocialAuth();
+  }, [creatorId]);
 
   // Auto-verify when the 4th digit lands. Calls /auth/verify with just
   // {user_id, otp, referral_code} per the new contract — basic info is
@@ -525,6 +564,7 @@ export function SignupProvider({ children }: { children: React.ReactNode }) {
       submitProfile: handleSubmitProfile,
       changeNumber,
       verifyOtp,
+      goToSocialAuth,
     }),
     [
       phone,
@@ -544,6 +584,7 @@ export function SignupProvider({ children }: { children: React.ReactNode }) {
       handleSubmitProfile,
       changeNumber,
       verifyOtp,
+      goToSocialAuth,
     ],
   );
 

--- a/lib/auth/redirect.ts
+++ b/lib/auth/redirect.ts
@@ -16,3 +16,14 @@ export function redirectToApp(args: RedirectToAppArgs): void {
   if (args.referralCode) url.searchParams.set("ref", args.referralCode);
   window.location.href = url.toString();
 }
+
+// Social-account verification handoff. The earn flow sends the user here after
+// OTP verify instead of straight into the app — they finish the 3-step social
+// check on this host. Auth cookies set by /verify are scoped to
+// .sparkonomy.com, so the session carries across the subdomain.
+export const SOCIAL_AUTH_URL = "https://dev.creator.sparkonomy.com/social-auth";
+
+export function redirectToSocialAuth(): void {
+  if (typeof window === "undefined") return;
+  window.location.href = SOCIAL_AUTH_URL;
+}

--- a/public/locales/en/creatorEarn.json
+++ b/public/locales/en/creatorEarn.json
@@ -24,6 +24,9 @@
       "verify": "Verify",
       "verifying": "Verifying",
       "verified": "Verified",
+      "socialTitle": "Verify your social account",
+      "socialSubtitle": "3 steps to unlock your rewards",
+      "socialCta": "Verify Social & Continue",
       "disclaimer": "By tapping, you agree to create an account and Sparkonomy's <0>Terms</0> and <1>Privacy Policy</1>."
     }
   },

--- a/public/locales/hi-Latn/creatorEarn.json
+++ b/public/locales/hi-Latn/creatorEarn.json
@@ -24,6 +24,9 @@
       "verify": "Verify",
       "verifying": "Verifying",
       "verified": "Verified",
+      "socialTitle": "Apna social account verify karein",
+      "socialSubtitle": "Rewards unlock karne ke liye 3 steps",
+      "socialCta": "Verify Social & Continue",
       "disclaimer": "By tapping, you agree to create an account and Sparkonomy's <0>Terms</0> and <1>Privacy Policy</1>."
     }
   },


### PR DESCRIPTION
## Summary

Adds a post-OTP-verify **social-account handoff** to the creator earn flow. When `socialAuthAfterVerify` is enabled (only on `/creator/earn`), a successful OTP verify now lands on a new `social` stage that replaces the profile form + app redirect with a "Verify your social account" panel. Its CTA hands off to the social-auth host.

## Changes

- **`SignupContext.tsx`** — new `social` signup stage, `goToSocialAuth()`, and a gated branch in `verify` that, for the earn flow, skips the profile sheet and app redirect and flips straight to `social` (no `VERIFIED_HOLD`, to avoid a mid-collapse layout bounce). Other promo pages keep the original new-user→profile / returning-user→app behaviour.
- **`PromoSignupCard.tsx`** — post-verify social panel with a gradient-bordered CTA (mirrors the promo "Create account" button) and the Meta/YouTube partner footer; the OTP "Verified" row stays visible above it.
- **`lib/auth/redirect.ts`** — `redirectToSocialAuth()` + `SOCIAL_AUTH_URL`. Auth cookies set by `/verify` are scoped to `.sparkonomy.com`, so the session carries across the subdomain.
- **`CreatorEarnPage.tsx`** — passes `socialAuthAfterVerify` to `SignupProvider`.
- **Copy** — `en` and `hi-Latn` strings for the social panel (title / subtitle / CTA).

## Notes

- `SOCIAL_AUTH_URL` currently points at `dev.creator.sparkonomy.com/social-auth` — confirm before promoting beyond dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)