### PR TITLE
feat(super-fan): treat /super-fan routes as legal pages in root layout

### DIFF
--- a/app/root-layout-client.tsx
+++ b/app/root-layout-client.tsx
@@ -29,7 +29,8 @@ export function RootLayoutClient({
   const isLegalPage =
     pathname.startsWith("/legal") ||
     pathname.startsWith("/gold-promo") ||
-    pathname.startsWith("/summer-promo");
+    pathname.startsWith("/summer-promo") ||
+    pathname.startsWith("/super-fan");
   const isCreatorPage = pathname.startsWith("/creator");
   const isBlogPage = pathname.startsWith("/blogs") || pathname.startsWith("/blog");
   const isPreviewPage = pathname.startsWith("/preview");


### PR DESCRIPTION
## Summary
Registers `/super-fan` routes as legal pages in the root layout, so the Super Fan terms page gets the same layout treatment as `/legal`, `/gold-promo`, and `/summer-promo`.

## Changes
- `app/root-layout-client.tsx` — add `/super-fan` to the `isLegalPage` check

## Note
Companion to the Super Fan terms page PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)