### PR TITLE
fix(blog): restore bottom margin on highlight box callouts

### DIFF
--- a/app/blogs/wordpress-content.css
+++ b/app/blogs/wordpress-content.css
@@ -683,7 +683,8 @@
   margin-bottom: 1.5em;
 }
 
-.wordpress-content p:last-child:not(.not-prose *) {
+.wordpress-content
+  p:last-child:not(.not-prose *):not(.highlight-box-section *):not(.pro-tip-box) {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
A Highlight Box wrapper holds exactly one <p>, so that paragraph is always :last-child. The article-level reset
`.wordpress-content p:last-child:not(.not-prose *)` scores 0,3,1 and outranked the box's own `margin: 2rem 0` (0,2,1), collapsing the gap between a Pro Tip / Watch Out box and the block after it.

Exclude callout boxes from the reset instead of duplicating margin values, so the box falls through to its own margin (and the 1.25rem mobile variant). Also excludes the legacy .pro-tip-box class, which hit the same bug whenever a Pro Tip was the final paragraph of a post.