### PR TITLE
feat(blog): implement pagination for blog categories and enhance metadata generation

### DIFF
--- a/app/blogs/brand/page.tsx
+++ b/app/blogs/brand/page.tsx
@@ -1,11 +1,15 @@
 import type { Metadata } from "next";
-import { CategoryBlogTemplate, CATEGORY_CONFIGS } from "@/components/blog/common";
+import { CategoryBlogTemplate, CATEGORY_CONFIGS, parseBlogPage, withPagedListingMetadata } from "@/components/blog/common";
 
 export const revalidate = 300;
 
 const config = CATEGORY_CONFIGS.brand;
 
-export const metadata: Metadata = {
+interface CategoryPageProps {
+  searchParams: Promise<{ page?: string }>;
+}
+
+const baseMetadata: Metadata = {
   metadataBase: new URL("https://www.sparkonomy.com/"),
   title: "Brand | Sparkonomy Blog",
   description: "Insights and updates for brands on Sparkonomy",
@@ -46,6 +50,12 @@ export const metadata: Metadata = {
   },
 };
 
-export default function BrandPage() {
-  return <CategoryBlogTemplate config={config} />;
+export async function generateMetadata({ searchParams }: CategoryPageProps): Promise<Metadata> {
+  const page = parseBlogPage((await searchParams).page);
+  return withPagedListingMetadata(baseMetadata, "https://www.sparkonomy.com/blogs/brand", page);
+}
+
+export default async function BrandPage({ searchParams }: CategoryPageProps) {
+  const page = parseBlogPage((await searchParams).page);
+  return <CategoryBlogTemplate config={config} currentPage={page} />;
 }

--- a/app/blogs/company/page.tsx
+++ b/app/blogs/company/page.tsx
@@ -1,11 +1,15 @@
 import type { Metadata } from "next";
-import { CategoryBlogTemplate, CATEGORY_CONFIGS } from "@/components/blog/common";
+import { CategoryBlogTemplate, CATEGORY_CONFIGS, parseBlogPage, withPagedListingMetadata } from "@/components/blog/common";
 
 export const revalidate = 300;
 
 const config = CATEGORY_CONFIGS.company;
 
-export const metadata: Metadata = {
+interface CategoryPageProps {
+  searchParams: Promise<{ page?: string }>;
+}
+
+const baseMetadata: Metadata = {
   metadataBase: new URL("https://www.sparkonomy.com/"),
   title: "Company | Sparkonomy Blog",
   description: "Company news and updates from Sparkonomy",
@@ -46,6 +50,12 @@ export const metadata: Metadata = {
   },
 };
 
-export default function CompanyPage() {
-  return <CategoryBlogTemplate config={config} />;
+export async function generateMetadata({ searchParams }: CategoryPageProps): Promise<Metadata> {
+  const page = parseBlogPage((await searchParams).page);
+  return withPagedListingMetadata(baseMetadata, "https://www.sparkonomy.com/blogs/company", page);
+}
+
+export default async function CompanyPage({ searchParams }: CategoryPageProps) {
+  const page = parseBlogPage((await searchParams).page);
+  return <CategoryBlogTemplate config={config} currentPage={page} />;
 }

--- a/app/blogs/creators/page.tsx
+++ b/app/blogs/creators/page.tsx
@@ -1,11 +1,15 @@
 import type { Metadata } from "next";
-import { CategoryBlogTemplate, CATEGORY_CONFIGS } from "@/components/blog/common";
+import { CategoryBlogTemplate, CATEGORY_CONFIGS, parseBlogPage, withPagedListingMetadata } from "@/components/blog/common";
 
 export const revalidate = 300;
 
 const config = CATEGORY_CONFIGS.creators;
 
-export const metadata: Metadata = {
+interface CategoryPageProps {
+  searchParams: Promise<{ page?: string }>;
+}
+
+const baseMetadata: Metadata = {
   metadataBase: new URL("https://www.sparkonomy.com/"),
   title: "Creators & Influencers | Sparkonomy Blog - Tips for YouTubers, Instagrammers & Social Media Influencers",
   description: "Insights, tips and updates for Creators, influencers, YouTubers, Instagrammers and social media influencers. Grow your audience and monetize your content with Sparkonomy.",
@@ -60,6 +64,12 @@ export const metadata: Metadata = {
   },
 };
 
-export default function CreatorsPage() {
-  return <CategoryBlogTemplate config={config} />;
+export async function generateMetadata({ searchParams }: CategoryPageProps): Promise<Metadata> {
+  const page = parseBlogPage((await searchParams).page);
+  return withPagedListingMetadata(baseMetadata, "https://www.sparkonomy.com/blogs/creators", page);
+}
+
+export default async function CreatorsPage({ searchParams }: CategoryPageProps) {
+  const page = parseBlogPage((await searchParams).page);
+  return <CategoryBlogTemplate config={config} currentPage={page} />;
 }

--- a/app/blogs/page.tsx
+++ b/app/blogs/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import Card from "@/components/blog/BlogCard";
 import FeaturedBlogCard from "@/components/blog/FeaturedBlogCard";
 import BlogPostsSkeleton from "@/components/blog/BlogPostsSkeleton";
+import BlogPagination from "@/components/blog/BlogPagination";
 import MainSection from "@/components/blog/MainSection";
 import MainSectionSkeleton from "@/components/blog/MainSectionSkeleton";
 import NewsletterSection from "@/components/blog/NewsletterSection";
@@ -10,67 +11,88 @@ import { getPosts, getPostsByCategory, getCategoryBySlug, getPostTags, decodeHtm
 
 export const revalidate = 300;
 
-export const metadata: Metadata = {
-  metadataBase: new URL("https://www.sparkonomy.com/"),
-  title: "Blog | Sparkonomy - Tips for Creators, Influencers, YouTubers & Instagrammers",
-  description: "Discover the latest insights, tips, and strategies for Creators, influencers, YouTubers & Instagrammers to monetize content, grow their audience, and succeed in the Creator economy. Expert guides from Sparkonomy.",
-  keywords: [
-    "creator economy",
-    "content monetization",
-    "creator tips",
-    "influencer tips",
-    "passive income",
-    "influencer marketing",
-    "content creation",
-    "digital creators",
-    "social media influencers",
-    "instagrammers",
-    "youtubers",
-    "instagram influencer tips",
-    "youtube creator tips",
-    "content creator monetization",
-    "influencer platform",
-    "Sparkonomy blog",
-  ],
-  authors: [{ name: "Sparkonomy Team" }],
-  creator: "Sparkonomy",
-  publisher: "Sparkonomy",
-  alternates: {
-    canonical: "https://www.sparkonomy.com/blogs",
-  },
-  robots: {
-    index: true,
-    follow: true,
-    googleBot: {
+// Posts shown in the grid per page. The page-1 hero + featured Company tile are
+// rendered on top of this and are not counted toward the per-page grid window.
+const POSTS_PER_PAGE = 12;
+const BLOG_URL = "https://www.sparkonomy.com/blogs";
+
+interface BlogsPageProps {
+  searchParams: Promise<{ page?: string }>;
+}
+
+// Parse ?page into a positive integer, defaulting to 1 for missing/garbage input.
+function parsePage(raw: string | undefined): number {
+  const n = parseInt(raw ?? "1", 10);
+  return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+export async function generateMetadata({ searchParams }: BlogsPageProps): Promise<Metadata> {
+  const currentPage = parsePage((await searchParams).page);
+  const canonical = currentPage > 1 ? `${BLOG_URL}?page=${currentPage}` : BLOG_URL;
+  const titleSuffix = currentPage > 1 ? ` - Page ${currentPage}` : "";
+
+  return {
+    metadataBase: new URL("https://www.sparkonomy.com/"),
+    title: `Blog${titleSuffix} | Sparkonomy - Tips for Creators, Influencers, YouTubers & Instagrammers`,
+    description: "Discover the latest insights, tips, and strategies for Creators, influencers, YouTubers & Instagrammers to monetize content, grow their audience, and succeed in the Creator economy. Expert guides from Sparkonomy.",
+    keywords: [
+      "creator economy",
+      "content monetization",
+      "creator tips",
+      "influencer tips",
+      "passive income",
+      "influencer marketing",
+      "content creation",
+      "digital creators",
+      "social media influencers",
+      "instagrammers",
+      "youtubers",
+      "instagram influencer tips",
+      "youtube creator tips",
+      "content creator monetization",
+      "influencer platform",
+      "Sparkonomy blog",
+    ],
+    authors: [{ name: "Sparkonomy Team" }],
+    creator: "Sparkonomy",
+    publisher: "Sparkonomy",
+    alternates: {
+      canonical,
+    },
+    robots: {
       index: true,
       follow: true,
-    },
-  },
-  openGraph: {
-    siteName: "Sparkonomy",
-    title: "Blog | Sparkonomy - Tips for Creators, Influencers & YouTubers",
-    description: "Insights, tips & strategies for Creators, influencers, YouTubers & Instagrammers to monetize content and succeed in the Creator economy.",
-    url: "https://www.sparkonomy.com/blogs",
-    type: "website",
-    locale: "en_US",
-    images: [
-      {
-        url: "https://www.sparkonomy.com/sparkonomy.png",
-        width: 1200,
-        height: 630,
-        alt: "Sparkonomy Blog",
+      googleBot: {
+        index: true,
+        follow: true,
       },
-    ],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Blog | Sparkonomy - Tips for Creators, Influencers & YouTubers",
-    description: "Insights, tips & strategies for Creators, influencers, YouTubers & Instagrammers to monetize content and succeed in the Creator economy.",
-    images: ["https://www.sparkonomy.com/sparkonomy.png"],
-    creator: "@sparkonomy",
-    site: "@sparkonomy",
-  },
-};
+    },
+    openGraph: {
+      siteName: "Sparkonomy",
+      title: "Blog | Sparkonomy - Tips for Creators, Influencers & YouTubers",
+      description: "Insights, tips & strategies for Creators, influencers, YouTubers & Instagrammers to monetize content and succeed in the Creator economy.",
+      url: canonical,
+      type: "website",
+      locale: "en_US",
+      images: [
+        {
+          url: "https://www.sparkonomy.com/sparkonomy.png",
+          width: 1200,
+          height: 630,
+          alt: "Sparkonomy Blog",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: "Blog | Sparkonomy - Tips for Creators, Influencers & YouTubers",
+      description: "Insights, tips & strategies for Creators, influencers, YouTubers & Instagrammers to monetize content and succeed in the Creator economy.",
+      images: ["https://www.sparkonomy.com/sparkonomy.png"],
+      creator: "@sparkonomy",
+      site: "@sparkonomy",
+    },
+  };
+}
 
 // Latest posts from the Company category (slugs match the /blogs/company page config).
 async function getLatestCompanyPosts() {
@@ -83,20 +105,24 @@ async function getLatestCompanyPosts() {
   return data.filter((p) => !p.slug.endsWith("-hi"));
 }
 
-async function BlogPosts() {
-  // Pull a bit extra to absorb the Hinglish counterparts we filter out below.
-  const [{ data: rawPosts }, companyPosts] = await Promise.all([
-    getPosts(1, 26),
+async function getEnglishPosts() {
+  const { data } = await getPosts(1, 100);
+  return data.filter((p) => !p.slug.endsWith("-hi"));
+}
+
+const dateLabel = (iso: string) =>
+  new Date(iso).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+
+const cardImage = (p: { _embedded?: any; yoast_head_json?: any }) =>
+  p._embedded?.["wp:featuredmedia"]?.[0]?.source_url || p.yoast_head_json?.og_image?.[0]?.url;
+
+async function BlogPosts({ currentPage }: { currentPage: number }) {
+  const [englishPosts, companyPosts] = await Promise.all([
+    getEnglishPosts(),
     getLatestCompanyPosts(),
   ]);
-  const allPosts = rawPosts.filter((p) => !p.slug.endsWith("-hi"));
-  // Featured horizontal tile always shows the latest Company post — skipping the
-  // overall-latest post, which is already shown in the hero above.
-  const companyPost = companyPosts.find((p) => p.id !== allPosts[0]?.id) ?? null;
-  
-  const posts = allPosts.filter((p) => p.id !== companyPost?.id).slice(0, 13);
 
-  if (posts.length === 0) {
+  if (englishPosts.length === 0) {
     return (
       <div className="text-center py-20 bg-gray-50 rounded-2xl border border-gray-200">
         <h2 className="text-2xl font-semibold text-gray-900 mb-3">No blog posts yet</h2>
@@ -107,76 +133,89 @@ async function BlogPosts() {
     );
   }
 
-  const heroPost = posts[0];
-  const firstRowPosts = posts.slice(1, 4);
-  // Company post owns the featured tile; fall back to the next grid post if none exists.
-  const secondRowPost = companyPost ? [companyPost] : posts.slice(4, 5);
-  const remainingPosts = companyPost ? posts.slice(4) : posts.slice(5);
+
+  const heroPost = englishPosts[0];
+  const companyPost = companyPosts.find((p) => p.id !== heroPost.id) ?? null;
+  const gridPool = englishPosts.filter(
+    (p) => p.id !== heroPost.id && p.id !== companyPost?.id
+  );
+
+  const totalPages = Math.max(1, Math.ceil(gridPool.length / POSTS_PER_PAGE));
+  const safePage = Math.min(currentPage, totalPages);
+  const isFirstPage = safePage === 1;
+  const start = (safePage - 1) * POSTS_PER_PAGE;
+  const pagePosts = gridPool.slice(start, start + POSTS_PER_PAGE);
+
+  // Page 1 keeps the editorial layout (3-card row → featured Company tile →
+  // remaining grid). Later pages render a plain grid of the page's posts.
+  const firstRowPosts = isFirstPage ? pagePosts.slice(0, 3) : [];
+  const remainingPosts = isFirstPage ? pagePosts.slice(3) : pagePosts;
 
   return (
     <>
-      {/* Container for First Row */}
-      <div className="max-w-7xl mx-auto px-4 ">
-        {/* First Row - 3 vertical cards */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:mb-12">
-          {firstRowPosts.map((p) => (
-            <Card
-              key={p.id}
-              title={decodeHtmlEntities(p.title.rendered)}
-              description={decodeHtmlEntities(p.excerpt.rendered)}
-              imageSrc={p._embedded?.['wp:featuredmedia']?.[0]?.source_url || p.yoast_head_json?.og_image?.[0]?.url}
-              href={`/blogs/${p.slug}`}
-              layout="vertical"
-              descriptionPosition="bottom"
-              imagePriority={true}
-              showReadMore={true}
-              meta={
-                <span>{new Date(p.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</span>
-              }
-            />
-          ))}
-        </div>
-      </div>
+      {isFirstPage && (
+        <>
+          {/* First Row - 3 vertical cards */}
+          <div className="max-w-7xl mx-auto px-4 ">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:mb-12">
+              {firstRowPosts.map((p) => (
+                <Card
+                  key={p.id}
+                  title={decodeHtmlEntities(p.title.rendered)}
+                  description={decodeHtmlEntities(p.excerpt.rendered)}
+                  imageSrc={cardImage(p)}
+                  href={`/blogs/${p.slug}`}
+                  layout="vertical"
+                  descriptionPosition="bottom"
+                  imagePriority={true}
+                  showReadMore={true}
+                  meta={<span>{dateLabel(p.date)}</span>}
+                />
+              ))}
+            </div>
+          </div>
 
-      {/* Second Row - 1 featured horizontal card (full width, no container) */}
-      <div className="w-full md:mb-12">
-        {secondRowPost.map((p) => (
-          <FeaturedBlogCard
-            key={p.id}
-            title={decodeHtmlEntities(p.title.rendered)}
-            description={decodeHtmlEntities(p.excerpt.rendered)}
-            imageSrc={p._embedded?.['wp:featuredmedia']?.[0]?.source_url || p.yoast_head_json?.og_image?.[0]?.url}
-            href={`/blogs/${p.slug}`}
-            tag="Company"
-            imagePriority={true}
-            meta={
-              <span>{new Date(p.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</span>
-            }
-          />
-        ))}
-      </div>
+          {/* Second Row - 1 featured horizontal card (full width, no container) */}
+          {companyPost && (
+            <div className="w-full md:mb-12">
+              <FeaturedBlogCard
+                key={companyPost.id}
+                title={decodeHtmlEntities(companyPost.title.rendered)}
+                description={decodeHtmlEntities(companyPost.excerpt.rendered)}
+                imageSrc={cardImage(companyPost)}
+                href={`/blogs/${companyPost.slug}`}
+                tag="Company"
+                imagePriority={true}
+                meta={<span>{dateLabel(companyPost.date)}</span>}
+              />
+            </div>
+          )}
+        </>
+      )}
 
-      {/* Container for Remaining Rows */}
+      {/* Grid of posts for this page */}
       <div className="max-w-7xl mx-auto px-4">
-        {/* Remaining Rows - 3 vertical cards per row */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {remainingPosts.map((p) => (
             <Card
               key={p.id}
               title={decodeHtmlEntities(p.title.rendered)}
               description={decodeHtmlEntities(p.excerpt.rendered)}
-              imageSrc={p._embedded?.['wp:featuredmedia']?.[0]?.source_url || p.yoast_head_json?.og_image?.[0]?.url}
+              imageSrc={cardImage(p)}
               href={`/blogs/${p.slug}`}
               layout="vertical"
               descriptionPosition="bottom"
               imagePriority={false}
               showReadMore={true}
-              meta={
-                <span>{new Date(p.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</span>
-              }
+              meta={<span>{dateLabel(p.date)}</span>}
             />
           ))}
         </div>
+      </div>
+
+      {/* Pagination */}
+      <div className="max-w-7xl mx-auto px-4 mt-12">
+        <BlogPagination currentPage={safePage} totalPages={totalPages} />
       </div>
     </>
   );
@@ -221,7 +260,9 @@ async function HeroSection() {
   );
 }
 
-export default function Home() {
+export default async function Home({ searchParams }: BlogsPageProps) {
+  const currentPage = parsePage((await searchParams).page);
+
   // Blog structured data for listing page
   const blogJsonLd = {
     "@context": "https://schema.org",
@@ -275,12 +316,14 @@ export default function Home() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
 
-      {/* Main Section with Background Image */}
-      <div className="relative z-10">
-        <Suspense fallback={<MainSectionSkeleton />}>
-          <HeroSection />
-        </Suspense>
-      </div>
+      {/* Main Section with Background Image — hero only leads the first page */}
+      {currentPage === 1 && (
+        <div className="relative z-10">
+          <Suspense fallback={<MainSectionSkeleton />}>
+            <HeroSection />
+          </Suspense>
+        </div>
+      )}
 
       {/* Blog Posts Section with Gradient Background */}
       <div className="relative py-12" id="posts">
@@ -294,8 +337,8 @@ export default function Home() {
         />
 
         <div className="relative z-10">
-          <Suspense fallback={<BlogPostsSkeleton />}>
-            <BlogPosts />
+          <Suspense key={currentPage} fallback={<BlogPostsSkeleton />}>
+            <BlogPosts currentPage={currentPage} />
           </Suspense>
         </div>
       </div>

--- a/app/blogs/wordpress-content.css
+++ b/app/blogs/wordpress-content.css
@@ -2349,6 +2349,23 @@
   color: #5b21b6;
 }
 
+.wordpress-content p a,
+.wordpress-content li a,
+.wordpress-content td a,
+.wordpress-content th a {
+  color: #8b5cf6;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color 0.2s ease;
+}
+
+.wordpress-content p a:hover,
+.wordpress-content li a:hover,
+.wordpress-content td a:hover,
+.wordpress-content th a:hover {
+  color: #7c3aed;
+}
+
 /* Legacy pro-tip-box support */
 .wordpress-content .pro-tip-box {
   background: linear-gradient(135deg, #f5f3ff 0%, #ede9fe 100%);

--- a/components/blog/BlogPagination.tsx
+++ b/components/blog/BlogPagination.tsx
@@ -1,0 +1,125 @@
+import Link from "next/link";
+
+interface BlogPaginationProps {
+  currentPage: number;
+  totalPages: number;
+  /** Route the pagination links point at. Defaults to the blog listing. */
+  basePath?: string;
+}
+
+
+function pageHref(basePath: string, page: number): string {
+  return page <= 1 ? `${basePath}#posts` : `${basePath}?page=${page}#posts`;
+}
+
+
+function buildPageItems(currentPage: number, totalPages: number): (number | "…")[] {
+  const items: (number | "…")[] = [];
+  const pushRange = (start: number, end: number) => {
+    for (let p = start; p <= end; p++) items.push(p);
+  };
+
+  if (totalPages <= 7) {
+    pushRange(1, totalPages);
+    return items;
+  }
+
+  const windowStart = Math.max(2, currentPage - 1);
+  const windowEnd = Math.min(totalPages - 1, currentPage + 1);
+
+  items.push(1);
+  if (windowStart > 2) items.push("…");
+  pushRange(windowStart, windowEnd);
+  if (windowEnd < totalPages - 1) items.push("…");
+  items.push(totalPages);
+  return items;
+}
+
+export default function BlogPagination({
+  currentPage,
+  totalPages,
+  basePath = "/blogs",
+}: BlogPaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const items = buildPageItems(currentPage, totalPages);
+  const hasPrev = currentPage > 1;
+  const hasNext = currentPage < totalPages;
+
+  const baseLink =
+    "inline-flex items-center justify-center min-w-[40px] h-10 px-3 rounded-lg text-sm font-medium transition-colors";
+
+  return (
+    <nav
+      aria-label="Blog pagination"
+      className="flex items-center justify-center gap-2 flex-wrap"
+    >
+      {/* Previous */}
+      {hasPrev ? (
+        <Link
+          href={pageHref(basePath, currentPage - 1)}
+          rel="prev"
+          aria-label="Previous page"
+          className={`${baseLink} text-gray-700 border border-gray-200 hover:border-purple-400 hover:text-purple-600`}
+        >
+          ←
+        </Link>
+      ) : (
+        <span
+          aria-disabled="true"
+          className={`${baseLink} text-gray-300 border border-gray-100 cursor-not-allowed`}
+        >
+          ←
+        </span>
+      )}
+
+      {/* Page numbers */}
+      {items.map((item, i) =>
+        item === "…" ? (
+          <span
+            key={`gap-${i}`}
+            className="inline-flex items-center justify-center min-w-[40px] h-10 text-gray-400"
+          >
+            …
+          </span>
+        ) : item === currentPage ? (
+          <span
+            key={item}
+            aria-current="page"
+            className={`${baseLink} bg-purple-600 text-white`}
+          >
+            {item}
+          </span>
+        ) : (
+          <Link
+            key={item}
+            href={pageHref(basePath, item)}
+            aria-label={`Page ${item}`}
+            className={`${baseLink} text-gray-700 border border-gray-200 hover:border-purple-400 hover:text-purple-600`}
+          >
+            {item}
+          </Link>
+        )
+      )}
+
+      {/* Next */}
+      {hasNext ? (
+        <Link
+          href={pageHref(basePath, currentPage + 1)}
+          rel="next"
+          aria-label="Next page"
+          className={`${baseLink} text-gray-700 border border-gray-200 hover:border-purple-400 hover:text-purple-600`}
+        >
+          →
+        </Link>
+      ) : (
+        <span
+          aria-disabled="true"
+          className={`${baseLink} text-gray-300 border border-gray-100 cursor-not-allowed`}
+        >
+          →
+        </span>
+      )}
+    </nav>
+  );
+}

--- a/components/blog/common/CategoryBlogTemplate.tsx
+++ b/components/blog/common/CategoryBlogTemplate.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
 import { getCategoryBySlug, getPostsByCategory, getPostTags, decodeHtmlEntities } from "@/lib/wordpress-improved";
 import BlogCard from "@/components/blog/BlogCard";
 import FeaturedBlogCard from "@/components/blog/FeaturedBlogCard";
@@ -7,17 +8,47 @@ import FeaturedBlogCardSkeleton from "@/components/blog/FeaturedBlogCardSkeleton
 import MainSection from "@/components/blog/MainSection";
 import MainSectionSkeleton from "@/components/blog/MainSectionSkeleton";
 import NewsletterSection from "@/components/blog/NewsletterSection";
+import BlogPagination from "@/components/blog/BlogPagination";
 import NoPostsPlaceholder from "./NoPostsPlaceholder";
+
+// Posts shown in the grid per page. The page-1 hero + featured tile sit on top of
+// this window and aren't counted toward it (matches the /blogs home behaviour).
+const POSTS_PER_PAGE = 12;
 
 // Configuration for each category
 export interface CategoryConfig {
   slugs: string[];
+  /** Route the category lives at, e.g. "/blogs/creators" — used for pagination links + canonical. */
+  basePath: string;
   title: string;
   subtitle: string;
   description: string;
   defaultHashtags: string[];
   gradient: string;
   noPostsMessage?: string;
+}
+
+// Parse ?page into a positive integer, defaulting to 1 for missing/garbage input.
+export function parseBlogPage(raw: string | undefined): number {
+  const n = parseInt(raw ?? "1", 10);
+  return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+// Adjust a base Metadata for a paginated listing: self-referencing canonical with
+// ?page, a " - Page N" title suffix, and a matching OG url. Page 1 is untouched.
+export function withPagedListingMetadata(
+  base: Metadata,
+  canonicalBase: string,
+  page: number
+): Metadata {
+  if (page <= 1) return base;
+  const canonical = `${canonicalBase}?page=${page}`;
+  return {
+    ...base,
+    title: typeof base.title === "string" ? `${base.title} - Page ${page}` : base.title,
+    alternates: { ...base.alternates, canonical },
+    openGraph: base.openGraph ? { ...base.openGraph, url: canonical } : base.openGraph,
+  };
 }
 
 // Resolve every slug in the config to a WordPress category ID, dropping any that don't exist.
@@ -46,15 +77,16 @@ function getFeaturedImage(post: any): string | undefined {
 }
 
 // Posts Grid Component
-async function CategoryPosts({ config }: { config: CategoryConfig }) {
+async function CategoryPosts({ config, currentPage }: { config: CategoryConfig; currentPage: number }) {
   const categoryIds = await resolveCategoryIds(config.slugs);
-  // Pull extra to absorb the Hinglish counterparts we filter out below (matches blogs home behavior).
+  // Fetch the full category once (WP caps per_page at 100) and paginate in memory,
+  // so the Hinglish filter below can't skew per-page counts (matches /blogs home).
   const { data: rawPosts } = categoryIds.length > 0
-    ? await getPostsByCategory(categoryIds, 1, 28)
+    ? await getPostsByCategory(categoryIds, 1, 100)
     : { data: [] };
-  const posts = rawPosts.filter((p) => !p.slug.endsWith("-hi")).slice(0, 14);
+  const englishPosts = rawPosts.filter((p) => !p.slug.endsWith("-hi"));
 
-  if (posts.length === 0) {
+  if (englishPosts.length === 0) {
     return (
       <div className="text-center py-20 bg-gray-50 rounded-2xl border border-gray-200 mx-4">
         <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-gray-100 mb-6">
@@ -87,55 +119,68 @@ async function CategoryPosts({ config }: { config: CategoryConfig }) {
     );
   }
 
-  // Skip first post (shown in hero), same structure as blogs page
-  const firstRowPosts = posts.slice(1, 4); // 3 vertical cards
-  const secondRowPost = posts.slice(4, 5); // 1 featured horizontal card
-  const remainingPosts = posts.slice(5);   // Remaining cards
+  // First post leads the hero banner (page 1 only, rendered by HeroSection); the
+  // rest form the paginated grid.
+  const gridPool = englishPosts.slice(1);
+
+  const totalPages = Math.max(1, Math.ceil(gridPool.length / POSTS_PER_PAGE));
+  const safePage = Math.min(currentPage, totalPages);
+  const isFirstPage = safePage === 1;
+  const start = (safePage - 1) * POSTS_PER_PAGE;
+  const pagePosts = gridPool.slice(start, start + POSTS_PER_PAGE);
+
+  // Page 1 keeps the editorial layout (3-card row → featured tile → remaining grid).
+  // Later pages render a plain grid of the page's posts.
+  const firstRowPosts = isFirstPage ? pagePosts.slice(0, 3) : [];
+  const featuredPost = isFirstPage ? pagePosts[3] : undefined;
+  const remainingPosts = isFirstPage ? pagePosts.slice(4) : pagePosts;
 
   return (
     <>
-      {/* Container for First Row */}
-      <div className="max-w-7xl mx-auto px-4">
-        {/* First Row - 3 vertical cards */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:mb-12">
-          {firstRowPosts.map((p) => (
-            <BlogCard
-              key={p.id}
-              title={decodeHtmlEntities(p.title.rendered)}
-              description={decodeHtmlEntities(p.excerpt.rendered)}
-              imageSrc={getFeaturedImage(p)}
-              href={`/blogs/${p.slug}`}
-              layout="vertical"
-              showReadMore={true}
-              imagePriority={true}
-              meta={<span>{formatDate(p.date)}</span>}
-            />
-          ))}
-        </div>
-      </div>
+      {isFirstPage && (
+        <>
+          {/* Container for First Row */}
+          <div className="max-w-7xl mx-auto px-4">
+            {/* First Row - 3 vertical cards */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:mb-12">
+              {firstRowPosts.map((p) => (
+                <BlogCard
+                  key={p.id}
+                  title={decodeHtmlEntities(p.title.rendered)}
+                  description={decodeHtmlEntities(p.excerpt.rendered)}
+                  imageSrc={getFeaturedImage(p)}
+                  href={`/blogs/${p.slug}`}
+                  layout="vertical"
+                  showReadMore={true}
+                  imagePriority={true}
+                  meta={<span>{formatDate(p.date)}</span>}
+                />
+              ))}
+            </div>
+          </div>
 
-      {/* Second Row - 1 horizontal featured card (full width) */}
-      {secondRowPost.length > 0 && (
-        <div className="w-full md:mb-12">
-          {secondRowPost.map((p) => (
-            <FeaturedBlogCard
-              key={p.id}
-              title={decodeHtmlEntities(p.title.rendered)}
-              description={decodeHtmlEntities(p.excerpt.rendered)}
-              imageSrc={getFeaturedImage(p)}
-              href={`/blogs/${p.slug}`}
-              tag="Featured"
-              imagePriority={true}
-              meta={<span>{formatDate(p.date)}</span>}
-            />
-          ))}
-        </div>
+          {/* Second Row - 1 horizontal featured card (full width) */}
+          {featuredPost && (
+            <div className="w-full md:mb-12">
+              <FeaturedBlogCard
+                key={featuredPost.id}
+                title={decodeHtmlEntities(featuredPost.title.rendered)}
+                description={decodeHtmlEntities(featuredPost.excerpt.rendered)}
+                imageSrc={getFeaturedImage(featuredPost)}
+                href={`/blogs/${featuredPost.slug}`}
+                tag="Featured"
+                imagePriority={true}
+                meta={<span>{formatDate(featuredPost.date)}</span>}
+              />
+            </div>
+          )}
+        </>
       )}
 
-      {/* Container for Remaining Rows */}
+      {/* Grid of posts for this page */}
       {remainingPosts.length > 0 && (
         <div className="max-w-7xl mx-auto px-4">
-          {/* Remaining Rows - 3 vertical cards per row */}
+          {/* 3 vertical cards per row */}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {remainingPosts.map((p) => (
               <BlogCard
@@ -153,6 +198,11 @@ async function CategoryPosts({ config }: { config: CategoryConfig }) {
           </div>
         </div>
       )}
+
+      {/* Pagination */}
+      <div className="max-w-7xl mx-auto px-4 mt-12">
+        <BlogPagination currentPage={safePage} totalPages={totalPages} basePath={config.basePath} />
+      </div>
     </>
   );
 }
@@ -228,17 +278,20 @@ async function HeroSection({ config }: { config: CategoryConfig }) {
 // Main Category Blog Page Template
 interface CategoryBlogTemplateProps {
   config: CategoryConfig;
+  currentPage?: number;
 }
 
-export default function CategoryBlogTemplate({ config }: CategoryBlogTemplateProps) {
+export default function CategoryBlogTemplate({ config, currentPage = 1 }: CategoryBlogTemplateProps) {
   return (
     <main className="relative overflow-hidden">
-      {/* Main Section with Background Image */}
-      <div className="relative z-10">
-        <Suspense fallback={<MainSectionSkeleton />}>
-          <HeroSection config={config} />
-        </Suspense>
-      </div>
+      {/* Main Section with Background Image — hero only leads the first page */}
+      {currentPage === 1 && (
+        <div className="relative z-10">
+          <Suspense fallback={<MainSectionSkeleton />}>
+            <HeroSection config={config} />
+          </Suspense>
+        </div>
+      )}
 
       {/* Blog Posts Section with Gradient Background */}
       <section className="relative py-16" id="posts">
@@ -252,8 +305,8 @@ export default function CategoryBlogTemplate({ config }: CategoryBlogTemplatePro
         />
 
         <div className="relative z-10">
-          <Suspense key={`${config.slugs.join(',')}-posts`} fallback={<BlogPostsSkeleton />}>
-            <CategoryPosts config={config} />
+          <Suspense key={`${config.slugs.join(',')}-${currentPage}`} fallback={<BlogPostsSkeleton />}>
+            <CategoryPosts config={config} currentPage={currentPage} />
           </Suspense>
         </div>
       </section>
@@ -268,6 +321,7 @@ export default function CategoryBlogTemplate({ config }: CategoryBlogTemplatePro
 export const CATEGORY_CONFIGS: Record<string, CategoryConfig> = {
   brand: {
     slugs: ["brand", "brand-en"],
+    basePath: "/blogs/brand",
     title: "Brand Insights & Marketing Strategies",
     subtitle: "For Brands",
     description: "Discover how top brands leverage creator partnerships to drive growth and engagement.",
@@ -277,6 +331,7 @@ export const CATEGORY_CONFIGS: Record<string, CategoryConfig> = {
   },
   creators: {
     slugs: ["creators", "creators-en"],
+    basePath: "/blogs/creators",
     title: "Creator Tips & Growth Strategies",
     subtitle: "For Creators",
     description: "Unlock your creative potential with tips, tools, and strategies for content creators.",
@@ -286,6 +341,7 @@ export const CATEGORY_CONFIGS: Record<string, CategoryConfig> = {
   },
   company: {
     slugs: ["company", "company-en"],
+    basePath: "/blogs/company",
     title: "Company News & Updates",
     subtitle: "Company",
     description: "Stay updated with the latest news, updates, and announcements from Sparkonomy.",

--- a/components/blog/common/index.ts
+++ b/components/blog/common/index.ts
@@ -16,6 +16,8 @@ export {
 export {
   default as CategoryBlogTemplate,
   CATEGORY_CONFIGS,
+  parseBlogPage,
+  withPagedListingMetadata,
   type CategoryConfig
 } from "./CategoryBlogTemplate";
 export {


### PR DESCRIPTION


- Added BlogPagination component for navigating between pages of blog posts.
- Updated blog category pages (Brand, Company, Creators) to support pagination and dynamic metadata generation based on the current page.
- Enhanced metadata structure to include canonical URLs and page-specific titles.
- Improved link styling in wordpress-content.css for better user experience.