### PR TITLE
feat(portfolio): wire hero to public portfolio user_details API

### DIFF
--- a/app/creator/portfolio/PortfolioPage.tsx
+++ b/app/creator/portfolio/PortfolioPage.tsx
@@ -5,11 +5,13 @@ import { useSearchParams } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import dynamic from "next/dynamic";
 import "@/lib/i18n"; // Initialize i18n
+import MotionProvider from "@/components/MotionProvider";
 import Navigation from "@/components/creator/earn/Navigation";
 import HeroSection from "@/components/creator/portfolio/HeroSection";
 import HeroIntro from "@/components/creator/portfolio/HeroIntro";
 import LandingBlobs from "@/components/creator/portfolio/LandingBlobs";
 import { SignupProvider } from "@/components/creator/promo/SignupContext";
+import { usePortfolioUserDetails } from "@/lib/hooks/usePortfolioUserDetails";
 
 // Below-the-fold sections are lazy-loaded, mirroring the earn funnel. Advantage
 // and FAQ come straight from the shared earn components (they already accept a
@@ -33,32 +35,77 @@ function CreatorPortfolioPageContent() {
   }, [searchParams, i18n]);
 
   // Two hero versions:
-  //   • "Claim your portfolio"      → the creator's own video (from the API).
+  //   • "Claim your portfolio"      → the creator's own media (from the API).
   //   • "Want a portfolio like @X"  → the placeholder clip.
-  // Until the portfolio API is wired here, the video/poster come off the URL
-  // (?video=<url>&poster=<url>). Replace this with the real fetch — pass the
-  // resolved URLs straight into <HeroSection>. Absent → HeroSection uses the
-  // bundled placeholder.
-  const heroVideoUrl = searchParams.get("video");
-  const heroPosterUrl = searchParams.get("poster");
+  //
+  // Creators land here as /creator/portfolio?portfolio_slug=<slug>. That slug is
+  // the only input to the public portfolio API — the same `user_details` section
+  // the creator app's portfolio hero reads (GET /v1/portfolios/{slug}/sections/
+  // user_details). It carries the hero video, its poster, a still fallback, the
+  // focal point, and the creator's display name.
+  //
+  // No slug, an unknown slug, or a creator with no hero media → the hook yields
+  // null and HeroSection falls back to the bundled placeholder clip, which is
+  // exactly the "want a portfolio like @X" version.
+  //
+  // TO CHECK: the happy path here is unverified. What's been confirmed is the
+  // endpoint exists on both app-api-dev and app-api (unknown slug → 404), and
+  // that CORS allows dev.sparkonomy.com / www.sparkonomy.com respectively. What
+  // hasn't: an actual portfolio slug returning hero media, and that media
+  // rendering in the band. Open /creator/portfolio?portfolio_slug=<real-slug>
+  // and confirm the creator's own video plays instead of the placeholder.
+  // Note the failure mode is silent by design — every error becomes the
+  // placeholder clip, so a wrong field name or shape would look like a creator
+  // who simply has no video. Check the network tab, not just the page.
+  const portfolioSlug = searchParams.get("portfolio_slug");
+  const { data: userDetails } = usePortfolioUserDetails(portfolioSlug);
+
+  // ?video= / ?poster= stay as demo overrides so the hero can be previewed
+  // without a real portfolio behind it. Absent → the API values win.
+  const heroVideoUrl = searchParams.get("video") ?? userDetails?.hero_video_url;
+  const heroPosterUrl =
+    searchParams.get("poster") ?? userDetails?.hero_video_poster_url;
 
   return (
     <SignupProvider socialAuthAfterVerify namespace="creatorPortfolio">
+      {/* Required: every section under components/creator/** renders `m.*`, which
+          needs a LazyMotion ancestor. Without it the feature bundle never loads,
+          `whileInView` never fires, and the below-the-fold sections stay stuck at
+          their `initial` opacity: 0 (visible as an empty gap under the hero). */}
+      <MotionProvider>
       <main className="relative min-h-screen bg-black overflow-hidden">
         {/* Decorative background blobs (config in components/creator/portfolio/blobConfig.ts). */}
         <LandingBlobs />
 
         {/* Content */}
         <div className="relative z-10">
-          <Navigation namespace="creatorPortfolio" className="py-2 md:py-2" />
+          <Navigation
+            namespace="creatorPortfolio"
+            languageSwitcherVariant="segmented"
+            className="py-2 md:py-2"
+          />
           {/* Invitation-only strip directly below the header. */}
-          <div className="relative z-40 border-y border-white/10 bg-black/40 px-5 py-1.5 text-center backdrop-blur-sm">
-            <p className="text-[11px] font-medium uppercase tracking-[0.15em] text-[#DD2A7B]">
+          {/* `backgroundImage` (not the `background` shorthand) so the warm glow
+              layers over the bg-black/40 base rather than replacing it — the
+              gradient is transparent at both ends and only lights the middle. */}
+          <div
+            className="relative z-40 border-y border-white/10 bg-black/40 px-5 py-1.5 text-center backdrop-blur-sm"
+            style={{
+              backgroundImage:
+                "linear-gradient(90deg, rgba(254, 226, 176, 0) 0%, rgba(254, 226, 176, 0.475962) 52.4%, rgba(254, 226, 176, 0) 100%)",
+            }}
+          >
+            <p className="text-[11px] font-medium uppercase tracking-[0.15em] text-white">
               {t("nav.invitationStrip")}
             </p>
           </div>
           {/* Hero = video band only (relative, h-[60vh]). */}
-          <HeroSection videoUrl={heroVideoUrl} posterUrl={heroPosterUrl} />
+          <HeroSection
+            videoUrl={heroVideoUrl}
+            posterUrl={heroPosterUrl}
+            imageUrl={userDetails?.hero_image_url}
+            focalPoint={userDetails?.hero_focal_point}
+          />
 
           {/* Everything else — identity + card + ALL sections — in ONE
               container, positioned to start 100px from the top of the hero.
@@ -72,7 +119,7 @@ function CreatorPortfolioPageContent() {
               layout while the page still scrolls. Change the 100px to shift the
               whole block up/down the video. */}
           <div className="relative z-30 -mt-[calc(60vh-400px)]">
-            <HeroIntro />
+            <HeroIntro displayName={userDetails?.display_name} />
             {/* 3. Your Advantage */}
             <AdvantageSection
               variant="promo"
@@ -105,6 +152,7 @@ function CreatorPortfolioPageContent() {
           cardBackground="linear-gradient(171.03deg, #000000 -0.78%, rgba(221, 42, 123, 0.09) 100.02%)"
         />
       </main>
+      </MotionProvider>
     </SignupProvider>
   );
 }

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -10,9 +10,19 @@ import MotionProvider from "@/components/MotionProvider";
 
 interface LanguageSwitcherProps {
   className?: string;
+  /**
+   * "dropdown" (default) — globe + current language + chevron, opens a menu.
+   * "segmented" — both languages side by side in one pill, active one ringed.
+   *   Used on /creator/portfolio, where the choice is meant to read as a
+   *   one-tap toggle rather than a menu to open.
+   */
+  variant?: "dropdown" | "segmented";
 }
 
-export const LanguageSwitcher = ({ className }: LanguageSwitcherProps) => {
+export const LanguageSwitcher = ({
+  className,
+  variant = "dropdown",
+}: LanguageSwitcherProps) => {
   const { i18n } = useTranslation();
   const router = useRouter();
   const pathname = usePathname();
@@ -54,6 +64,59 @@ export const LanguageSwitcher = ({ className }: LanguageSwitcherProps) => {
 
     setIsOpen(false);
   };
+
+  if (variant === "segmented") {
+    return (
+      <MotionProvider>
+        <m.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.4, duration: 0.5 }}
+          className={`w-fit ${className ?? ""}`}
+        >
+          <div
+            className="relative flex items-center rounded-full p-1"
+            style={{
+              background: "rgba(255,255,255,0.06)",
+              border: "1px solid rgba(255,255,255,0.14)",
+              backdropFilter: "blur(14px)",
+              WebkitBackdropFilter: "blur(14px)",
+            }}
+          >
+            {languages.map((lang) => {
+              const isActive = currentLang === lang.code;
+              return (
+                <button
+                  key={lang.code}
+                  type="button"
+                  aria-pressed={isActive}
+                  onClick={() => handleLanguageSelect(lang.code)}
+                  className={`
+                    relative rounded-full px-4 py-1.5
+                    text-[15px] font-medium leading-none
+                    transition-colors duration-200 select-none
+                    ${isActive ? "text-white" : "text-white/60 hover:text-white/90"}
+                  `}
+                >
+                  {/* The ring travels between the two options instead of
+                      cross-fading — layoutId needs the domMax feature bundle,
+                      which MotionProvider already loads. */}
+                  {isActive && (
+                    <m.span
+                      layoutId="language-switcher-pill"
+                      transition={{ type: "spring", stiffness: 400, damping: 32 }}
+                      className="absolute inset-0 rounded-full border border-white/45 bg-white/10"
+                    />
+                  )}
+                  <span className="relative z-10">{lang.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </m.div>
+      </MotionProvider>
+    );
+  }
 
   // Self-contained MotionProvider: this component renders on the creator routes
   // (already inside a provider — nesting is harmless, both resolve the same

--- a/components/creator/earn/Navigation.tsx
+++ b/components/creator/earn/Navigation.tsx
@@ -12,6 +12,9 @@ interface NavigationProps {
   showLanguageSwitcher?: boolean;
   showCTA?: boolean;
   namespace?: string;
+  // "segmented" renders both languages as a single pill toggle instead of the
+  // default globe + chevron dropdown.
+  languageSwitcherVariant?: "dropdown" | "segmented";
   // Optional overrides for the <nav> classes (merged via tailwind-merge, so
   // e.g. passing "py-2 md:py-2" overrides the default vertical padding).
   className?: string;
@@ -21,6 +24,7 @@ export default function Navigation({
   showLanguageSwitcher = true,
   showCTA = true,
   namespace = "creatorEarn",
+  languageSwitcherVariant = "dropdown",
   className,
 }: NavigationProps = {}) {
   const { t } = useTranslation(namespace);
@@ -51,7 +55,7 @@ export default function Navigation({
         <div className="flex items-center gap-3">
           {showLanguageSwitcher && (
             <Suspense fallback={null}>
-              <LanguageSwitcher />
+              <LanguageSwitcher variant={languageSwitcherVariant} />
             </Suspense>
           )}
           {/* Hidden on mobile, visible on md and above */}

--- a/components/creator/portfolio/HeroIntro.tsx
+++ b/components/creator/portfolio/HeroIntro.tsx
@@ -5,21 +5,28 @@ import { ChevronDown, Clock } from "lucide-react";
 import PromoSignupCard from "@/components/creator/promo/PromoSignupCard";
 import PortfolioName from "./PortfolioName";
 
+interface HeroIntroProps {
+  // Creator's name from the portfolio API (`user_details.display_name`), shown
+  // in the H1. Falls back to the i18n placeholder before the fetch resolves and
+  // when the page is opened without a `?portfolio_slug=`.
+  displayName?: string | null;
+}
+
 // Identity lines + signup/claim card. Lives at the top of the content stack
 // (above the Advantage/FAQ sections) so the card and the sections share one
 // normal-flow container — that's what keeps the card from overlapping the
 // sections as it expands.
-export default function HeroIntro() {
+export default function HeroIntro({ displayName }: HeroIntroProps = {}) {
   const { t } = useTranslation("creatorPortfolio");
 
   return (
     <div className="mx-auto flex w-full max-w-[520px] flex-col items-center px-4">
-      {/* Identity — name + tagline + claim line. name/@handle come from the API
-          alongside the video; these are the placeholders. */}
+      {/* Identity — name + tagline + claim line. The name comes from the API
+          alongside the video; the i18n string is the pre-fetch placeholder. */}
       <div className="mb-6 text-center text-white">
         {/* Name rendered with the portfolio hero's fit-to-width / two-line /
             truncate logic. */}
-        <PortfolioName displayName={t("hero.name")} />
+        <PortfolioName displayName={displayName || t("hero.name")} />
         <p className="mt-4 text-[32px] font-bold leading-tight drop-shadow-[0_2px_12px_rgba(0,0,0,0.7)]">
           <Trans i18nKey="hero.tagline" t={t} components={[<span key="h" className="text-white/90" />]} />
         </p>

--- a/components/creator/portfolio/HeroSection.tsx
+++ b/components/creator/portfolio/HeroSection.tsx
@@ -1,30 +1,70 @@
 "use client";
 
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useSectionViewTracking } from "@/lib/hooks/useSectionViewTracking";
 
-// Placeholder clip shown when the API doesn't hand us a creator video — i.e.
-// the "someone wants a portfolio like @X" version. When a video URL is provided
-// (the "claim your own portfolio" version) it plays that instead.
+// Placeholder clip shown when the API doesn't hand us any creator media — i.e.
+// the "someone wants a portfolio like @X" version. When the portfolio's own
+// media is available (the "claim your own portfolio" version) it plays that
+// instead.
 const PLACEHOLDER_VIDEO = "/videos/portfolio-hero-placeholder.mp4";
 
 interface HeroSectionProps {
-  // API-provided hero video for the portfolio being claimed. Falls back to the
-  // placeholder clip when null/undefined.
+  // Hero backdrop media from `user_details` (see lib/portfolio/api.ts). The
+  // fallback chain mirrors the creator app's portfolio hero:
+  //   hero_video_url → hero_image_url (still) → placeholder clip.
   videoUrl?: string | null;
-  // Optional poster frame while the video buffers.
+  // Poster frame while the video buffers; the still falls in behind it.
   posterUrl?: string | null;
+  // Still backdrop used when the creator has no hero video.
+  imageUrl?: string | null;
+  // Normalised 0–1 coords → `object-position`, so the subject stays in frame
+  // when the media is cropped to the band.
+  focalPoint?: { x: number; y: number } | null;
 }
 
 // Hero = the video band only (relative, h-[50vh]). The identity + card + the
 // rest of the sections are rendered by the page in ONE container positioned
 // relative to this section (see PortfolioPage), so they overlay the video and
 // stack together.
-export default function HeroSection({ videoUrl, posterUrl }: HeroSectionProps = {}) {
+export default function HeroSection({
+  videoUrl,
+  posterUrl,
+  imageUrl,
+  focalPoint,
+}: HeroSectionProps = {}) {
   const sectionRef = useRef<HTMLElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
   useSectionViewTracking(sectionRef, "portfolio_hero", { event: "portfolio_hero_view" });
 
-  const src = videoUrl || PLACEHOLDER_VIDEO;
+  // A still is only used when the creator has no hero video at all — otherwise
+  // it (and the poster) just cover the video while it buffers.
+  const src = videoUrl || (imageUrl ? null : PLACEHOLDER_VIDEO);
+  const poster = posterUrl ?? imageUrl ?? undefined;
+  const objectPosition = focalPoint
+    ? `${focalPoint.x * 100}% ${focalPoint.y * 100}%`
+    : "center";
+
+  // A playing video repaints its layer every frame, and the nav's backdrop-blur
+  // has to re-sample that region each time. Off screen none of it is visible but
+  // the browser keeps paying for it — so pause once the hero scrolls away.
+  // (Same treatment as the creator app's portfolio hero.)
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || typeof IntersectionObserver === "undefined") return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        if (entry.isIntersecting) void video.play().catch(() => {});
+        else video.pause();
+      },
+      { threshold: 0 },
+    );
+    observer.observe(video);
+    return () => observer.disconnect();
+  }, [src]);
 
   return (
     <section ref={sectionRef} className="relative h-[60vh] overflow-hidden">
@@ -41,17 +81,33 @@ export default function HeroSection({ videoUrl, posterUrl }: HeroSectionProps = 
             "linear-gradient(to bottom, black 0%, black 78%, transparent 100%)",
         }}
       >
-        <video
-          key={src}
-          className="absolute inset-0 h-full w-full object-cover"
-          src={src}
-          poster={posterUrl ?? undefined}
-          autoPlay
-          muted
-          loop
-          playsInline
-          preload="metadata"
-        />
+        {src ? (
+          <video
+            ref={videoRef}
+            key={src}
+            // Decorative, muted background loop with no audible track — hidden
+            // from assistive tech.
+            aria-hidden="true"
+            className="absolute inset-0 h-full w-full object-cover"
+            style={{ objectPosition }}
+            src={src}
+            poster={poster}
+            autoPlay
+            muted
+            loop
+            playsInline
+            preload="metadata"
+          />
+        ) : (
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-cover bg-no-repeat"
+            style={{
+              backgroundImage: `url(${imageUrl})`,
+              backgroundPosition: objectPosition,
+            }}
+          />
+        )}
         {/* Legibility overlay so the white text + card read over the video. */}
         <div className="absolute inset-0 bg-gradient-to-b from-black/55 via-black/25 to-black/80" />
       </div>

--- a/lib/hooks/usePortfolioUserDetails.ts
+++ b/lib/hooks/usePortfolioUserDetails.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fetchPortfolioUserDetails } from "@/lib/portfolio/api";
+import type { PortfolioUserDetails } from "@/types/portfolio";
+
+interface PortfolioUserDetailsState {
+  data: PortfolioUserDetails | null;
+  /** `true` while the request is in flight. `false` when there's no slug to fetch. */
+  loading: boolean;
+}
+
+/**
+ * Fetches the `user_details` section for a public portfolio.
+ *
+ * This repo has no react-query (unlike creator-frontend, where the equivalent
+ * is `usePublicPortfolioSection`), so this is a plain fetch-on-mount hook. The
+ * request aborts on unmount and whenever the slug changes, and a stale response
+ * can never overwrite a newer one — the `cancelled` guard drops it.
+ *
+ * Never rejects: `fetchPortfolioUserDetails` maps 404 / timeout / network
+ * failure to `null`, which the hero renders as "no creator media" and falls
+ * back to the bundled placeholder.
+ */
+export function usePortfolioUserDetails(
+  slug: string | null | undefined,
+): PortfolioUserDetailsState {
+  const [state, setState] = useState<PortfolioUserDetailsState>({
+    data: null,
+    loading: Boolean(slug),
+  });
+
+  useEffect(() => {
+    if (!slug) {
+      setState({ data: null, loading: false });
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    setState({ data: null, loading: true });
+
+    fetchPortfolioUserDetails(slug, controller.signal).then((response) => {
+      if (cancelled) return;
+      setState({ data: response?.data ?? null, loading: false });
+    });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [slug]);
+
+  return state;
+}

--- a/lib/portfolio/api.ts
+++ b/lib/portfolio/api.ts
@@ -1,0 +1,64 @@
+import type { PortfolioUserDetailsResponse } from "@/types/portfolio";
+
+// 10s matches the other API helpers in this repo (lib/auth/fetch.ts,
+// lib/hooks/useSubmitEmail.tsx) so failure-mode UX is consistent.
+const TIMEOUT_MS = 10_000;
+
+/**
+ * `GET /v1/portfolios/{slug}/sections/user_details` — the public portfolio
+ * section that carries the hero backdrop media (video / still / poster /
+ * focal point) plus the creator's display name and headline.
+ *
+ * Public endpoint: no auth, no cookies — hence no `credentials: "include"`
+ * (mirrors `axiosInstancePublic` in creator-frontend, which sets
+ * `withCredentials: false`). The slug is the only input; the route accepts
+ * either a UUID or a slug.
+ *
+ * Returns `null` rather than throwing when the portfolio doesn't exist, the
+ * request times out, or the network fails — the hero has a placeholder for
+ * every one of those cases, so there's nothing for a caller to handle.
+ *
+ * TO CHECK: only exercised against a 404 so far. The response shape below is
+ * taken from the creator app's contract (SectionEnvelope<'user_details',
+ * UserDetailsData>) rather than from an observed 200 on this host — verify a
+ * real slug returns `{ data: { hero_video_url, ... } }` and that the field
+ * names still match types/portfolio.ts. Because every failure collapses to
+ * `null`, a shape mismatch degrades quietly to the placeholder clip.
+ */
+export async function fetchPortfolioUserDetails(
+  slug: string,
+  signal?: AbortSignal,
+): Promise<PortfolioUserDetailsResponse | null> {
+  const base = process.env.NEXT_PUBLIC_API_BASE;
+  if (!base || !slug) return null;
+
+  // Compose the caller's signal (unmount / slug change) with our own timeout so
+  // either can abort the request.
+  const controller = new AbortController();
+  const onAbort = () => controller.abort();
+  signal?.addEventListener("abort", onAbort);
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const res = await fetch(
+      `${base}/v1/portfolios/${encodeURIComponent(slug)}/sections/user_details`,
+      {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      },
+    );
+
+    // 404 = no such portfolio (or the section isn't confirmed yet). Treated the
+    // same as "no media" — the placeholder clip covers it.
+    if (!res.ok) return null;
+
+    const parsed = (await res.json()) as PortfolioUserDetailsResponse;
+    return parsed?.data ? parsed : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+    signal?.removeEventListener("abort", onAbort);
+  }
+}

--- a/types/portfolio.ts
+++ b/types/portfolio.ts
@@ -1,0 +1,35 @@
+// Types for the public portfolio API (`/v1/portfolios/{slug}/sections/...`).
+//
+// This is the same backend surface the creator app reads
+// (creator-frontend/src/types/publicPortfolio.ts). Only the `user_details`
+// section is modelled here — it's all the landing page's claim flow needs.
+// Keep the field names in sync with that file if the backend contract moves.
+
+/** Every section endpoint returns its payload inside this envelope. */
+export interface PortfolioSectionEnvelope<T extends string, D> {
+  section_type: T;
+  display_order: number;
+  data: D;
+  confirmed_at: string;
+}
+
+export interface PortfolioUserDetails {
+  display_name: string;
+  headline: string;
+  location: string;
+  /** Whether the creator has already claimed this portfolio. */
+  is_claimed?: boolean;
+  // Hero backdrop media (public GCS URLs). All optional — absent means fall
+  // back down the chain in components/creator/portfolio/HeroSection.tsx.
+  hero_image_url?: string | null;
+  hero_video_url?: string | null;
+  hero_video_poster_url?: string | null;
+  /** Normalised 0–1 coordinates → CSS `object-position` on the hero media. */
+  hero_focal_point?: { x: number; y: number } | null;
+  hero_source?: "auto" | "manual";
+}
+
+export type PortfolioUserDetailsResponse = PortfolioSectionEnvelope<
+  "user_details",
+  PortfolioUserDetails
+>;


### PR DESCRIPTION
## Summary

Wires the `/creator/portfolio` hero to the public portfolio API instead of the temporary `?video=` / `?poster=` URL params.

Creators land on `/creator/portfolio?portfolio_slug=<slug>`. That slug is the only input to `GET /v1/portfolios/{slug}/sections/user_details` — the same public section the creator app's portfolio hero reads. It carries the hero video, its poster, a still fallback, the focal point, and the creator's display name.

## Changes

**New**
- `types/portfolio.ts` — envelope + `user_details` shape, mirroring `creator-frontend/src/types/publicPortfolio.ts`
- `lib/portfolio/api.ts` — `fetchPortfolioUserDetails(slug, signal)`; public (no cookies), 10s timeout to match the other API helpers in this repo, maps 404 / timeout / network failure to `null`
- `lib/hooks/usePortfolioUserDetails.ts` — plain fetch-on-mount hook (no react-query in this repo); aborts on unmount and slug change, stale responses can't overwrite newer ones

**Hero**
- `HeroSection` — fallback chain `hero_video_url` → `hero_image_url` (still) → bundled placeholder clip. Focal point maps to `object-position` so the subject stays in frame when cropped to the band. Video pauses via `IntersectionObserver` once the hero scrolls away (a playing video forces the nav's `backdrop-blur` to re-sample every frame). Backdrop marked `aria-hidden`.
- `HeroIntro` — renders the API `display_name`, with the i18n string as the pre-fetch placeholder

**Page / chrome**
- `PortfolioPage` wrapped in `MotionProvider` — the sections under `components/creator/**` render `m.*`, which needs a `LazyMotion` ancestor; without it `whileInView` never fires and the below-the-fold sections sat stuck at `opacity: 0`
- `LanguageSwitcher` — new `"segmented"` variant (both languages in one pill, ring animates between them via `layoutId`), exposed through `Navigation`'s `languageSwitcherVariant` prop. Default stays `"dropdown"`, so no other route changes.
- Invitation-only strip restyled with the warm gradient glow (`backgroundImage`, not the `background` shorthand, so it layers over the `bg-black/40` base)

`?video=` / `?poster=` are kept as demo overrides that win over the API, so the hero can still be previewed without a real portfolio behind it.

## Testing

Not fully verified — worth a look before merge.

- Confirmed: the endpoint exists on both `app-api-dev` and `app-api` (unknown slug → 404), and CORS allows `dev.sparkonomy.com` / `www.sparkonomy.com` respectively.
- **Not confirmed:** an actual portfolio slug returning hero media, and that media rendering in the band. Open `/creator/portfolio?portfolio_slug=<real-slug>` and check the creator's own video plays instead of the placeholder.
- The failure mode is silent by design — every error collapses to the placeholder clip, so a wrong field name or response shape would look identical to a creator with no video. Check the network tab, not just the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
