### PR TITLE
perf(creator): lazy-load framer-motion features via LazyMotion

### DIFF
--- a/app/creator/earn/CreatorEarnPage.tsx
+++ b/app/creator/earn/CreatorEarnPage.tsx
@@ -9,6 +9,7 @@ import Navigation from "@/components/creator/earn/Navigation";
 import HeroSection from "@/components/creator/earn/HeroSection";
 import ReferralBanner from "@/components/creator/earn/ReferralBanner";
 import { SignupProvider } from "@/components/creator/promo/SignupContext";
+import MotionProvider from "@/components/MotionProvider";
 
 const ValueProposition = dynamic(() => import("@/components/creator/earn/ValueProposition"));
 const ThreeStepSection = dynamic(() => import("@/components/creator/promo/ThreeStepSection"));
@@ -40,6 +41,7 @@ function CreatorEarnPageContent() {
 
   return (
     <SignupProvider socialAuthAfterVerify namespace="creatorEarn">
+      <MotionProvider>
       <main className="relative min-h-screen bg-black overflow-hidden">
         {/* Background Gradients — tuned to reach the end of the FAQ
             (the "View All" / "Show Less" toggle), so bg-black only
@@ -96,6 +98,7 @@ function CreatorEarnPageContent() {
           triggerElementId="promo-hero-card"
         />
       </main>
+      </MotionProvider>
     </SignupProvider>
   );
 }

--- a/app/creator/earn/faqs/page.tsx
+++ b/app/creator/earn/faqs/page.tsx
@@ -3,6 +3,7 @@ import Navigation from "@/components/creator/earn/Navigation";
 import CTASection from "@/components/creator/earn/CTASection";
 import EarnFooter from "@/components/creator/earn/EarnFooter";
 import FAQPageContent from "@/components/creator/earn/FAQPageContent";
+import MotionProvider from "@/components/MotionProvider";
 import {siteUrl} from "@/lib/urls";
 
 const title = "Creator FAQs: Invoicing, Payments & Taxes | Sparkonomy";
@@ -34,12 +35,14 @@ export default function CreatorEarnFAQsPage() {
             </div>
 
             {/* Content */}
-            <div className="relative z-10">
-                <Navigation />
-                <FAQPageContent />
-                <CTASection/>
-                <EarnFooter/>
-            </div>
+            <MotionProvider>
+                <div className="relative z-10">
+                    <Navigation />
+                    <FAQPageContent />
+                    <CTASection/>
+                    <EarnFooter/>
+                </div>
+            </MotionProvider>
         </main>
     );
 }

--- a/app/creator/promo/CreatorPromoPage.tsx
+++ b/app/creator/promo/CreatorPromoPage.tsx
@@ -8,6 +8,7 @@ import Navigation from "@/components/creator/earn/Navigation";
 import HeroSection from "@/components/creator/promo/HeroSection";
 import ReferralBanner from "@/components/creator/earn/ReferralBanner";
 import { SignupProvider } from "@/components/creator/promo/SignupContext";
+import MotionProvider from "@/components/MotionProvider";
 
 // Below-the-fold sections are code-split. They still SSR (default
 // dynamic = ssr:true) so crawlers and Lighthouse get the full DOM, but
@@ -96,6 +97,7 @@ export default function CreatorPromoPage({ variant, enableTypewriter }: CreatorP
 
   return (
     <SignupProvider>
+      <MotionProvider>
       <main className="relative min-h-screen bg-black overflow-hidden">
         {/* Background Gradients — second blob's height is tuned so the gradient
             reaches the end of the FAQ (the "Sab Dekho" / View All button) and
@@ -143,6 +145,7 @@ export default function CreatorPromoPage({ variant, enableTypewriter }: CreatorP
           />
         </Suspense>
       </main>
+      </MotionProvider>
     </SignupProvider>
   );
 }

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -3,9 +3,10 @@
 import { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
-import { motion, AnimatePresence } from "framer-motion";
+import { m, AnimatePresence } from "framer-motion";
 import { Globe, Check, ChevronDown } from "lucide-react";
 import { track } from "@/lib/analytics/track";
+import MotionProvider from "@/components/MotionProvider";
 
 interface LanguageSwitcherProps {
   className?: string;
@@ -54,8 +55,14 @@ export const LanguageSwitcher = ({ className }: LanguageSwitcherProps) => {
     setIsOpen(false);
   };
 
+  // Self-contained MotionProvider: this component renders on the creator routes
+  // (already inside a provider — nesting is harmless, both resolve the same
+  // framer-motion chunk) *and* standalone on /blogs/[slug] and /preview/[slug],
+  // which have no provider of their own. Wrapping here keeps `m.*` valid on
+  // every route without dragging those pages into the migration.
   return (
-    <motion.div
+    <MotionProvider>
+    <m.div
       ref={dropdownRef}
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
@@ -109,7 +116,7 @@ export const LanguageSwitcher = ({ className }: LanguageSwitcherProps) => {
       {/* Dropdown */}
       <AnimatePresence>
         {isOpen && (
-          <motion.div
+          <m.div
             initial={{ opacity: 0, y: -4 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -4 }}
@@ -151,10 +158,11 @@ export const LanguageSwitcher = ({ className }: LanguageSwitcherProps) => {
                 )}
               </button>
             ))}
-          </motion.div>
+          </m.div>
         )}
       </AnimatePresence>
-    </motion.div>
+    </m.div>
+    </MotionProvider>
   );
 };
 

--- a/components/MotionProvider.tsx
+++ b/components/MotionProvider.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { LazyMotion } from "framer-motion";
+import type { ReactNode } from "react";
+
+// framer-motion's `motion` component eagerly bundles every animation feature
+// into whatever chunk imports it. On /creator/earn that put the full ~136 KiB
+// framer-motion build on the critical hydration path — Lighthouse attributed
+// 1,899 ms of mobile main-thread time to that chunk, the single largest script
+// on the page.
+//
+// LazyMotion + `m` ships only the tiny component shell up front and streams the
+// feature bundle in afterwards, so hydration no longer pays for it. Every
+// component under components/creator/** uses `m.*` instead of `motion.*`; a
+// single stray `motion.*` import anywhere in the route graph would pull the
+// eager bundle back in and undo this.
+//
+// `domMax` rather than `domAnimation` because PromoSignupCard animates the
+// `layout` prop, which needs layout projection. `strict` is deliberately NOT
+// enabled: it throws on any missed `motion.*`, and a crash in a rarely-rendered
+// branch is a worse failure mode than silently losing the size win.
+const loadFeatures = () => import("framer-motion").then((mod) => mod.domMax);
+
+export default function MotionProvider({ children }: { children: ReactNode }) {
+  return <LazyMotion features={loadFeatures}>{children}</LazyMotion>;
+}

--- a/components/creator/earn/AdvantageFeature.tsx
+++ b/components/creator/earn/AdvantageFeature.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import Image from "next/image";
 
 interface AdvantageFeatureProps {
@@ -19,7 +19,7 @@ export default function AdvantageFeature({
   index,
 }: AdvantageFeatureProps) {
   return (
-    <motion.div
+    <m.div
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, margin: "-50px" }}
@@ -48,6 +48,6 @@ export default function AdvantageFeature({
         </h3>
         <p className="text-sm text-white text-left md:text-center">{description}</p>
       </div>
-    </motion.div>
+    </m.div>
   );
 }

--- a/components/creator/earn/AdvantageSection.tsx
+++ b/components/creator/earn/AdvantageSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {Suspense, useRef} from "react";
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import AdvantageFeature from "./AdvantageFeature";
@@ -61,7 +61,7 @@ function TitleWithLaptopBreak({ title }: { title: string }) {
 // differs from AdvantageFeature's bare-with-bottom-border earn layout.
 function PromoAdvantageCard({ index, title, description, iconUrl }: AdvantageItem & { index: number; iconUrl: string }) {
   return (
-    <motion.div
+    <m.div
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, margin: "-50px" }}
@@ -77,7 +77,7 @@ function PromoAdvantageCard({ index, title, description, iconUrl }: AdvantageIte
           <p className="mt-1 md:mt-0 text-white text-sm leading-snug md:text-center">{description}</p>
         </div>
       </div>
-    </motion.div>
+    </m.div>
   );
 }
 
@@ -102,7 +102,7 @@ export default function AdvantageSection({
   return (
     <section ref={sectionRef} className={isPromo ? "relative py-8 md:py-12 px-5 md:px-20" : "relative py-12 md:py-20 px-5 md:px-20"}>
       <div className="max-w-[1440px] mx-auto">
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -117,7 +117,7 @@ export default function AdvantageSection({
               {t("advantage.subtitle")}
             </p>
           )}
-        </motion.div>
+        </m.div>
 
         {isPromo ? (
           <div className="flex flex-col items-center gap-4 max-w-[480px] mx-auto md:max-w-none md:grid md:grid-cols-2 lg:grid-cols-4 md:gap-x-[55px] md:gap-y-[49px] md:items-stretch">
@@ -146,7 +146,7 @@ export default function AdvantageSection({
               ))}
             </div>
 
-            <motion.div
+            <m.div
               initial={{ opacity: 0, scale: 0.9 }}
               whileInView={{ opacity: 1, scale: 1 }}
               viewport={{ once: true }}
@@ -156,7 +156,7 @@ export default function AdvantageSection({
               <Suspense fallback={null}>
                 <CTAButton buttonText={t("advantage.cta")} analyticsEvent={analyticsEvent}/>
               </Suspense>
-            </motion.div>
+            </m.div>
           </>
         )}
       </div>

--- a/components/creator/earn/BenefitCard.tsx
+++ b/components/creator/earn/BenefitCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import Image from "next/image";
 
 interface BenefitCardProps {
@@ -17,7 +17,7 @@ export default function BenefitCard({
   decorativeImages = [],
 }: BenefitCardProps) {
   return (
-    <motion.div
+    <m.div
       initial={{ opacity: 0, y: 30 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, margin: "-50px" }}
@@ -58,6 +58,6 @@ export default function BenefitCard({
           dangerouslySetInnerHTML={{ __html: description }}
         />
       </div>
-    </motion.div>
+    </m.div>
   );
 }

--- a/components/creator/earn/BenefitsSection.tsx
+++ b/components/creator/earn/BenefitsSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {Suspense, useState, useEffect, useRef} from "react";
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import BenefitCard from "./BenefitCard";
 import CTAButton from "./CTAButton";
@@ -46,7 +46,7 @@ export default function BenefitsSection() {
     <section ref={sectionRef} className="relative py-4 px-5 md:px-20">
       <div className="max-w-[1440px] mx-auto">
         {/* Section Header */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -56,7 +56,7 @@ export default function BenefitsSection() {
           <h2 className="text-2xl md:text-[52px] font-bold text-white">
             {t("benefits.title")}
           </h2>
-        </motion.div>
+        </m.div>
 
         {/* Benefits Cards */}
         <div className="flex flex-col lg:flex-row gap-4 md:gap-8 items-center lg:items-start justify-center mb-12 md:mb-16">
@@ -72,7 +72,7 @@ export default function BenefitsSection() {
         </div>
 
         {/* CTA Button */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, scale: 0.9 }}
           whileInView={{ opacity: 1, scale: 1 }}
           viewport={{ once: true }}
@@ -82,7 +82,7 @@ export default function BenefitsSection() {
             <Suspense fallback={null}>
               <CTAButton buttonText={t("benefits.cta")}/>
             </Suspense>
-        </motion.div>
+        </m.div>
       </div>
     </section>
   );

--- a/components/creator/earn/CTASection.tsx
+++ b/components/creator/earn/CTASection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {Suspense, useState, useEffect} from "react";
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import CTAButton from "./CTAButton";
 
@@ -19,7 +19,7 @@ export default function CTASection() {
 
   return (
     <section className="relative py-12 md:py-20 px-5 md:px-20">
-      <motion.div
+      <m.div
         initial={{ opacity: 0, y: 30 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
@@ -40,7 +40,7 @@ export default function CTASection() {
               </Suspense>
           </div>
         </div>
-      </motion.div>
+      </m.div>
     </section>
   );
 }

--- a/components/creator/earn/EarnFooter.tsx
+++ b/components/creator/earn/EarnFooter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import Image from "next/image";
 import Link from "next/link";
@@ -11,7 +11,7 @@ export default function EarnFooter() {
 
   return (
     <footer className="relative py-8 md:py-12 px-5 md:px-20 mb-36">
-      <motion.div
+      <m.div
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
@@ -70,7 +70,7 @@ export default function EarnFooter() {
             <span>{t("footer.copyright")}</span>
           </div>
         </div>
-      </motion.div>
+      </m.div>
     </footer>
   );
 }

--- a/components/creator/earn/FAQItem.tsx
+++ b/components/creator/earn/FAQItem.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {useState} from "react";
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import {ChevronDown} from "lucide-react";
 import {track} from "@/lib/analytics/track";
 
@@ -45,7 +45,7 @@ export default function FAQItem({
   };
 
   return (
-    <motion.div
+    <m.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4, delay: index * 0.05 }}
@@ -60,17 +60,17 @@ export default function FAQItem({
         <span className="text-lg md:text-xl font-semibold text-white leading-normal flex-1">
           {question}
         </span>
-        <motion.div
+        <m.div
           animate={{ rotate: isOpen ? 180 : 0 }}
           transition={{ duration: 0.3 }}
           className="flex-shrink-0 mt-1 md:mt-0"
         >
           <ChevronDown className="w-6 h-6 text-white" />
-        </motion.div>
+        </m.div>
       </button>
 
       {answer && (
-          <motion.div
+          <m.div
             initial={false}
             animate={{
               height: isOpen ? "auto" : 0,
@@ -82,8 +82,8 @@ export default function FAQItem({
             <p className="text-sm md:text-[14px] text-white leading-[1.4] pb-5 whitespace-pre-line">
               {answer}
             </p>
-          </motion.div>
+          </m.div>
       )}
-    </motion.div>
+    </m.div>
   );
 }

--- a/components/creator/earn/FAQPageContent.tsx
+++ b/components/creator/earn/FAQPageContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import {useState} from "react";
 import FAQItem from "./FAQItem";
 import PlanComparison from "./PlanComparison";
@@ -41,14 +41,14 @@ export default function FAQPageContent() {
     <section className="relative py-12 md:py-20 px-5 md:px-20">
       <div className="max-w-[1440px] mx-auto">
         {/* Page Title */}
-        <motion.h1
+        <m.h1
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
           className="text-[40px] md:text-[40px] font-bold text-white mb-8 md:mb-12 text-left md:text-left"
         >
           {t("faq.title")}
-        </motion.h1>
+        </m.h1>
 
         <div className="flex flex-col lg:flex-row gap-8 lg:gap-12 min-w-0">
           {/* Mobile Category Dropdown */}
@@ -67,7 +67,7 @@ export default function FAQPageContent() {
               />
             </button>
             {showCategoryDropdown && (
-              <motion.div
+              <m.div
                 initial={{ opacity: 0, y: -10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.2 }}
@@ -89,12 +89,12 @@ export default function FAQPageContent() {
                     {category.label}
                   </button>
                 ))}
-              </motion.div>
+              </m.div>
             )}
           </div>
 
           {/* Desktop Category Sidebar */}
-          <motion.div
+          <m.div
             initial={{ opacity: 0, x: -20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.6 }}
@@ -113,10 +113,10 @@ export default function FAQPageContent() {
                 {category.label}
               </button>
             ))}
-          </motion.div>
+          </m.div>
 
           {/* FAQ List */}
-          <motion.div
+          <m.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.2 }}
@@ -137,16 +137,16 @@ export default function FAQPageContent() {
 
             {/* Plan Comparison - shown under Pricing category for Indian users */}
             {selectedCategory === "pricing" && isIndian && !isGeoLoading && (
-              <motion.div
+              <m.div
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.6, delay: 0.3 }}
                 className="mt-8 w-full overflow-x-auto"
               >
                 <PlanComparison showTitle={true} showActionButtons={false} showPricing={true} />
-              </motion.div>
+              </m.div>
             )}
-          </motion.div>
+          </m.div>
         </div>
       </div>
     </section>

--- a/components/creator/earn/FAQSection.tsx
+++ b/components/creator/earn/FAQSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {Suspense, useRef, useState} from "react";
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import FAQItem from "./FAQItem";
@@ -60,7 +60,7 @@ export default function FAQSection({
 
   return (
     <section ref={sectionRef} className="relative py-4 px-5 md:px-20">
-      <motion.div
+      <m.div
         initial={{ opacity: 0, y: 30 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
@@ -140,7 +140,7 @@ export default function FAQSection({
             </div>
           )}
         </div>
-      </motion.div>
+      </m.div>
     </section>
   );
 }

--- a/components/creator/earn/FlippingCoin.tsx
+++ b/components/creator/earn/FlippingCoin.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { Sparkle } from "lucide-react";
 
 interface FlippingCoinProps {
@@ -61,7 +61,7 @@ export default function FlippingCoin({
           }}
         />
       )}
-      <motion.div
+      <m.div
         className="animate-coin-flip w-full h-full relative [transform-style:preserve-3d]"
         style={{ animationDuration: "var(--coin-duration, 2.5s)" }}
         initial={{ ["--coin-duration" as string]: isFast ? "0.4s" : "2.5s" }}
@@ -84,7 +84,7 @@ export default function FlippingCoin({
           className="absolute inset-0 w-full h-full object-contain"
           style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
         />
-      </motion.div>
+      </m.div>
       {glint &&
         !isFast &&
         TWINKLES.map((t, i) => {

--- a/components/creator/earn/FloatingCTA.tsx
+++ b/components/creator/earn/FloatingCTA.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense, useEffect, useRef, useState } from "react";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { AnimatePresence, m, useReducedMotion } from "framer-motion";
 import { Trans, useTranslation } from "react-i18next";
 import { ValidatedPhoneInput } from "./ValidatedPhoneInput";
 import FlippingCoin from "./FlippingCoin";
@@ -152,7 +152,7 @@ function EarnFloatingCTA({ isVisible, t, trackingPrefix }: EarnVariantProps) {
         // -bottom-px on the fixed wrapper (and the matching +1px on the
         // inner pb) overshoots the viewport by 1px to cover the sub-pixel
         // gap left by framer-motion's translateY(0) on fractional-DPR screens.
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 100 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: 100 }}
@@ -258,7 +258,7 @@ function EarnFloatingCTA({ isVisible, t, trackingPrefix }: EarnVariantProps) {
               />
             </p>
           </div>
-        </motion.div>
+        </m.div>
       )}
     </AnimatePresence>
   );
@@ -309,7 +309,7 @@ function PromoFloatingCTA({ isVisible, t, trackingPrefix }: PromoVariantProps) {
   return (
     <AnimatePresence>
       {isVisible && (
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 100 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: 100 }}
@@ -343,7 +343,7 @@ function PromoFloatingCTA({ isVisible, t, trackingPrefix }: PromoVariantProps) {
                 </div>
                 <div className="flex-1 min-w-0">
                   <h3 className="text-primary font-medium text-sm leading-tight">
-                    <motion.span
+                    <m.span
                       aria-hidden
                       animate={
                         prefersReducedMotion
@@ -376,12 +376,12 @@ function PromoFloatingCTA({ isVisible, t, trackingPrefix }: PromoVariantProps) {
                       className="inline-block mr-1"
                     >
                       ⚡
-                    </motion.span>
+                    </m.span>
                     <Trans
                       i18nKey="floatingCta.heading"
                       t={t}
                       components={[
-                        <motion.span
+                        <m.span
                           key="rupee"
                           className="inline-block origin-center"
                           animate={
@@ -467,7 +467,7 @@ function PromoFloatingCTA({ isVisible, t, trackingPrefix }: PromoVariantProps) {
               </p>
             </div>
           </div>
-        </motion.div>
+        </m.div>
       )}
     </AnimatePresence>
   );
@@ -543,7 +543,7 @@ function AnimatedOtpButton({
           <span className="leading-5">{staticPrefix}</span>
           <span className="relative inline-block overflow-hidden h-5 min-w-[4ch] text-center leading-5">
             <AnimatePresence mode="wait" initial={false}>
-              <motion.span
+              <m.span
                 key={current}
                 initial={{ y: "100%" }}
                 animate={{ y: 0 }}
@@ -552,7 +552,7 @@ function AnimatedOtpButton({
                 className="block leading-5"
               >
                 {current === "primary" ? primaryLabel : swapLabel}
-              </motion.span>
+              </m.span>
             </AnimatePresence>
           </span>
         </>

--- a/components/creator/earn/GoldCoinAnimation.tsx
+++ b/components/creator/earn/GoldCoinAnimation.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useReducedMotion } from "framer-motion";
+import { m, useReducedMotion } from "framer-motion";
 
 interface GoldCoinAnimationProps {
   size?: number;
@@ -28,7 +28,7 @@ export default function GoldCoinAnimation({
       className="relative shrink-0 flex items-center justify-center"
       style={{ width: size, height: size }}
     >
-      <motion.div
+      <m.div
         className="relative"
         style={{ width: size, height: size, willChange: "transform" }}
         animate={animate ? { y: [0, -2, 0], rotate: [0, 6, 0, -6, 0] } : undefined}
@@ -68,7 +68,7 @@ export default function GoldCoinAnimation({
         </svg>
 
         {animate && (
-          <motion.span
+          <m.span
             aria-hidden
             className="absolute -top-1 -right-1 text-[10px]"
             animate={{ opacity: [0, 1, 0], scale: [0.6, 1.1, 0.6] }}
@@ -80,9 +80,9 @@ export default function GoldCoinAnimation({
             }}
           >
             ✨
-          </motion.span>
+          </m.span>
         )}
-      </motion.div>
+      </m.div>
     </div>
   );
 }

--- a/components/creator/earn/HeroStoryCarousel.tsx
+++ b/components/creator/earn/HeroStoryCarousel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Image from "next/image";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { AnimatePresence, m, useReducedMotion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { Heart, Send } from "lucide-react";
 import AnimatedEmojis from "./stories/AnimatedEmojis";
@@ -127,7 +127,7 @@ export default function HeroStoryCarousel() {
               key={i}
               className="flex-1 h-0.5 rounded-full bg-white/30 overflow-hidden"
             >
-              <motion.div
+              <m.div
                 className="h-full bg-white"
                 initial={false}
                 animate={{
@@ -161,7 +161,7 @@ export default function HeroStoryCarousel() {
               width=192 → Next serves its w=384 srcset variant (≈half the
               bytes) for the 210px box; page.tsx preload mirrors it. */}
           <AnimatePresence initial={false}>
-            <motion.div
+            <m.div
               key={index}
               className="absolute inset-0"
               initial={{ x: "100%" }}
@@ -180,7 +180,7 @@ export default function HeroStoryCarousel() {
                 priority={index === 0}
                 className="absolute inset-0 w-full h-full object-cover"
               />
-            </motion.div>
+            </m.div>
           </AnimatePresence>
         </div>
 

--- a/components/creator/earn/ReferralBanner.tsx
+++ b/components/creator/earn/ReferralBanner.tsx
@@ -4,7 +4,7 @@ import {useEffect, useState} from "react";
 import {useSearchParams} from "next/navigation";
 import {useTranslation} from "react-i18next";
 import Image from "next/image";
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 
 interface ReferrerInfo {
   first_name: string;
@@ -101,7 +101,7 @@ export default function ReferralBanner({ namespace = "creatorEarn" }: ReferralBa
   }
 
   return (
-    <motion.div
+    <m.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6 }}
@@ -129,6 +129,6 @@ export default function ReferralBanner({ namespace = "creatorEarn" }: ReferralBa
       <div className="text-white max-w-[350px] md:max-w-[550px]">
         {messageText}
       </div>
-    </motion.div>
+    </m.div>
   );
 }

--- a/components/creator/earn/TestimonialCard.tsx
+++ b/components/creator/earn/TestimonialCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import Image from "next/image";
 
 interface TestimonialCardProps {
@@ -35,7 +35,7 @@ export default function TestimonialCard({
       };
 
   return (
-    <motion.div
+    <m.div
       {...motionProps}
       className={`
         p-3 rounded-[24px] bg-gradient-to-br from-white/10 via-white/0 to-black/10 border border-[#FFFFFF33] backdrop-blur-[2px]
@@ -63,6 +63,6 @@ export default function TestimonialCard({
           <span className="text-white font-normal leading-5 text-sm">{handle}</span>
         </div>
       </div>
-    </motion.div>
+    </m.div>
   );
 }

--- a/components/creator/earn/TestimonialsSection.tsx
+++ b/components/creator/earn/TestimonialsSection.tsx
@@ -5,7 +5,7 @@ import useEmblaCarousel, { UseEmblaCarouselType } from "embla-carousel-react";
 import { useTranslation } from "react-i18next";
 import TestimonialCard from "./TestimonialCard";
 import styles from "./carousel.module.css";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { useSectionViewTracking } from "@/lib/hooks/useSectionViewTracking";
 
 interface TestimonialsSectionProps {
@@ -114,7 +114,7 @@ export default function TestimonialsSection({
     <section ref={sectionRef} className="relative py-4 md:px-20">
       <div className="max-w-[1440px] mx-auto">
         {/* Section header */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -129,7 +129,7 @@ export default function TestimonialsSection({
               {subtitle}
             </p>
           )}
-        </motion.div>
+        </m.div>
 
         {/* ---------- Carousel for tablet & phone ---------- */}
         {isCarouselActive ? (
@@ -138,7 +138,7 @@ export default function TestimonialsSection({
               <div className={styles.embla__container}>
                 {testimonials.map((testimonial, index) => (
                   <div className={styles.embla__slide} key={index}>
-                    <motion.div
+                    <m.div
                       animate={{
                         scale: selectedIndex === index ? 1 : 0.93,
                         opacity: selectedIndex === index ? 1 : 0.55,
@@ -154,7 +154,7 @@ export default function TestimonialsSection({
                         index={index}
                         disableEntryAnimation={disableSlideEntryAnimation}
                       />
-                    </motion.div>
+                    </m.div>
                   </div>
                 ))}
               </div>

--- a/components/creator/earn/ValueProposition.tsx
+++ b/components/creator/earn/ValueProposition.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef } from "react";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { useSectionViewTracking } from "@/lib/hooks/useSectionViewTracking";
 
@@ -15,7 +15,7 @@ export default function ValueProposition() {
       ref={sectionRef}
       className="relative pt-2 pb-10 md:pt-4 md:pb-16 px-5 md:px-20"
     >
-      <motion.div
+      <m.div
         initial={{ opacity: 0, y: 24 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true, margin: "-80px" }}
@@ -39,7 +39,7 @@ export default function ValueProposition() {
         <p className="text-base md:text-lg text-white/90 leading-relaxed max-w-[640px] mx-auto">
           {t("pitch.description")}
         </p>
-      </motion.div>
+      </m.div>
     </section>
   );
 }

--- a/components/creator/earn/VideoSection.tsx
+++ b/components/creator/earn/VideoSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {Suspense, useState, useEffect} from "react";
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import CTAButton from "./CTAButton";
 
@@ -19,7 +19,7 @@ export default function VideoSection() {
 
   return (
     <section className="relative py-12 md:py-20 px-5 md:px-20">
-      <motion.div
+      <m.div
         initial={{ opacity: 0, y: 30 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
@@ -35,13 +35,13 @@ export default function VideoSection() {
         {/*      /!* Placeholder for video *!/*/}
         {/*      <div className="absolute inset-0 flex flex-col items-center justify-center">*/}
         {/*        /!* Play Button *!/*/}
-        {/*        <motion.button*/}
+        {/*        <m.button*/}
         {/*          whileHover={{ scale: 1.1 }}*/}
         {/*          whileTap={{ scale: 0.95 }}*/}
         {/*          className="w-12 h-12 md:w-16 md:h-16 rounded-full bg-white/10 backdrop-blur-sm border-2 border-white/30 flex items-center justify-center hover:bg-white/20 transition-colors"*/}
         {/*        >*/}
         {/*          <Play className="w-6 h-6 md:w-8 md:h-8 text-white fill-white ml-1" />*/}
-        {/*        </motion.button>*/}
+        {/*        </m.button>*/}
         {/*          <p className={"text-white"}>Awaited</p>*/}
         {/*      </div>*/}
         {/*    </div>*/}
@@ -49,7 +49,7 @@ export default function VideoSection() {
         {/*</div>*/}
 
         {/* Video Description */}
-        {/*<motion.div*/}
+        {/*<m.div*/}
         {/*  initial={{ opacity: 0, y: 10 }}*/}
         {/*  whileInView={{ opacity: 1, y: 0 }}*/}
         {/*  viewport={{ once: true }}*/}
@@ -59,10 +59,10 @@ export default function VideoSection() {
         {/*  <p className="text-xs md:text-2xl font-normal md:font-semibold text-white">*/}
         {/*    How to Use: Lorem ipsum is the best font for the design*/}
         {/*  </p>*/}
-        {/*</motion.div>*/}
+        {/*</m.div>*/}
 
         {/* CTA Button */}
-        <motion.div
+        <m.div
           initial={{ opacity: 0, scale: 0.9 }}
           whileInView={{ opacity: 1, scale: 1 }}
           viewport={{ once: true }}
@@ -72,8 +72,8 @@ export default function VideoSection() {
             <Suspense fallback={null}>
               <CTAButton buttonText={t("video.cta")}/>
             </Suspense>
-        </motion.div>
-      </motion.div>
+        </m.div>
+      </m.div>
     </section>
   );
 }

--- a/components/creator/earn/stories/AnimatedEmojis.tsx
+++ b/components/creator/earn/stories/AnimatedEmojis.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 
 interface AnimatedEmojisProps {
   emojis: string[];
@@ -11,7 +11,7 @@ export default function AnimatedEmojis({ emojis, className = "" }: AnimatedEmoji
   return (
     <div className={`flex gap-0.5 ${className}`}>
       {emojis.map((emoji, index) => (
-        <motion.span
+        <m.span
           key={index}
           initial={{ opacity: 0, scale: 0, y: 4 }}
           animate={{ opacity: 1, scale: 1, y: 0 }}
@@ -23,7 +23,7 @@ export default function AnimatedEmojis({ emojis, className = "" }: AnimatedEmoji
           className="inline-block"
         >
           {emoji}
-        </motion.span>
+        </m.span>
       ))}
     </div>
   );

--- a/components/creator/earn/stories/FloatingHeart.tsx
+++ b/components/creator/earn/stories/FloatingHeart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import {useEffect, useMemo} from "react";
 
 interface FloatingHeartProps {
@@ -36,7 +36,7 @@ export default function FloatingHeart({ id, onComplete, delay = 0 }: FloatingHea
   }, [id, onComplete, animationProps.duration, delay]);
 
   return (
-    <motion.div
+    <m.div
       className="absolute pointer-events-none"
       initial={{
         y: 0,
@@ -74,6 +74,6 @@ export default function FloatingHeart({ id, onComplete, delay = 0 }: FloatingHea
           opacity={animationProps.color.opacity}
         />
       </svg>
-    </motion.div>
+    </m.div>
   );
 }

--- a/components/creator/earn/stories/StoriesContainer.tsx
+++ b/components/creator/earn/stories/StoriesContainer.tsx
@@ -2,7 +2,7 @@
 
 import {useCallback, useEffect, useRef, useState} from "react";
 import {useSearchParams} from "next/navigation";
-import {AnimatePresence, motion} from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 // import { StoriesContainerProps } from "./types";
@@ -191,7 +191,7 @@ export default function StoriesContainer({
       )}
     <AnimatePresence>
       {isVisible && (
-        <motion.div
+        <m.div
           className="fixed inset-0 z-50 bg-black"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -298,7 +298,7 @@ export default function StoriesContainer({
               <CurrentStoryComponent imageSrc={currentStory?.imageSrc} priority />
             </StoryPanel>
           </div>
-        </motion.div>
+        </m.div>
       )}
     </AnimatePresence>
     </>

--- a/components/creator/earn/stories/StoryPanel.tsx
+++ b/components/creator/earn/stories/StoryPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {AnimatePresence, motion} from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 import {StoryPanelProps} from "./types";
 // import StoryProgressBar from "./StoryProgressBar";
 import {useEffect, useRef} from "react";
@@ -68,7 +68,7 @@ export default function StoryPanel({
   };
 
   return (
-    <motion.div
+    <m.div
       ref={containerRef}
       className="relative w-full h-full cursor-pointer overflow-hidden"
       onClick={handleClick}
@@ -83,7 +83,7 @@ export default function StoryPanel({
       transition={{ duration: 0.3 }}
     >
       <AnimatePresence mode="sync" initial={false} custom={direction}>
-        <motion.div
+        <m.div
           key={currentIndex}
           className="absolute inset-0"
           custom={direction}
@@ -94,7 +94,7 @@ export default function StoryPanel({
           transition={{ x: { type: "tween", duration: 0.35, ease: [0.32, 0.72, 0, 1] } }}
         >
           {children}
-        </motion.div>
+        </m.div>
       </AnimatePresence>
       {/* Close button overlay - positioned to match the X icon in story content */}
       <button
@@ -106,6 +106,6 @@ export default function StoryPanel({
       >
         <XIcon />
       </button>
-    </motion.div>
+    </m.div>
   );
 }

--- a/components/creator/earn/stories/StoryProgressBar.tsx
+++ b/components/creator/earn/stories/StoryProgressBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import {StoryProgressBarProps} from "./types";
 
 export default function StoryProgressBar({
@@ -16,7 +16,7 @@ export default function StoryProgressBar({
             key={index}
             className="flex-1 h-[2.5px] bg-white/30 rounded-full overflow-hidden"
           >
-            <motion.div
+            <m.div
               className="h-full bg-white rounded-full"
               initial={{ width: "0%" }}
               animate={{

--- a/components/creator/promo/GiftCardStackAnimation.tsx
+++ b/components/creator/promo/GiftCardStackAnimation.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 
 // "Flower" bloom: cards share a bottom-center pivot and start perfectly
 // stacked. They burst out one-by-one into a wide upper-half fan (the
@@ -98,7 +98,7 @@ export default function GiftCardStackAnimation({
         }}
       >
       {CARDS.map((card, i) => (
-        <motion.div
+        <m.div
           key={card.src}
           className="absolute"
           style={{
@@ -146,7 +146,7 @@ export default function GiftCardStackAnimation({
             loading="eager"
             decoding="async"
           />
-        </motion.div>
+        </m.div>
       ))}
 
       {/* Shining particles on top of the front (black) voucher. They sit
@@ -157,7 +157,7 @@ export default function GiftCardStackAnimation({
         style={{ zIndex: 10 }}
       >
         {SPARKLES.map((s, i) => (
-          <motion.span
+          <m.span
             key={i}
             className="absolute block"
             style={{
@@ -192,7 +192,7 @@ export default function GiftCardStackAnimation({
             }}
           >
             <SparkleIcon size={s.size} />
-          </motion.span>
+          </m.span>
         ))}
       </div>
       </div>

--- a/components/creator/promo/HeroSection.tsx
+++ b/components/creator/promo/HeroSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import Image from "next/image";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -205,13 +205,13 @@ export default function HeroSection({ variant, enableTypewriter = false }: HeroS
             </p>
 
             {/* Signup card — fades in last */}
-            <motion.div
+            <m.div
               initial={{ opacity: 0, y: 20 }}
               animate={showCard ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
               transition={{ duration: CARD_FADE_MS / 1000, ease: "easeOut" }}
             >
               <PromoSignupCard play={showCard} variant={variant} />
-            </motion.div>
+            </m.div>
           </>
         ) : (
           <>

--- a/components/creator/promo/PhoneMockupSection.tsx
+++ b/components/creator/promo/PhoneMockupSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {useEffect, useRef, useState} from "react";
-import {AnimatePresence, motion, useInView, useReducedMotion} from "framer-motion";
+import { AnimatePresence, m, useInView, useReducedMotion } from "framer-motion";
 import Image from "next/image";
 import {useTranslation} from "react-i18next";
 import {getCurrentLang, type SupportedLang} from "@/lib/i18n";
@@ -51,7 +51,7 @@ export default function PhoneMockupSection({lang}: {lang?: SupportedLang} = {}) 
   return (
     <section ref={sectionRef} className="relative py-5 md:py-0 px-5">
       <div className="flex justify-center">
-        <motion.div
+        <m.div
           initial={{opacity: 0, y: 24}}
           whileInView={{opacity: 1, y: 0}}
           viewport={{once: true, margin: "-50px"}}
@@ -61,7 +61,7 @@ export default function PhoneMockupSection({lang}: {lang?: SupportedLang} = {}) 
           {/* Screen viewport — 190x412 inside the 212x433 phone frame (11px x bezel, ~10.5px y bezel) */}
           <div className="absolute inset-x-[11px] top-[10px] bottom-[11px] rounded-[34px] overflow-hidden">
             <AnimatePresence mode="wait" initial={false}>
-              <motion.div
+              <m.div
                 key={activeIndex}
                 initial={{x: "100%", opacity: 0}}
                 animate={{x: 0, opacity: 1}}
@@ -78,7 +78,7 @@ export default function PhoneMockupSection({lang}: {lang?: SupportedLang} = {}) 
                   loading="lazy"
                   decoding="async"
                 />
-              </motion.div>
+              </m.div>
             </AnimatePresence>
           </div>
 
@@ -115,11 +115,11 @@ export default function PhoneMockupSection({lang}: {lang?: SupportedLang} = {}) 
             loading="lazy"
             decoding="async"
           />
-        </motion.div>
+        </m.div>
       </div>
 
       {/* Partner Logos */}
-      <motion.div
+      <m.div
         initial={{opacity: 0, y: 20}}
         whileInView={{opacity: 1, y: 0}}
         viewport={{once: true, margin: "-50px"}}
@@ -140,7 +140,7 @@ export default function PhoneMockupSection({lang}: {lang?: SupportedLang} = {}) 
           width={120}
           className="h-[32px] w-auto object-contain pl-4"
         />
-      </motion.div>
+      </m.div>
     </section>
   );
 }

--- a/components/creator/promo/PromoSignupCard.tsx
+++ b/components/creator/promo/PromoSignupCard.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useEffect, useState } from "react";
 import Image from "next/image";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 import { Trans, useTranslation } from "react-i18next";
 import { ArrowRight, Check, ChevronLeft, Loader2, X } from "lucide-react";
 import { ValidatedPhoneInput } from "@/components/creator/earn/ValidatedPhoneInput";
@@ -224,7 +224,7 @@ export default function PromoSignupCard({
   }, [profile.lastName, hasTypedLastName]);
 
   return (
-    <motion.div
+    <m.div
       id="promo-hero-card"
       layout
       style={{ background: isEarn ? EARN_CARD_GRADIENT : CARD_GRADIENT }}
@@ -309,7 +309,7 @@ export default function PromoSignupCard({
                   // /promo-f: static "500" that bounces in sync with the
                   // Get OTP button once the user first scrolls or taps.
                   // Same keyframes/timing as the button below.
-                  <motion.span
+                  <m.span
                     key="amount"
                     className="inline-block origin-center"
                     style={{
@@ -333,7 +333,7 @@ export default function PromoSignupCard({
                     }
                   >
                     500
-                  </motion.span>
+                  </m.span>
                 ) : variant === "w" ? (
                   // /promo-w: static "500" — no count-up, no bounce.
                   <span key="amount">500</span>
@@ -344,7 +344,7 @@ export default function PromoSignupCard({
                   // /promo-w: static rupee glyph — no scale pulse.
                   <span key="rupee" />
                 ) : (
-                  <motion.span
+                  <m.span
                     key="rupee"
                     className="inline-block origin-center"
                     style={{
@@ -459,7 +459,7 @@ export default function PromoSignupCard({
                   stage === "submitting" ||
                   stage === "submitted"));
             return (
-              <motion.button
+              <m.button
                 type="button"
                 onClick={phoneLocked ? changeNumber : sendOtp}
                 disabled={ctaDisabled}
@@ -497,7 +497,7 @@ export default function PromoSignupCard({
                 ) : (
                   t("hero.card.sendOtp")
                 )}
-              </motion.button>
+              </m.button>
             );
           })()}
         </div>
@@ -507,7 +507,7 @@ export default function PromoSignupCard({
             bumped back to phone (PHONE_ALREADY_IN_USE, USER_NOT_FOUND). */}
         <AnimatePresence initial={false}>
           {stage === "phone" && error && (
-            <motion.p
+            <m.p
               key="phone-error"
               initial={{ height: 0, opacity: 0, marginTop: 0 }}
               animate={{ height: "auto", opacity: 1, marginTop: 8 }}
@@ -517,14 +517,14 @@ export default function PromoSignupCard({
               className="overflow-hidden text-xs text-red-100 bg-red-600/20 px-2 py-1 rounded text-center"
             >
               {error}
-            </motion.p>
+            </m.p>
           )}
         </AnimatePresence>
 
         {/* Disclaimer — only shown in stage 1 (hidden once OTP is sent) */}
         <AnimatePresence initial={false}>
           {stage === "phone" && (
-            <motion.p
+            <m.p
               key="disclaimer"
               initial={{ height: 0, opacity: 0, marginTop: 0 }}
               animate={{ height: "auto", opacity: 1, marginTop: isEarn ? 6 : 8 }}
@@ -556,7 +556,7 @@ export default function PromoSignupCard({
                   />,
                 ]}
               />
-            </motion.p>
+            </m.p>
           )}
         </AnimatePresence>
       </div>
@@ -657,7 +657,7 @@ export default function PromoSignupCard({
               watcher in SignupContext). */}
           <AnimatePresence initial={false}>
             {verifyStatus === "error" && (
-              <motion.div
+              <m.div
                 key="earn-pill-error"
                 initial={{ opacity: 0, y: -4 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -666,7 +666,7 @@ export default function PromoSignupCard({
                 className="mt-2 flex justify-center"
               >
                 <VerifiedBadge status={verifyStatus} t={t} />
-              </motion.div>
+              </m.div>
             )}
           </AnimatePresence>
 
@@ -750,7 +750,7 @@ export default function PromoSignupCard({
           this block is suppressed for variant="earn". */}
       <AnimatePresence initial={false}>
         {!isEarn && otpVisible && (
-          <motion.div
+          <m.div
             key="otp-section"
             initial={{ height: 0, opacity: 0, marginTop: 0 }}
             animate={{ height: "auto", opacity: 1, marginTop: 12 }}
@@ -799,7 +799,7 @@ export default function PromoSignupCard({
                   the Edit button itself, not here. */}
               <AnimatePresence initial={false}>
                 {verifyStatus === "error" && (
-                  <motion.div
+                  <m.div
                     key="pill-error"
                     initial={{ opacity: 0, y: -4 }}
                     animate={{ opacity: 1, y: 0 }}
@@ -807,18 +807,18 @@ export default function PromoSignupCard({
                     transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
                   >
                     <VerifiedBadge status={verifyStatus} t={t} />
-                  </motion.div>
+                  </m.div>
                 )}
               </AnimatePresence>
             </div>
-          </motion.div>
+          </m.div>
         )}
       </AnimatePresence>
 
       {/* Stage 3: profile form */}
       <AnimatePresence initial={false}>
         {profileVisible && (
-          <motion.div
+          <m.div
             key="profile-section"
             initial={{ height: 0, opacity: 0, marginTop: 0 }}
             animate={{ height: "auto", opacity: 1, marginTop: 16 }}
@@ -839,7 +839,7 @@ export default function PromoSignupCard({
                   content. Forward-only — see hasTypedFirstName state above. */}
               <AnimatePresence initial={false}>
                 {hasTypedFirstName && (
-                  <motion.div
+                  <m.div
                     key="last-name-row"
                     initial={{ height: 0, opacity: 0, marginTop: 0 }}
                     animate={{ height: "auto", opacity: 1, marginTop: 8 }}
@@ -854,7 +854,7 @@ export default function PromoSignupCard({
                       onChange={(e) => setProfileField("lastName", e.target.value)}
                       autoComplete="off"
                     />
-                  </motion.div>
+                  </m.div>
                 )}
               </AnimatePresence>
 
@@ -862,7 +862,7 @@ export default function PromoSignupCard({
                   lastName has been touched. */}
               <AnimatePresence initial={false}>
                 {hasTypedLastName && (
-                  <motion.div
+                  <m.div
                     key="email-and-submit"
                     initial={{ height: 0, opacity: 0, marginTop: 0 }}
                     animate={{ height: "auto", opacity: 1, marginTop: 8 }}
@@ -914,14 +914,14 @@ export default function PromoSignupCard({
                           <span className="bg-[linear-gradient(162.34deg,#DD2A7B_4.78%,#9747FF_89.95%)] bg-clip-text text-transparent">
                             {submitButtonLabel}
                           </span>
-                          <motion.span
+                          <m.span
                             aria-hidden="true"
                             animate={{ x: [0, 4, 0] }}
                             transition={{ duration: 1.1, ease: "easeInOut", repeat: Infinity }}
                             className="inline-flex"
                           >
                             <ArrowRight className="h-4 w-4 text-[#DD2A7B]" strokeWidth={2.5} />
-                          </motion.span>
+                          </m.span>
                         </span>
                       </button>
 
@@ -934,14 +934,14 @@ export default function PromoSignupCard({
                         }
                       />
                     </div>
-                  </motion.div>
+                  </m.div>
                 )}
               </AnimatePresence>
             </div>
-          </motion.div>
+          </m.div>
         )}
       </AnimatePresence>
-    </motion.div>
+    </m.div>
   );
 }
 

--- a/components/creator/promo/ThreeStepSection.tsx
+++ b/components/creator/promo/ThreeStepSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {useRef, type ReactNode} from "react";
-import {motion} from "framer-motion";
+import { m } from "framer-motion";
 import Image from "next/image";
 import { Trans, useTranslation } from "react-i18next";
 import {useSectionViewTracking} from "@/lib/hooks/useSectionViewTracking";
@@ -20,7 +20,7 @@ const STEP_IMAGES = [
 
 function StepCard({ index, title, description, tags, imageUrl }: Omit<ThreeStepItem, "description"> & { description: ReactNode; index: number; imageUrl: string }) {
   return (
-    <motion.div
+    <m.div
       initial={{ opacity: 0, y: 24 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, margin: "-50px" }}
@@ -57,7 +57,7 @@ function StepCard({ index, title, description, tags, imageUrl }: Omit<ThreeStepI
           )}
         </div>
       </div>
-    </motion.div>
+    </m.div>
   );
 }
 
@@ -80,7 +80,7 @@ export default function BenefitsSection({
   return (
     <section ref={sectionRef} className="relative pb-5 md:pb-12 px-5 md:px-20">
       <div className="max-w-[1200px] mx-auto">
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -93,7 +93,7 @@ export default function BenefitsSection({
           <p className="text-sm md:text-base text-white/70 max-w-[520px] mx-auto">
             {t("threeStep.subtitle")}
           </p>
-        </motion.div>
+        </m.div>
 
         <div className="flex flex-col items-center lg:flex-row lg:items-stretch lg:justify-center gap-4 md:gap-6">
           {steps.map((step, i) => (


### PR DESCRIPTION
The `motion` component eagerly bundles every animation feature into the chunk that imports it. On /creator/earn that put the full ~136 KiB framer-motion build on the critical hydration path — the largest script on the page by main-thread time.

- Add components/MotionProvider.tsx: a LazyMotion wrapper that streams the feature bundle in after hydration. `domMax` (not `domAnimation`) because PromoSignupCard animates `layout`, which needs projection. `strict` is off on purpose — a throw in a rarely-rendered branch is a worse failure than silently losing the size win.
- Swap `motion.*` -> `m.*` across components/creator/**. A single stray `motion.*` in the route graph pulls the eager bundle back in.
- Wrap CreatorEarnPage, CreatorPromoPage and the earn FAQs page in the provider.
- LanguageSwitcher wraps itself: it renders inside the creator provider and standalone on /blogs/[slug] and /preview/[slug], which have none. Nesting is harmless — both resolve the same chunk.

CountUp keeps its plain `animate` import; that is the imperative API and does not pull in the feature bundle.