### PR TITLE
fix(blog): pin trust para copy to 16px across breakpoints

### DIFF
--- a/app/blogs/wordpress-content.css
+++ b/app/blogs/wordpress-content.css
@@ -2501,6 +2501,20 @@
 }
 
 /* ====================
+   TRUST PARA SECTION ("Why trust this guide")
+   ==================== */
+
+/* The trust paragraph is supporting copy, not body prose, so it stays at 16px
+   on every breakpoint instead of following the article's 18px → 20px ramp.
+   Specificity ties with `.wordpress-content p:not(.not-prose *)` (both 0,2,1),
+   so this block must stay *after* that rule and its 768px media query — moving
+   it above them silently restores the 20px desktop size. */
+.wordpress-content .trust-para-section p,
+.wordpress-content .trust-para-section li {
+  font-size: 1rem;
+}
+
+/* ====================
    CHECKMARK EMOJI STYLING
    Replace green ✅ emoji with primary purple checkmark
    ==================== */

--- a/app/blogs/wordpress-content.css
+++ b/app/blogs/wordpress-content.css
@@ -1142,6 +1142,45 @@
   background: #a1a1a1;
 }
 
+/* Horizontal-scroll affordance ("scrolling shadows").
+
+   The `white-space: nowrap` above deliberately keeps every cell on one line, so
+   a wide table overflows its wrapper rather than wrapping — but `overflow-x:
+   auto` scrolls silently, so on a narrow viewport the table just looks clipped
+   mid-word at the screen edge. Nothing tells the reader it can be swiped.
+
+   Two gradient pairs fix that with no JS and no extra markup. The white "cover"
+   gradients use `background-attachment: local` so they travel with the scrolled
+   content; the grey shadows use `scroll` so they stay pinned to the wrapper. At
+   the start of the scroll range the left cover sits exactly on top of the left
+   shadow and hides it — scroll right and the cover slides away, revealing it.
+   Net effect: a shadow appears on a given side only while there is more table
+   in that direction, and both stay hidden when the table already fits.
+
+   Applied at every breakpoint, not just mobile: it self-hides when there is no
+   overflow, and the 760px article column can clip a wide table on desktop too.
+   The cover colour must match the page background (#fff, set by the article
+   `bg-white`) — on a tinted background the covers would show as white bands. */
+.wordpress-content .wp-block-table {
+  background-image:
+    linear-gradient(to right, #fff 30%, rgba(255, 255, 255, 0)),
+    linear-gradient(to left, #fff 30%, rgba(255, 255, 255, 0)),
+    radial-gradient(
+      farthest-side at 0 50%,
+      rgba(107, 114, 128, 0.28),
+      rgba(107, 114, 128, 0)
+    ),
+    radial-gradient(
+      farthest-side at 100% 50%,
+      rgba(107, 114, 128, 0.28),
+      rgba(107, 114, 128, 0)
+    );
+  background-position: left center, right center, left center, right center;
+  background-repeat: no-repeat;
+  background-size: 32px 100%, 32px 100%, 16px 100%, 16px 100%;
+  background-attachment: local, local, scroll, scroll;
+}
+
 /* Pullquote/Quote blocks - Clean centered style */
 .wordpress-content .wp-block-pullquote,
 .wordpress-content .wp-block-quote {

--- a/app/blogs/wordpress-content.css
+++ b/app/blogs/wordpress-content.css
@@ -2504,14 +2504,18 @@
    TRUST PARA SECTION ("Why trust this guide")
    ==================== */
 
-/* The trust paragraph is supporting copy, not body prose, so it stays at 16px
-   on every breakpoint instead of following the article's 18px → 20px ramp.
+/* The trust paragraph is supporting copy, not body prose, so it holds 16px/1.5
+   on every breakpoint instead of following the article's 18px → 20px ramp and
+   its loose 1.7 leading. Both values are set here rather than left to inherit,
+   so the block reads as one deliberate scale — tune the leading on this line.
+
    Specificity ties with `.wordpress-content p:not(.not-prose *)` (both 0,2,1),
    so this block must stay *after* that rule and its 768px media query — moving
-   it above them silently restores the 20px desktop size. */
+   it above them silently restores the 20px / 1.7 body defaults. */
 .wordpress-content .trust-para-section p,
 .wordpress-content .trust-para-section li {
   font-size: 1rem;
+  line-height: 1.5;
 }
 
 /* ====================

--- a/data/authors.ts
+++ b/data/authors.ts
@@ -139,7 +139,7 @@ export const authors: AuthorEntry[] = [
     wordpressAuthorId: 5,
 
     name: "Guneet Singh",
-    role: "Global Tech Leader | Startup Mentor | Venture Builder",
+    role: "Co-Founder, Sparkonomy | Building AI Infrastructure for the Next 100M Creator-Founders",
     avatarUrl: "/authors/ProfilePicture_gunnet.webp",
     shortBio: "I am a tech leader and strategist based in Singapore. After 20 years working across Google, Microsoft, and Samsung I now build and mentor at the edge of technology and new work. Besides building Sparkonomy, I write about how technology systems and AI can support creators by handling the friction, so they can spend more time creating and building a sustainable career.",
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -20,7 +20,7 @@ api: No public API currently available
 
 ## Authors / Experts
 The Sparkonomy blog is written by named domain experts. Each has a profile (ProfilePage + Person structured data) at the URL below.
-- [Guneet Singh](https://www.sparkonomy.com/blogs/author/guneet-singh) — Founder; global tech leader, startup mentor & venture builder with 20+ years across Google, Microsoft and Samsung. Writes on the creator economy, AI productivity, platform ecosystems and business growth.
+- [Guneet Singh](https://www.sparkonomy.com/blogs/author/guneet-singh) — Co-Founder; building AI infrastructure for the next 100M creator-founders, with 20+ years across Google, Microsoft and Samsung. Writes on the creator economy, AI productivity, platform ecosystems and business growth.
 - [Megha Thareja Tyagi](https://www.sparkonomy.com/blogs/author/megha-thareja-tyagi) — Co-Founder; AI strategy and creator-economy infrastructure leader, ex-Google, PayPal and American Express. Writes on go-to-market strategy, commercialization and payments.
 - [Vipasha Joshi](https://www.sparkonomy.com/blogs/author/vipasha-joshi) — Co-Founder & Global Head of Creator Business; creator-economy veteran and LinkedIn Top Voice, ex-Google and Jellysmack. Writes on creator business, AI content strategy and community.
 - [Rachit Jain](https://www.sparkonomy.com/blogs/author/rachit-jain) — Growth, partnerships and GTM leader with 20+ years across Meta, Google, SAP and IBM. Writes on growth strategy, monetization and partnerships.


### PR DESCRIPTION
The "Why trust this guide" block had no font-size of its own, so it fell through to the generic article paragraph rule and rode the 18px -> 20px ramp at 768px. As supporting copy it should not compete with body prose.

The new rule ties on specificity with `.wordpress-content p:not(.not-prose *)` (both 0,2,1), so it is placed after that rule and its media query and wins on source order.