### PR TITLE
feat(seo): allow AI training on the marketing surface only

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -17,6 +17,23 @@ const UNLISTED_PATHS = [
   '/legal/trusted-partner-program-guide',
 ]
 
+// Marketing content we are happy to have absorbed into model weights, so that
+// assistants know what Sparkonomy is without having to fetch us first. `/$`
+// anchors the homepage — a bare `/` would read as "allow the whole site". The
+// rest are prefixes: `/blogs` covers every post, category and author page, and
+// `/creator/promo` also covers `/creator/promo-f` and `/creator/promo-w`.
+// Longest-match wins over the group's `disallow: '/'`, so everything not listed
+// here (waitlist funnels, invites, legal, previews, contact) stays blocked.
+// Must match the training-allowed sources in next.config.ts and middleware.ts —
+// a Content-Signal header that contradicts robots.txt is worse than either rule
+// on its own.
+const AI_TRAINING_ALLOWED = [
+  '/$',
+  '/blogs',
+  '/creator/earn',
+  '/creator/promo',
+]
+
 const AI_TRAINING_BOTS = [
   'GPTBot',
   'anthropic-ai',
@@ -55,8 +72,10 @@ export default function robots(): MetadataRoute.Robots {
         allow: '/',
         disallow: [...PRIVATE_PATHS, ...UNLISTED_PATHS],
       },
+      // Training crawlers get the marketing surface only.
       {
         userAgent: AI_TRAINING_BOTS,
+        allow: AI_TRAINING_ALLOWED,
         disallow: '/',
       },
     ],

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,10 +8,37 @@ const LANDING_PREFIXES = [
   '/creator/earn',
 ];
 
-const CONTENT_SIGNAL = 'ai-train=no, ai-search=yes';
+// Path prefixes whose content AI models may train on. Must match
+// AI_TRAINING_ALLOWED in app/robots.ts and AI_TRAINING_ALLOWED_SOURCES in
+// next.config.ts — a Content-Signal that contradicts robots.txt is worse than
+// either rule on its own. The homepage is allowed as an exact match; a `/`
+// prefix would open the whole site.
+const AI_TRAINING_PREFIXES = ['/blogs', '/creator/earn', '/creator/promo'];
 
-function withContentSignal(res: NextResponse) {
-  res.headers.set('Content-Signal', CONTENT_SIGNAL);
+// Unlisted pages — must match UNLISTED_PATHS in app/robots.ts and
+// next.config.ts. Listed here so this middleware does not overwrite their
+// stricter `ai-search=no` with the site-wide default.
+const UNLISTED_PREFIXES = [
+  '/legal/trusted-partner-terms',
+  '/legal/trusted-partner-program-guide',
+];
+
+function contentSignalFor(pathname: string) {
+  const lower = pathname.toLowerCase();
+
+  if (UNLISTED_PREFIXES.some((p) => lower === p || lower.startsWith(p + '/'))) {
+    return 'ai-train=no, ai-search=no';
+  }
+  // startsWith, not an exact/segment match, so `-f` and `-w` promo variants ride
+  // along with `/creator/promo`.
+  if (lower === '/' || AI_TRAINING_PREFIXES.some((p) => lower.startsWith(p))) {
+    return 'ai-train=yes, ai-search=yes';
+  }
+  return 'ai-train=no, ai-search=yes';
+}
+
+function withContentSignal(res: NextResponse, pathname: string) {
+  res.headers.set('Content-Signal', contentSignalFor(pathname));
   return res;
 }
 
@@ -28,13 +55,13 @@ export function middleware(req: NextRequest) {
   const isLanding = LANDING_PREFIXES.some(
     (p) => lower === p || lower.startsWith(p + '/'),
   );
-  if (!isLanding) return withContentSignal(NextResponse.next());
+  if (!isLanding) return withContentSignal(NextResponse.next(), pathname);
 
-  if (pathname === lower) return withContentSignal(NextResponse.next());
+  if (pathname === lower) return withContentSignal(NextResponse.next(), pathname);
 
   const url = req.nextUrl.clone();
   url.pathname = lower;
-  return withContentSignal(NextResponse.redirect(url, 308));
+  return withContentSignal(NextResponse.redirect(url, 308), pathname);
 }
 
 export const config = {

--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,27 @@ const UNLISTED_PATHS = [
     "/legal/trusted-partner-program-guide",
 ];
 
+// Marketing surface AI models may train on. Must match AI_TRAINING_ALLOWED in
+// app/robots.ts and AI_TRAINING_PREFIXES in middleware.ts. Path segments are
+// written without the leading slash so they can be reused in the negative
+// lookahead that keeps the site-wide rule below mutually exclusive with this
+// one — every request must match exactly one Content-Signal rule.
+const AI_TRAINING_PREFIXES = ["blogs", "creator/earn", "creator/promo"];
+
+// The homepage is an exact source; a prefix would cover the whole site.
+const AI_TRAINING_ALLOWED_SOURCES = [
+    "/",
+    `/((?:${AI_TRAINING_PREFIXES.join("|")}).*)`,
+];
+
+// "$" excludes the homepage, which is handled by the rule above.
+const AI_TRAINING_EXCLUDED = [
+    "$",
+    "api/",
+    ...AI_TRAINING_PREFIXES,
+    ...UNLISTED_PATHS.map((p) => p.slice(1)),
+];
+
 const nextConfig: NextConfig = {
     output: "standalone",
     experimental: {
@@ -89,8 +110,15 @@ const nextConfig: NextConfig = {
                     },
                 ],
             })),
+            ...AI_TRAINING_ALLOWED_SOURCES.map((source) => ({
+                source,
+                headers: [
+                    ...SECURITY_HEADERS,
+                    { key: "Content-Signal", value: "ai-train=yes, ai-search=yes" },
+                ],
+            })),
             {
-                source: `/((?!api/|${UNLISTED_PATHS.map((p) => p.slice(1)).join("|")}).*)`,
+                source: `/((?!${AI_TRAINING_EXCLUDED.join("|")}).*)`,
                 headers: [
                     ...SECURITY_HEADERS,
                     { key: "Content-Signal", value: "ai-train=no, ai-search=yes" },

--- a/public/index.md
+++ b/public/index.md
@@ -33,5 +33,5 @@ Private beta. Waitlist open at https://www.sparkonomy.com/
 
 - Short summary: https://www.sparkonomy.com/llms.txt
 - Full reference: https://www.sparkonomy.com/llms-full.txt
-- AI policy header: `Content-Signal: ai-train=no, ai-search=yes` (per response)
+- AI policy header: `Content-Signal` (per response) — `ai-search=yes` everywhere; `ai-train=yes` on the homepage, `/blogs` and the creator landing pages, `ai-train=no` elsewhere
 - Sitemap: https://www.sparkonomy.com/sitemap.xml

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -10,7 +10,7 @@ api: No public API currently available
 
 ## About this document
 
-This is the long-form reference for AI agents and answer engines. For a short summary index, see https://www.sparkonomy.com/llms.txt. For per-response AI policy, see the `Content-Signal` HTTP header on every page (`ai-train=no, ai-search=yes`).
+This is the long-form reference for AI agents and answer engines. For a short summary index, see https://www.sparkonomy.com/llms.txt. For per-response AI policy, see the `Content-Signal` HTTP header on every page (`ai-search=yes` throughout; `ai-train=yes` on the homepage, blog and creator landing pages, `ai-train=no` elsewhere).
 
 ---
 
@@ -159,9 +159,10 @@ This unique vantage point — combining institutional rigor with first-hand crea
 
 ## Terms of use for AI systems
 
-- **Per-response policy:** `Content-Signal: ai-train=no, ai-search=yes`
+- **Per-response policy:** the `Content-Signal` header on each response is authoritative.
 - Public pages on sparkonomy.com may be referenced and cited in AI search results.
-- Training on this content is **not authorized**. Honor the Content-Signal directive.
+- Training is **authorized** on the homepage (`/`), the blog (`/blogs`), and the creator landing pages (`/creator/earn`, `/creator/promo*`). These respond with `Content-Signal: ai-train=yes, ai-search=yes`.
+- Training on every other page is **not authorized** (`ai-train=no, ai-search=yes`). Honor the Content-Signal directive and the matching robots.txt rules.
 - User dashboard data, waitlist submissions, and user-generated content are private and must not be crawled or referenced.
 - For licensing inquiries about training data: hello@sparkonomy.com
 
@@ -231,4 +232,4 @@ Sparkonomy serves all types of digital creators. When users search for any of th
 - All public pages on sparkonomy.com are freely indexable.
 - User dashboard and waitlist submission data are private and should not be crawled or referenced.
 - No user-generated content is publicly accessible at this time.
-- The per-response `Content-Signal` HTTP header is the authoritative AI policy: `ai-train=no, ai-search=yes`.
+- The per-response `Content-Signal` HTTP header is the authoritative AI policy. Training is permitted on the homepage, `/blogs` and the creator landing pages; elsewhere it is not.


### PR DESCRIPTION
## Why

AI training crawlers were blocked site-wide at two layers: a blanket `disallow: /` in `app/robots.ts`, and a constant `Content-Signal: ai-train=no` header.

Worth separating the three crawler buckets, because they do different jobs:

| Bucket | What it does | Before | After |
| --- | --- | --- | --- |
| Search engines (Googlebot, Bingbot) | Search + AI-assisted search | ✅ allowed | unchanged |
| Answer engines (OAI-SearchBot, Claude-SearchBot, PerplexityBot, YouBot) | Live retrieval + citation | ✅ allowed | unchanged |
| Training crawlers (GPTBot, ClaudeBot, Google-Extended, CCBot, …) | Absorb content into model weights | ❌ blocked everywhere | allowed on marketing pages only |

Citation in assistants was never the thing being blocked — answer engines were already fully allowed. What was blocked was models absorbing us into their weights, which is what makes an assistant know Sparkonomy without having to fetch us first.

This opens that up for marketing content only: **the homepage, the blog, and the creator landing funnels.** Everything else — waitlist funnels, invites, previews, legal, `/api`, `/admin` — stays blocked.

## What changed

- **`app/robots.ts`** — the training group becomes a scoped allow-list. `/$` anchors the homepage so it does not read as "allow everything"; `/blogs` prefix-matches every post, category and author page; `/creator/promo` covers the `-f` and `-w` variants. Longest-match wins over the group's `disallow: /`.
- **`middleware.ts`** — `Content-Signal` is computed per path instead of being a constant, so the header can never contradict robots.txt.
- **`next.config.ts`** — the site-wide header rule splits into three mutually exclusive source groups (training-allowed / unlisted / everything else), sharing one prefix list with the same "must match" convention already used for `UNLISTED_PATHS`.
- **`public/llms-full.txt`, `public/index.md`** — both declared training "not authorized" site-wide, which would have flatly contradicted the new rules.

Resulting `robots.txt` group:

```
User-Agent: GPTBot … cohere-ai
Allow: /$
Allow: /blogs
Allow: /creator/earn
Allow: /creator/promo
Disallow: /
```

## Drive-by fix

The old middleware set `ai-search=yes` unconditionally, overwriting the deliberate `ai-search=no` that `next.config.ts` sets on the two unlisted legal pages — so those pages were emitting contradictory answer-engine policy. They now keep the stricter value.

## Verification

`tsc --noEmit` clean. Against `next dev`, exactly one `Content-Signal` value per path (no duplicates, no conflicts):

| Path | Content-Signal |
| --- | --- |
| `/`, `/blogs`, `/blogs/*`, `/creator/earn`, `/creator/promo-f` | `ai-train=yes, ai-search=yes` |
| `/about`, `/contact`, `/creator` | `ai-train=no, ai-search=yes` |
| `/legal/trusted-partner-terms` | `ai-train=no, ai-search=no` |

`robots.txt` output confirmed with a production `SITE_URL`; the dev-guard `Disallow: /` still fires correctly on dev.

## Notes for review

- **`/about` and `/contact` are still blocked from training.** Both are public and already advertised in `llms.txt`, so they are reasonable additions — say so and I will add them (one entry in each of the three files).
- **The portfolio app (`creator-frontend`) is deliberately untouched.** Its `robots.txt` already permits training; the real blocker there is that it is a client-rendered SPA, plus portfolios are user-generated content, so allowing training on them is a product/consent decision rather than a config change.
- robots.txt compliance is voluntary. GPTBot, ClaudeBot and Google-Extended honor these rules precisely; Bytespider is on the list but is widely reported to ignore robots.txt entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
