### PR TITLE
fix(preview): match blog post rendering exactly

### DIFF
--- a/app/blogs/tools/barter-deal-checker/BarterDealChecker.tsx
+++ b/app/blogs/tools/barter-deal-checker/BarterDealChecker.tsx
@@ -239,24 +239,32 @@ function compute(form: Form): Result {
 // ──────────────────────────────────────────
 //  SHARED STYLE TOKENS (blog theme)
 // ──────────────────────────────────────────
+/* Panel gradient — sits behind white body copy, so every stop is deepened
+   enough for white to clear WCAG AA (4.5:1). The undeepened brand stops
+   (#DD2A7B / #9747FF) only reach ~4.48:1 against white, which left the
+   smaller sentences on these panels hard to read. */
 const BRAND_GRADIENT =
-  "linear-gradient(135deg, #DD2A7B 0%, #9747FF 50%, #334CCA 100%)";
+  "linear-gradient(135deg, #C42169 0%, #7B2FD9 50%, #2A3FA8 100%)";
 const CREATOR_GRADIENT = "linear-gradient(135deg, #DD2A7B 0%, #9747FF 100%)";
 
 const VERDICT_STYLES: Record<
   Verdict,
   { background: string; color: string }
 > = {
+  /* Light-hued verdicts (green, amber) carry dark ink; deep-hued ones (red,
+     brand purple) carry white. White on the bright green was only 2.2:1 —
+     the worst contrast in the tool — so it keeps its colour and flips to
+     dark ink, the same treatment MAYBE already used. */
   YES: {
     background: "linear-gradient(135deg, #2BB44E 0%, #34C759 100%)",
-    color: "#FFFFFF",
+    color: "#06280F",
   },
   MAYBE: {
     background: "linear-gradient(135deg, #F5A623 0%, #FFCC00 100%)",
     color: "#33270A",
   },
   NO: {
-    background: "linear-gradient(135deg, #E12B20 0%, #FF3B30 100%)",
+    background: "linear-gradient(135deg, #B81C13 0%, #D9291F 100%)",
     color: "#FFFFFF",
   },
   NEED_FEE: { background: BRAND_GRADIENT, color: "#FFFFFF" },
@@ -865,13 +873,16 @@ const BarterDealChecker = ({ embed = false }: { embed?: boolean } = {}) => {
                     className="mb-4 px-5 py-7 text-center"
                     style={{ ...cardRadius, ...style }}
                   >
-                    <p className="mb-2 text-[11px] font-bold uppercase tracking-[.1em] opacity-85">
+                    {/* No opacity on the small copy — dimming 11px and 15px
+                        text over a saturated gradient was what pushed these
+                        sentences below a readable contrast ratio. */}
+                    <p className="mb-2 text-[11px] font-bold uppercase tracking-[.1em]">
                       {copy.label}
                     </p>
                     <p className="mb-2 text-[30px] font-bold leading-tight tracking-tight sm:text-[38px]">
                       {copy.big}
                     </p>
-                    <p className="text-[15px] opacity-95">{copy.sub}</p>
+                    <p className="text-[15px]">{copy.sub}</p>
                   </div>
 
                   {!needsMoreInput && (
@@ -1080,14 +1091,14 @@ const BarterDealChecker = ({ embed = false }: { embed?: boolean } = {}) => {
                     <h3 className="mb-2 text-xl font-bold tracking-tight">
                       Stop guessing on every deal
                     </h3>
-                    <p className="mb-4 text-sm opacity-90">
+                    <p className="mb-4 text-sm">
                       Sparkonomy tracks your deals, deliverables and payments in
                       one place — so you know your worth before the brand tells
                       you.
                     </p>
                     <Link
                       href="/creator/earn?utm_source=blog&utm_medium=tool&utm_campaign=barter_checker"
-                      className="inline-block rounded-full bg-white px-7 py-3 text-[15px] font-bold text-[#9747FF]"
+                      className="inline-block rounded-full bg-white px-7 py-3 text-[15px] font-bold text-[#7B2FD9]"
                     >
                       Join Sparkonomy free
                     </Link>

--- a/app/blogs/wordpress-content.css
+++ b/app/blogs/wordpress-content.css
@@ -11,14 +11,46 @@
   text-align: justify;
 }
 
+/* ====================
+   .not-prose — ESCAPE HATCH FOR EMBEDDED REACT TOOLS
+   ==================== */
+
+/* The blog tools (barter deal checker, calculators) are portalled *into*
+   .wordpress-content by the injectors in components/blog/, so every prose rule
+   below is an ancestor match for their markup. Those rules score (0,1,1) while
+   the tools style themselves with Tailwind utilities at (0,1,0), so the article
+   styles silently win: `.wordpress-content li` forced `display: list-item` over
+   the tool's `flex` and re-enabled the `::marker`, which is why the intro list
+   grew bullet dots in front of its tick badges when embedded but not on
+   /blogs/tools/barter-deal-checker.
+
+   Fixing that needs exclusion, not an override — a higher-specificity reset
+   would beat the tool's own utilities too, and there is no value for `display`
+   that means "let the utility class through". So every prose rule that can
+   reach into a tool carries :not(.not-prose *), the same escape hatch Tailwind
+   Typography ships. Mark a portal container .not-prose and its whole subtree is
+   the tool's own business.
+
+   Adding a prose rule that styles a bare element (p, li, h2, a, b …)? Add the
+   guard too, or it will leak into the tools. */
+.wordpress-content .not-prose {
+  /* These three are inherited from .wordpress-content itself, so :not() on the
+     descendant selectors cannot stop them — the container has to opt out.
+     Values restore the page default the tools get standalone (16px / 1.5),
+     so an embedded tool renders identically to its own route. */
+  text-align: initial;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
 /* Keep headings left-aligned — justify only the running body text so multi-line
    headings don't get their words stretched apart. */
-.wordpress-content h1,
-.wordpress-content h2,
-.wordpress-content h3,
-.wordpress-content h4,
-.wordpress-content h5,
-.wordpress-content h6 {
+.wordpress-content h1:not(.not-prose *),
+.wordpress-content h2:not(.not-prose *),
+.wordpress-content h3:not(.not-prose *),
+.wordpress-content h4:not(.not-prose *),
+.wordpress-content h5:not(.not-prose *),
+.wordpress-content h6:not(.not-prose *) {
   text-align: left;
 }
 
@@ -429,7 +461,7 @@
 }
 
 /* Global heading styles for WordPress content */
-.wordpress-content h1 {
+.wordpress-content h1:not(.not-prose *) {
   font-size: 2.5rem;
   font-weight: 700;
   line-height: 1.15;
@@ -440,7 +472,7 @@
 }
 
 @media (min-width: 768px) {
-  .wordpress-content h1 {
+  .wordpress-content h1:not(.not-prose *) {
     font-size: 3rem;
   }
 }
@@ -449,7 +481,7 @@
    H1 (21:1) → H2 (12.6:1) → H3-H6 (7.5:1) → body p (4.8:1); all pass WCAG AA.
    H2/H3 previously shared the body's #6B7280, and H4-H6 were pure #000000 —
    which made a sub-heading darker than the section heading above it. */
-.wordpress-content h2 {
+.wordpress-content h2:not(.not-prose *) {
   font-size: 1.625rem;
   font-weight: 700;
   line-height: 1.25;
@@ -460,19 +492,19 @@
 }
 
 @media (min-width: 768px) {
-  .wordpress-content h2 {
+  .wordpress-content h2:not(.not-prose *) {
     font-size: 1.875rem;
     margin-top: 1.75rem;
   }
 }
 
 @media (min-width: 1024px) {
-  .wordpress-content h2 {
+  .wordpress-content h2:not(.not-prose *) {
     font-size: 2rem;
   }
 }
 
-.wordpress-content h2:first-child {
+.wordpress-content h2:first-child:not(.not-prose *) {
   margin-top: 0;
 }
 
@@ -599,7 +631,7 @@
   margin-bottom: 0;
 }
 
-.wordpress-content h3 {
+.wordpress-content h3:not(.not-prose *) {
   font-size: 1.375rem !important;
   font-weight: 700;
   line-height: 1.3;
@@ -610,7 +642,7 @@
 }
 
 @media (min-width: 1024px) {
-  .wordpress-content h3 {
+  .wordpress-content h3:not(.not-prose *) {
     font-size: 1.5rem;
   }
 }
@@ -643,7 +675,7 @@
 }
 
 /* Global paragraph and list styles */
-.wordpress-content p {
+.wordpress-content p:not(.not-prose *) {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.7;
@@ -651,25 +683,25 @@
   margin-bottom: 1.5em;
 }
 
-.wordpress-content p:last-child {
+.wordpress-content p:last-child:not(.not-prose *) {
   margin-bottom: 0;
 }
 
 @media (min-width: 768px) {
-  .wordpress-content p {
+  .wordpress-content p:not(.not-prose *) {
     font-size: 1.25rem;
   }
 }
 
-.wordpress-content ul,
-.wordpress-content ol {
+.wordpress-content ul:not(.not-prose *),
+.wordpress-content ol:not(.not-prose *) {
   list-style-position: outside;
   margin-top: 1rem;
   margin-bottom: 1.5rem;
   color: #6B7280;
 }
 
-.wordpress-content ul {
+.wordpress-content ul:not(.not-prose *) {
   list-style-type: disc;
 }
 
@@ -681,7 +713,7 @@
   list-style-type: lower-alpha;
 }
 
-.wordpress-content li {
+.wordpress-content li:not(.not-prose *) {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.7;
@@ -692,7 +724,7 @@
 }
 
 @media (min-width: 768px) {
-  .wordpress-content li {
+  .wordpress-content li:not(.not-prose *) {
     font-size: 1.25rem;
   }
 }
@@ -711,12 +743,12 @@
 }
 
 /* Primary color for list bullets/markers */
-.wordpress-content ul li::marker {
+.wordpress-content ul li:not(.not-prose *)::marker {
   color: #9747FF;
 }
 
-.wordpress-content li strong,
-.wordpress-content li b {
+.wordpress-content li strong:not(.not-prose *),
+.wordpress-content li b:not(.not-prose *) {
   font-size: inherit;
 }
 
@@ -881,13 +913,13 @@
   list-style-type: decimal;
 }
 
-.wordpress-content strong,
-.wordpress-content b {
+.wordpress-content strong:not(.not-prose *),
+.wordpress-content b:not(.not-prose *) {
   font-weight: 600;
 }
 
-.wordpress-content em,
-.wordpress-content i {
+.wordpress-content em:not(.not-prose *),
+.wordpress-content i:not(.not-prose *) {
   font-style: italic;
 }
 
@@ -1874,21 +1906,21 @@
     font-size: 1rem;
   }
 
-  .wordpress-content ul,
-  .wordpress-content ol,
+  .wordpress-content ul:not(.not-prose *),
+  .wordpress-content ol:not(.not-prose *),
   .wordpress-content .wp-block-list {
     padding-left: 1.25rem;
   }
 
-  .wordpress-content h1 {
+  .wordpress-content h1:not(.not-prose *) {
     font-size: 2rem;
   }
 
-  .wordpress-content h2 {
+  .wordpress-content h2:not(.not-prose *) {
     font-size: 1.75rem;
   }
 
-  .wordpress-content h3 {
+  .wordpress-content h3:not(.not-prose *) {
     font-size: 1.5rem;
   }
 
@@ -2340,8 +2372,8 @@
    body text, and it disagreed with the article intro paragraph, which is
    rendered outside .wordpress-content and has always used #7c3aed. Unified on
    #7c3aed (5.7:1) so every link on the page is one colour and passes AA. */
-.wordpress-content p a,
-.wordpress-content li a,
+.wordpress-content p a:not(.not-prose *),
+.wordpress-content li a:not(.not-prose *),
 .wordpress-content td a,
 .wordpress-content th a {
   color: #7c3aed;

--- a/app/blogs/wordpress-content.css
+++ b/app/blogs/wordpress-content.css
@@ -445,12 +445,16 @@
   }
 }
 
+/* Heading colour scale. Contrast against white decreases monotonically
+   H1 (21:1) → H2 (12.6:1) → H3-H6 (7.5:1) → body p (4.8:1); all pass WCAG AA.
+   H2/H3 previously shared the body's #6B7280, and H4-H6 were pure #000000 —
+   which made a sub-heading darker than the section heading above it. */
 .wordpress-content h2 {
   font-size: 1.625rem;
   font-weight: 700;
   line-height: 1.25;
   letter-spacing: -0.01em;
-  color: #6B7280;
+  color: #333333;
   margin-top: 1.5rem;
   margin-bottom: 0.875rem;
 }
@@ -484,7 +488,6 @@
   color: #1f2937;
   margin-top: 2.25rem;
   margin-bottom: 1.25rem;
-  padding: 0;
   background: #F2F2F2;
   border-left: 4px solid #8b5cf6;
   border-radius: 0 0.5rem 0.5rem 0;
@@ -601,7 +604,7 @@
   font-weight: 700;
   line-height: 1.3;
   letter-spacing: -0.005em;
-  color: #6B7280;
+  color: #4B5563;
   margin-top: 2.5rem;
   margin-bottom: 0.875rem;
 }
@@ -616,7 +619,7 @@
   font-size: 1.5rem;
   font-weight: bold;
   line-height: 1.4;
-  color: #000000;
+  color: #4B5563;
   margin-top: 1.75rem;
   margin-bottom: 0.75rem;
 }
@@ -625,7 +628,7 @@
   font-size: 1.25rem;
   font-weight: bold;
   line-height: 1.4;
-  color: #000000;
+  color: #4B5563;
   margin-top: 1.5rem;
   margin-bottom: 0.5rem;
 }
@@ -634,7 +637,7 @@
   font-size: 1.125rem;
   font-weight: bold;
   line-height: 1.4;
-  color: #000000;
+  color: #4B5563;
   margin-top: 1.25rem;
   margin-bottom: 0.5rem;
 }
@@ -668,10 +671,6 @@
 
 .wordpress-content ul {
   list-style-type: disc;
-}
-
-.wordpress-content ol {
-  list-style-type: decimal;
 }
 
 .wordpress-content ul ul {
@@ -866,7 +865,11 @@
   
 }
 
-/* Ensure ordered lists show numbers */
+/* Ensure ordered lists show numbers. Sole standalone `ol` rule — the
+   `list-style-type: decimal` that used to sit beside the `ul` rule above was a
+   dead duplicate of this one. The `margin` here deliberately overrides the
+   1.5rem bottom margin from the shared `ul, ol` block, so `ol` is tighter than
+   `ul`; change it here rather than adding another `ol` block. */
 .wordpress-content ol {
   list-style-type: decimal !important;
   padding-left: 1.5rem;
@@ -1161,7 +1164,6 @@
 .wordpress-content .wp-block-quote cite {
   display: block;
   text-align: center;
-  font-style: ;
   font-size: 0.875rem;
   font-weight: 600;
   letter-spacing: 0.05em;
@@ -2332,23 +2334,9 @@
   }
 }
 
-.wordpress-content p a,
-.wordpress-content li a,
-.wordpress-content td a,
-.wordpress-content th a {
-  color: #7c3aed;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  transition: color 0.2s ease;
-}
-
-.wordpress-content p a:hover,
-.wordpress-content li a:hover,
-.wordpress-content td a:hover,
-.wordpress-content th a:hover {
-  color: #5b21b6;
-}
-
+/* Inline link colour. This block was previously declared twice at identical
+   specificity (#7c3aed then #8b5cf6); the second won, so #8b5cf6 is what has
+   always rendered. Kept that value and deleted the dead first copy. */
 .wordpress-content p a,
 .wordpress-content li a,
 .wordpress-content td a,

--- a/app/blogs/wordpress-content.css
+++ b/app/blogs/wordpress-content.css
@@ -2334,14 +2334,17 @@
   }
 }
 
-/* Inline link colour. This block was previously declared twice at identical
-   specificity (#7c3aed then #8b5cf6); the second won, so #8b5cf6 is what has
-   always rendered. Kept that value and deleted the dead first copy. */
+/* Inline link colour. Single source of truth — this block was previously
+   declared twice at identical specificity (#7c3aed then #8b5cf6), so #8b5cf6
+   silently won. #8b5cf6 only reaches 4.24:1 on white and fails WCAG AA for
+   body text, and it disagreed with the article intro paragraph, which is
+   rendered outside .wordpress-content and has always used #7c3aed. Unified on
+   #7c3aed (5.7:1) so every link on the page is one colour and passes AA. */
 .wordpress-content p a,
 .wordpress-content li a,
 .wordpress-content td a,
 .wordpress-content th a {
-  color: #8b5cf6;
+  color: #7c3aed;
   text-decoration: underline;
   text-underline-offset: 2px;
   transition: color 0.2s ease;
@@ -2351,7 +2354,7 @@
 .wordpress-content li a:hover,
 .wordpress-content td a:hover,
 .wordpress-content th a:hover {
-  color: #7c3aed;
+  color: #5b21b6;
 }
 
 /* Legacy pro-tip-box support */

--- a/app/preview/[slug]/page.tsx
+++ b/app/preview/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { getDraftPostById, getFeaturedImageUrl, getAuthorName, getAuthorNames, getPostAuthors, getPostAuthorsAsync, formatDate, stripHtml, decodeHtmlEntities, getReadingTime, getDraftPosts, getPostsByCategory } from "@/lib/wordpress-improved";
-import { extractHeadings, addHeadingIds, removeWordPressTOC, extractFirstParagraph, removeLeadingFeaturedImageBlock, processH6Markers, openLinksInNewTab } from "@/lib/content-processor";
+import { extractHeadings, addHeadingIds, removeWordPressTOC, extractFirstParagraph, removeLeadingFeaturedImageBlock, processH6Markers, lazyLoadImages, openLinksInNewTab } from "@/lib/content-processor";
 import Breadcrumb from "@/components/blog/Breadcrumb";
 import BlogLanguageSwitcher from "@/components/blog/BlogLanguageSwitcher";
 import TOCEnhancer from "@/components/blog/TOCEnhancer";
@@ -27,6 +27,7 @@ import BarterDealCheckerInjector from "@/components/blog/BarterDealCheckerInject
 import ImageOrientationEnhancer from "@/components/blog/ImageOrientationEnhancer";
 import ImageLightboxEnhancer from "@/components/blog/ImageLightboxEnhancer";
 import NewsletterSection from "@/components/blog/NewsletterSection";
+import LazyOnVisible from "@/components/blog/LazyOnVisible";
 import RelatedResourcesInjector from "@/components/blog/RelatedResourcesInjector";
 import MetaShareButton from "@/components/blog/MetaShareButton";
 import { getAuthorPageSlug, getAuthorByWordPressSlug, getAuthorBySlug, isFoundingTeamPost } from "@/data/authors";
@@ -125,6 +126,7 @@ export default async function PreviewPostPage({ params }: PreviewPostPageProps) 
   }
 
   const featuredImage = post._embedded?.["wp:featuredmedia"]?.[0]?.source_url || getFeaturedImageUrl(post, "full");
+  const featuredAlt = post._embedded?.["wp:featuredmedia"]?.[0]?.alt_text || stripHtml(post.title.rendered);
   // Use async version to fetch Co-Authors Plus guest authors
   const postAuthors = await getPostAuthorsAsync(post);
   const publishDate = formatDate(post.date);
@@ -192,7 +194,9 @@ export default async function PreviewPostPage({ params }: PreviewPostPageProps) 
   const contentWithoutLeadingImage = featuredImage
     ? removeLeadingFeaturedImageBlock(contentAfterParagraph, featuredImage)
     : contentAfterParagraph;
-  const processedContent = openLinksInNewTab(contentWithoutLeadingImage);
+  // Add native lazy-loading to body images (only featured image competes for LCP)
+  // and force links to open in a new tab
+  const processedContent = openLinksInNewTab(lazyLoadImages(contentWithoutLeadingImage));
 
   // Get category for breadcrumb and related resources
   const categoryName = post._embedded?.["wp:term"]?.[0]?.[0]?.name || "";
@@ -276,7 +280,9 @@ export default async function PreviewPostPage({ params }: PreviewPostPageProps) 
                 <span>·</span>
                 <span>{readingTime} min read</span>
                 <Suspense fallback={<span className="text-sm">Loading...</span>}>
-                  <BlogLanguageSwitcher />
+                  {/* Preview renders a single draft with no Hinglish counterpart,
+                      so the option is disabled — same as a blog post without one. */}
+                  <BlogLanguageSwitcher hinglishAvailable={false} />
                 </Suspense>
               </div>
               <MetaShareButton
@@ -290,7 +296,7 @@ export default async function PreviewPostPage({ params }: PreviewPostPageProps) 
             <div className="border-t border-b border-gray-200 py-2 md:py-5">
               <div className="flex flex-col gap-4">
                 {displayAuthors.map((authorData, index) => (
-                  <div key={index} className={`flex items-center justify-between ${index > 0 ? 'pt-4 border-t border-gray-100' : ''}`}>
+                  <div key={index} className={`flex items-center justify-between gap-1 ${index > 0 ? 'pt-4 border-t border-gray-100' : ''}`}>
                     {/* Author Info */}
                     <div className="flex items-center gap-4">
                       {authorData.avatarUrl && (
@@ -423,7 +429,7 @@ export default async function PreviewPostPage({ params }: PreviewPostPageProps) 
             const [firstSentence, rest] = splitFirstSentence(blogDescription);
             return (
               <div
-                className="px-4 md:px-6 lg:px-0 text-[18px] md:text-[22px] text-[#6B7280] leading-[1.6] text-justify"
+                className="px-4 md:px-6 lg:px-0 text-[18px] md:text-[22px] text-[#6B7280] leading-[1.6] text-justify [&_a]:text-[#7c3aed] [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:text-[#5b21b6] [&_a]:transition-colors"
               >
                 <span className="font-semibold" dangerouslySetInnerHTML={{ __html: firstSentence }} />
                 {rest && <span dangerouslySetInnerHTML={{ __html: rest }} />}
@@ -440,7 +446,7 @@ export default async function PreviewPostPage({ params }: PreviewPostPageProps) 
               >
                 <Image
                   src={featuredImage}
-                  alt={stripHtml(post.title.rendered)}
+                  alt={featuredAlt}
                   fill
                   className="object-cover"
                   priority
@@ -536,12 +542,16 @@ export default async function PreviewPostPage({ params }: PreviewPostPageProps) 
 
         {/* Related Posts - full width, outside the narrow reading column */}
         <div className="relative z-0 mt-10 lg:mt-16 px-4 md:px-0">
-          <RelatedPosts posts={relatedPosts} basePath="/preview" />
+          <LazyOnVisible minHeight={400}>
+            <RelatedPosts posts={relatedPosts} basePath="/preview" />
+          </LazyOnVisible>
         </div>
       </main>
 
       {/* Newsletter Section */}
-      <NewsletterSection />
+      <LazyOnVisible>
+        <NewsletterSection />
+      </LazyOnVisible>
     </>
   );
 }

--- a/app/preview/layout.tsx
+++ b/app/preview/layout.tsx
@@ -1,19 +1,16 @@
 import BlogHeader from "@/components/blog/BlogHeader";
 import BlogFooter from "@/components/blog/BlogFooter";
-import { Roboto } from "next/font/google";
-
-const roboto = Roboto({
-  subsets: ["latin"],
-  weight: ["300", "400", "500", "700"],
-});
 
 export default function PreviewLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // No local font instance here on purpose — preview must inherit the root
+  // layout's Roboto (400/700) exactly like /blogs does, or weight-500 text
+  // (pullquotes, FAQ questions, CTA buttons) renders heavier than on the blog.
   return (
-    <div className={`min-h-screen bg-white flex flex-col ${roboto.className}`}>
+    <div className="min-h-screen bg-white flex flex-col">
       <BlogHeader />
       <main className="flex-1">{children}</main>
       <BlogFooter />

--- a/components/blog/BarterDealCheckerInjector.tsx
+++ b/components/blog/BarterDealCheckerInjector.tsx
@@ -38,7 +38,9 @@ export default function BarterDealCheckerInjector() {
     const created: HTMLElement[] = [];
     for (const h6 of markers) {
       const container = document.createElement("div");
-      container.className = "barter-check-embed-container";
+      // not-prose keeps the article's prose rules (bullets, heading sizes,
+      // justified text) out of the tool — see wordpress-content.css.
+      container.className = "barter-check-embed-container not-prose";
       container.setAttribute("data-section-type", "barter-check");
       h6.parentNode?.insertBefore(container, h6);
       h6.remove();

--- a/components/blog/FMVCalculatorInjector.tsx
+++ b/components/blog/FMVCalculatorInjector.tsx
@@ -38,7 +38,9 @@ export default function FMVCalculatorInjector() {
     const created: HTMLElement[] = [];
     for (const h6 of markers) {
       const container = document.createElement("div");
-      container.className = "fmv-calc-embed-container";
+      // not-prose keeps the article's prose rules (bullets, heading sizes,
+      // justified text) out of the tool — see wordpress-content.css.
+      container.className = "fmv-calc-embed-container not-prose";
       container.setAttribute("data-section-type", "fmv-calc");
       h6.parentNode?.insertBefore(container, h6);
       h6.remove();

--- a/components/blog/TaxCalculatorInjector.tsx
+++ b/components/blog/TaxCalculatorInjector.tsx
@@ -38,7 +38,9 @@ export default function TaxCalculatorInjector() {
     const created: HTMLElement[] = [];
     for (const h6 of markers) {
       const container = document.createElement("div");
-      container.className = "tax-calc-embed-container";
+      // not-prose keeps the article's prose rules (bullets, heading sizes,
+      // justified text) out of the tool — see wordpress-content.css.
+      container.className = "tax-calc-embed-container not-prose";
       container.setAttribute("data-section-type", "tax-calc");
       h6.parentNode?.insertBefore(container, h6);
       h6.remove();


### PR DESCRIPTION
Draft preview drifted from the published blog post layout it is meant to proof. Bring the two render paths back in line:

- Drop the local Roboto instance from the preview layout so it inherits the root font (400/700). The extra 300/500 weights meant every weight-500 element (pullquotes, FAQ questions, CTA buttons, breadcrumb, nav) rendered as true Medium on preview but as the 400 face on the blog, and preview pulled down a second Roboto set.
- Restore the intro paragraph's link styling. That block sits outside .wordpress-content, so the stylesheet's `p a` rule never reached it and links rendered as flat gray body text.
- Disable the Hinglish option in the language switcher. It defaulted to enabled and offered a ?lang=hi-Latn route preview does not handle; a blog post without a Hinglish version renders it disabled.
- Add the missing gap-1 to the author header row.
- Use the WordPress media alt_text (title as fallback) for the featured image instead of always using the title.
- Lazy-load body images and defer RelatedPosts / NewsletterSection behind LazyOnVisible, matching the blog's loading behaviour.

Breadcrumb labels, Related Resources sourcing, listing pagination, the share URL and the /preview basePath are left as-is — those differences are intentional.