### PR TITLE
fix(authors): restore readable type scale on author profiles

### DIFF
--- a/components/blog/AuthorCard.tsx
+++ b/components/blog/AuthorCard.tsx
@@ -50,10 +50,10 @@ export default function  AuthorCard({
 
   return (
     <div className="bg-[#F2F2F2] rounded-lg p-6 md:p-8">
-      <h3 className="text-lg md:text-2xl font-semibold text-[#6B7280] mb-4">About the author</h3>
+      <h3 className="text-lg md:text-2xl font-semibold text-[#333333] mb-4">About the author</h3>
 
       <div className="border-l-4 border-purple-600 pl-4 md:pl-6">
-        <p className="text-sm md:text-base font-normal text-[#6B7280] leading-relaxed mb-6">{bio}</p>
+        <p className="text-base md:text-lg font-normal text-[#6B7280] leading-relaxed mb-6">{bio}</p>
 
       <div className="flex flex-col gap-6">
         <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-6 md:gap-20">
@@ -73,14 +73,14 @@ export default function  AuthorCard({
               {authorSlug ? (
                 <Link
                   href={`/blogs/author/${authorSlug}`}
-                  className="text-base font-medium text-[#6B7280] hover:text-purple-600 transition-colors"
+                  className="text-base font-medium text-[#4B5563] hover:text-purple-600 transition-colors"
                 >
                   {name}
                 </Link>
               ) : (
-                <h4 className="text-base font-medium text-[#6B7280]">{name}</h4>
+                <h4 className="text-base font-medium text-[#4B5563]">{name}</h4>
               )}
-              {role && <p className="text-xs text-[#999999] mb-3">{role}</p>}
+              {role && <p className="text-xs text-[#4B5563] mb-3">{role}</p>}
 
               {/* Social Links */}
               {hasSocialLinks && (
@@ -90,7 +90,7 @@ export default function  AuthorCard({
                       href={socialLinks.linkedin}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-gray-400 hover:text-gray-600 transition-colors"
+                      className="text-[#6B7280] hover:text-[#4B5563] transition-colors"
                       aria-label="LinkedIn"
                     >
                       <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -103,7 +103,7 @@ export default function  AuthorCard({
                       href={socialLinks.instagram}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-gray-400 hover:text-gray-600 transition-colors"
+                      className="text-[#6B7280] hover:text-[#4B5563] transition-colors"
                       aria-label="Instagram"
                     >
                       <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -116,7 +116,7 @@ export default function  AuthorCard({
                       href={socialLinks.youtube}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-gray-400 hover:text-gray-600 transition-colors"
+                      className="text-[#6B7280] hover:text-[#4B5563] transition-colors"
                       aria-label="YouTube"
                     >
                       <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -129,7 +129,7 @@ export default function  AuthorCard({
                       href={socialLinks.facebook}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-gray-400 hover:text-gray-600 transition-colors"
+                      className="text-[#6B7280] hover:text-[#4B5563] transition-colors"
                       aria-label="Facebook"
                     >
                       <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -142,7 +142,7 @@ export default function  AuthorCard({
                       href={socialLinks.twitter}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-gray-400 hover:text-gray-600 transition-colors"
+                      className="text-[#6B7280] hover:text-[#4B5563] transition-colors"
                       aria-label="Twitter"
                     >
                       <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -158,7 +158,7 @@ export default function  AuthorCard({
           {/* Previous Companies - Right Side on Desktop */}
           {displayCompanies.length > 0 && (
             <div className="hidden md:flex flex-col items-end max-w-[50%]">
-              <p className="text-sm text-[#6B7280] mb-2">{previousCompaniesLabel}</p>
+              <p className="text-sm text-[#4B5563] mb-2">{previousCompaniesLabel}</p>
               <div className="flex flex-wrap items-center justify-end gap-4">
                 {displayCompanies.map((company, index) => (
                   company.logo ? (
@@ -172,7 +172,7 @@ export default function  AuthorCard({
                       style={{ filter: getLogoFilter(company) }}
                     />
                   ) : (
-                    <span key={index} className="text-lg md:text-xl font-bold text-gray-900">
+                    <span key={index} className="text-lg md:text-xl font-bold text-[#333333]">
                       {company.name}
                     </span>
                   )
@@ -185,7 +185,7 @@ export default function  AuthorCard({
         {/* Previous Companies - Below on Mobile */}
         {displayCompanies.length > 0 && (
           <div className="md:hidden flex flex-col items-start">
-            <p className="text-xs text-[#6B7280] mb-2">{previousCompaniesLabel}</p>
+            <p className="text-xs text-[#4B5563] mb-2">{previousCompaniesLabel}</p>
             <div className="flex flex-wrap items-center gap-3">
               {displayCompanies.map((company, index) => (
                 company.logo ? (
@@ -199,7 +199,7 @@ export default function  AuthorCard({
                     style={{ filter: getLogoFilter(company) }}
                   />
                 ) : (
-                  <span key={index} className="text-lg font-bold text-gray-900">
+                  <span key={index} className="text-lg font-bold text-[#333333]">
                     {company.name}
                   </span>
                 )

--- a/components/blog/AuthorPageTemplate.tsx
+++ b/components/blog/AuthorPageTemplate.tsx
@@ -119,7 +119,7 @@ export default function AuthorPageTemplate({
     // <article> (not <main>) — the blog layout already provides the <main> landmark.
     <article className="min-h-screen bg-white">
       {/* Breadcrumb — mirrors the BreadcrumbList JSON-LD (Blog › Name) */}
-      <div className="max-w-4xl mx-auto px-4 pt-[16px]">
+      <div className="max-w-4xl mx-auto px-[29px] md:px-4 pt-[16px]">
         <Breadcrumb
           items={[
             { label: "Blog", href: "/blogs" },
@@ -129,7 +129,7 @@ export default function AuthorPageTemplate({
       </div>
 
       {/* Hero Section - Author Profile */}
-      <section className="max-w-4xl mx-auto px-4 py-[16px] text-center">
+      <section className="max-w-4xl mx-auto px-[29px] md:px-4 py-[16px] text-center">
         {/* Avatar */}
         <div className="relative w-[200px] h-[200px] mx-auto mb-[16px] md:mb-[20px]">
           <Image
@@ -143,22 +143,22 @@ export default function AuthorPageTemplate({
         </div>
 
         {/* Author Info Card */}
-        <div className="px-[22px] md:px-0">
+        <div className="px-0">
           {/* Author Label, Name, Role */}
           <div className="flex flex-col gap-1 mb-3 md:mb-4">
-            <p className="text-xs md:text-sm font-bold text-[#6B7280] uppercase tracking-wider">
+            <p className="text-xs md:text-sm font-bold text-[#4B5563] uppercase tracking-wider">
               ABOUT THE AUTHOR
             </p>
             <h1 className="text-[24px] md:text-[26px] lg:text-[28px] font-semibold text-primary">
               {author.name.toUpperCase()}
             </h1>
-            <p className="text-sm md:text-base font-normal text-gray-600">
+            <p className="text-sm md:text-base font-normal text-[#4B5563]">
               {author.role}
             </p>
           </div>
 
           {/* Short Bio Quote */}
-          <blockquote className="text-base md:text-[18px] font-semibold text-[#6B7280] leading-relaxed max-w-2xl mx-auto mb-3 md:mb-4">
+          <blockquote className="text-base md:text-lg font-semibold text-[#6B7280] leading-relaxed max-w-2xl mx-auto mb-3 md:mb-4">
             &ldquo; {author.shortBio}&rdquo;
           </blockquote>
 
@@ -169,7 +169,7 @@ export default function AuthorPageTemplate({
                 href={author.socialLinks.twitter}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                className="text-[#6B7280] hover:text-[#9747FF] transition-colors"
                 aria-label="Twitter"
               >
                 {SocialIcons.twitter}
@@ -180,7 +180,7 @@ export default function AuthorPageTemplate({
                 href={author.socialLinks.linkedin}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                className="text-[#6B7280] hover:text-[#9747FF] transition-colors"
                 aria-label="LinkedIn"
               >
                 {SocialIcons.linkedin}
@@ -191,7 +191,7 @@ export default function AuthorPageTemplate({
                 href={author.socialLinks.instagram}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                className="text-[#6B7280] hover:text-[#9747FF] transition-colors"
                 aria-label="Instagram"
               >
                 {SocialIcons.instagram}
@@ -202,7 +202,7 @@ export default function AuthorPageTemplate({
                 href={author.socialLinks.youtube}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                className="text-[#6B7280] hover:text-[#9747FF] transition-colors"
                 aria-label="YouTube"
               >
                 {SocialIcons.youtube}
@@ -213,7 +213,7 @@ export default function AuthorPageTemplate({
                 href={author.socialLinks.facebook}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                className="text-[#6B7280] hover:text-[#9747FF] transition-colors"
                 aria-label="Facebook"
               >
                 {SocialIcons.facebook}
@@ -224,7 +224,7 @@ export default function AuthorPageTemplate({
                 href={author.socialLinks.website}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                className="text-[#6B7280] hover:text-[#9747FF] transition-colors"
                 aria-label="Website"
               >
                 {SocialIcons.website}
@@ -235,7 +235,7 @@ export default function AuthorPageTemplate({
                 href={author.socialLinks.github}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                className="text-[#6B7280] hover:text-[#9747FF] transition-colors"
                 aria-label="GitHub"
               >
                 {SocialIcons.github}
@@ -246,7 +246,7 @@ export default function AuthorPageTemplate({
                 href={`https://mail.google.com/mail/?view=cm&fs=1&to=${encodeURIComponent(author.socialLinks.email)}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-[#999999] hover:text-[#9747FF] transition-colors"
+                className="text-[#6B7280] hover:text-[#9747FF] transition-colors"
                 aria-label="Email"
               >
                 {SocialIcons.email}
@@ -258,7 +258,7 @@ export default function AuthorPageTemplate({
         {/* Previous Companies */}
         {author.previousCompanies.length > 0 && (
           <div className="bg-[#F8F8F8] rounded-[12px] p-4">
-            <p className="text-base md:text-lg text-gray-500 mb-4 text-center">
+            <p className="text-base md:text-lg text-[#4B5563] mb-4 text-center">
               {author.previousCompaniesLabel || "Previously at"}
             </p>
             <div className="flex flex-wrap gap-4 md:gap-6 justify-center items-center">
@@ -285,7 +285,7 @@ export default function AuthorPageTemplate({
                       }}
                     />
                   ) : (
-                    <span className="text-gray-500 font-semibold text-sm md:text-lg">
+                    <span className="text-[#4B5563] font-semibold text-sm md:text-lg">
                       {company.name}
                     </span>
                   )}
@@ -297,30 +297,30 @@ export default function AuthorPageTemplate({
       </section>
 
       {/* Story Section */}
-      <section className="max-w-4xl mx-auto px-[38px] md:px-4 py-[16px]">
+      <section className="max-w-4xl mx-auto px-[29px] md:px-4 py-[16px]">
         <div className="bg-white">
-          <h2 className="text-[24px] md:text-[26px] lg:text-[28px] font-semibold text-[#8134AF] mb-6 text-center px-[2px]">
+          <h2 className="text-[24px] md:text-[26px] lg:text-[28px] font-semibold text-[#333333] mb-6 text-center px-[2px]">
             {author.storyTitle}
           </h2>
 
           {author.storyContent.map((paragraph, index) => (
             <p
               key={index}
-              className="text-sm md:text-base font-normal text-[#999999] leading-relaxed mb-4"
+              className="text-base md:text-lg font-normal text-[#6B7280] leading-relaxed mb-4"
             >
               {paragraph}
             </p>
           ))}
 
           {/* Highlight Quote */}
-          <blockquote className="text-[20px] md:text-[22px] lg:text-[24px] font-semibold text-[#8134AF] text-center my-8 px-4">
+          <blockquote className="text-[20px] md:text-[22px] lg:text-[24px] font-semibold text-primary text-center my-8 px-4">
             &ldquo;{author.highlightQuote}&rdquo;
           </blockquote>
 
           {author.storyConclusion.map((paragraph, index) => (
             <p
               key={index}
-              className="text-sm md:text-base font-normal text-[#999999] leading-relaxed mb-4"
+              className="text-base md:text-lg font-normal text-[#6B7280] leading-relaxed mb-4"
             >
               {paragraph.includes("Sparkonomy") ? (
                 <>
@@ -346,15 +346,15 @@ export default function AuthorPageTemplate({
                 height={60}
                 className="h-14 w-auto"
               />
-              <p className="text-gray-600 mt-2">{author.name}</p>
+              <p className="text-[#4B5563] mt-2">{author.name}</p>
             </div>
           )}
         </div>
       </section>
 
       {/* About Section */}
-      <section className="max-w-4xl mx-auto px-[38px] md:px-4 py-[16px]">
-        <h2 className="text-[24px] md:text-[26px] lg:text-[28px] font-semibold text-[#6B7280] mb-4">
+      <section className="max-w-4xl mx-auto px-[29px] md:px-4 py-[16px]">
+        <h2 className="text-[24px] md:text-[26px] lg:text-[28px] font-semibold text-[#333333] mb-4">
           {author.aboutTitle}
         </h2>
 
@@ -393,7 +393,7 @@ export default function AuthorPageTemplate({
           return (
             <p
               key={index}
-              className="text-[14px] md:text-base font-normal text-[#999999] leading-relaxed mb-4"
+              className="text-base md:text-lg font-normal text-[#6B7280] leading-relaxed mb-4"
             >
               {content}
             </p>
@@ -403,8 +403,8 @@ export default function AuthorPageTemplate({
 
       {/* Career Highlights */}
       {author.careerHighlights.length > 0 && (
-        <section className="max-w-4xl mx-auto px-[38px] md:px-4 pb-[12px]">
-          <h2 className="text-[20px] md:text-[22px] lg:text-[24px] font-semibold text-[#999999]">
+        <section className="max-w-4xl mx-auto px-[29px] md:px-4 pb-[12px]">
+          <h2 className="text-[20px] md:text-[22px] lg:text-[24px] font-semibold text-[#333333]">
             Career & Recognition Highlights:
           </h2>
 
@@ -412,9 +412,9 @@ export default function AuthorPageTemplate({
             {author.careerHighlights.map((highlight, index) => (
               <li
                 key={index}
-                className="flex items-start gap-2 text-[14px] md:text-[16px] font-normal text-[#999999]"
+                className="flex items-start gap-2 text-base md:text-lg font-normal text-[#374151]"
               >
-                <span className="text-[#999999] mt-1" aria-hidden="true">✓</span>
+                <span className="text-primary mt-1" aria-hidden="true">✓</span>
                 <span>{highlight}</span>
               </li>
             ))}
@@ -425,7 +425,7 @@ export default function AuthorPageTemplate({
       {/* Trust & Authority */}
       {author.trustItems.length > 0 && (
         <section className="max-w-4xl mx-auto px-[29px] md:px-4 pt-[12px]">
-          <h2 className="text-[20px] md:text-[22px] lg:text-[24px] font-semibold text-[#999999] mb-4">
+          <h2 className="text-[20px] md:text-[22px] lg:text-[24px] font-semibold text-[#333333] mb-4">
             Trust & Authority
           </h2>
 
@@ -447,7 +447,7 @@ export default function AuthorPageTemplate({
                 <p className="text-[12px] md:text-[14px] font-normal text-primary">
                   {item.label}
                 </p>
-                <p className="text-base md:text-lg font-medium text-[#999999]">
+                <p className="text-base md:text-lg font-medium text-[#4B5563]">
                   {item.value}
                 </p>
               </div>
@@ -458,8 +458,8 @@ export default function AuthorPageTemplate({
 
       {/* Certifications & Credentials */}
       {author.certifications && author.certifications.length > 0 && (
-        <section className="max-w-4xl mx-auto px-[38px] md:px-4 py-[16px]">
-          <h2 className="text-[20px] md:text-[22px] lg:text-[24px] font-semibold text-[#999999] mb-4">
+        <section className="max-w-4xl mx-auto px-[29px] md:px-4 py-[16px]">
+          <h2 className="text-[20px] md:text-[22px] lg:text-[24px] font-semibold text-[#333333] mb-4">
             Certifications & Credentials
           </h2>
 
@@ -467,13 +467,13 @@ export default function AuthorPageTemplate({
             {author.certifications.map((cert, index) => (
               <li
                 key={index}
-                className="flex items-start gap-2 text-[14px] md:text-[16px] font-normal text-[#999999]"
+                className="flex items-start gap-2 text-base md:text-lg font-normal text-[#374151]"
               >
-                <span className="text-[#999999] mt-1" aria-hidden="true">✓</span>
+                <span className="text-primary mt-1" aria-hidden="true">✓</span>
                 <span>
                   {cert.name}
                   {cert.issuer && (
-                    <span className="text-[#B3B3B3]"> — {cert.issuer}</span>
+                    <span className="text-[#6B7280]"> — {cert.issuer}</span>
                   )}
                 </span>
               </li>
@@ -485,8 +485,8 @@ export default function AuthorPageTemplate({
       {/* As Seen In - Only show if there are media mentions */}
       {author.mediaMentions.length > 0 && (
         <section className="bg-[#F8F8F8] py-[16px] my-[16px]">
-          <div className="max-w-4xl mx-auto px-[29px]">
-            <h2 className="text-[24px] md:text-[26px] font-semibold text-[#6B7280] mb-4">
+          <div className="max-w-4xl mx-auto px-[29px] md:px-4">
+            <h2 className="text-[24px] md:text-[26px] font-semibold text-[#333333] mb-4">
               As Seen In
             </h2>
 
@@ -517,7 +517,7 @@ export default function AuthorPageTemplate({
                       <p className="text-[14px] md:text-base font-medium text-[#6B7280]">
                         {mention.title}
                       </p>
-                      <p className="text-[12px] md:text-sm font-normal text-[#999999]">
+                      <p className="text-[12px] md:text-sm font-normal text-[#6B7280]">
                         {mention.author} • {mention.date}
                       </p>
                     </div>
@@ -546,7 +546,7 @@ export default function AuthorPageTemplate({
       {/* Featured Articles - Only show if there are articles from WordPress */}
       {displayFeaturedArticles.length > 0 && (
         <section className="max-w-6xl mx-auto px-0 py-[16px]">
-          <h2 className="text-[24px] md:text-[26px] font-semibold text-[#6B7280] mb-4 text-left px-[29px] md:px-4">
+          <h2 className="text-[24px] md:text-[26px] font-semibold text-[#333333] mb-4 text-left px-[29px] md:px-4">
             Featured Articles
           </h2>
           <RelatedPosts
@@ -563,8 +563,8 @@ export default function AuthorPageTemplate({
 
       {/* Recent Articles */}
       {displayRecentArticles.length > 0 && (
-        <section className="max-w-4xl mx-auto px-[29px] py-[16px]">
-          <h2 className="text-[24px] md:text-[26px] font-semibold text-[#6B7280] mb-4">
+        <section className="max-w-4xl mx-auto px-[29px] md:px-4 py-[16px]">
+          <h2 className="text-[24px] md:text-[26px] font-semibold text-[#333333] mb-4">
             Recent Articles
           </h2>
 
@@ -588,7 +588,7 @@ export default function AuthorPageTemplate({
                       {article.title}
                     </h3>
                   </Link>
-                  <p className="text-[12px] md:text-sm font-normal text-[#999999]">
+                  <p className="text-[12px] md:text-sm font-normal text-[#6B7280]">
                     {article.date}
                   </p>
                 </div>
@@ -621,8 +621,8 @@ export default function AuthorPageTemplate({
 
       {/* Areas of Expertise */}
       {author.areasOfExpertise.length > 0 && (
-        <section className="max-w-4xl mx-auto px-[29px] py-[16px]">
-          <h2 className="text-[24px] md:text-[26px] font-semibold text-[#6B7280] mb-4">
+        <section className="max-w-4xl mx-auto px-[29px] md:px-4 py-[16px]">
+          <h2 className="text-[24px] md:text-[26px] font-semibold text-[#333333] mb-4">
             Areas of Expertise
           </h2>
 
@@ -630,7 +630,7 @@ export default function AuthorPageTemplate({
             {author.areasOfExpertise.map((expertise, index) => (
               <span
                 key={index}
-                className="px-4 py-2 rounded-full bg-[#F2F2F2] text-[12px] md:text-sm font-medium text-[#999999]"
+                className="px-4 py-2 rounded-full bg-[#F2F2F2] text-[12px] md:text-sm font-medium text-[#4B5563]"
               >
                 {expertise}
               </span>
@@ -641,8 +641,8 @@ export default function AuthorPageTemplate({
 
       {/* Specializations */}
       {author.specializations && author.specializations.length > 0 && (
-        <section className="max-w-4xl mx-auto px-[29px] py-[16px]">
-          <h2 className="text-[24px] md:text-[26px] font-semibold text-[#6B7280] mb-4">
+        <section className="max-w-4xl mx-auto px-[29px] md:px-4 py-[16px]">
+          <h2 className="text-[24px] md:text-[26px] font-semibold text-[#333333] mb-4">
             Specializations
           </h2>
 
@@ -650,7 +650,7 @@ export default function AuthorPageTemplate({
             {author.specializations.map((item, index) => (
               <li
                 key={index}
-                className="flex items-start gap-2 text-[14px] md:text-[16px] font-normal text-[#999999]"
+                className="flex items-start gap-2 text-base md:text-lg font-normal text-[#374151]"
               >
                 <span className="text-primary mt-1" aria-hidden="true">•</span>
                 <span>{item}</span>
@@ -661,12 +661,12 @@ export default function AuthorPageTemplate({
       )}
 
       {/* Let's Connect CTA */}
-      <section className="max-w-4xl mx-auto px-[14px] py-[16px]">
+      <section className="max-w-4xl mx-auto px-[29px] md:px-4 py-[16px]">
         <div className="bg-gray-50 rounded-3xl p-8 text-center">
-          <h2 className="text-[24px] md:text-[26px] font-semibold text-primary mb-4">
+          <h2 className="text-[24px] md:text-[26px] font-semibold text-[#333333] mb-4">
             Let&apos;s Connect!
           </h2>
-          <p className="text-[20px] md:text-[22px] font-semibold text-[#999999] mb-6 max-w-md mx-auto">
+          <p className="text-[20px] md:text-[22px] font-semibold text-[#4B5563] mb-6 max-w-md mx-auto">
             Have questions about the creator economy or collaboration
             opportunities? I&apos;d love to hear from you.
           </p>
@@ -708,7 +708,7 @@ export default function AuthorPageTemplate({
 
 
           {author.responseTime && (
-            <p className="text-[14px] md:text-base font-normal text-[#999999] italic mt-4">
+            <p className="text-[14px] md:text-base font-normal text-[#6B7280] italic mt-4">
               {author.responseTime}
             </p>
           )}
@@ -717,14 +717,14 @@ export default function AuthorPageTemplate({
 
       {/* Personal-views disclaimer */}
       {author.disclaimerNote && (
-        <p className="max-w-4xl mx-auto px-[29px] text-center text-[12px] md:text-sm font-normal text-[#B3B3B3] italic pb-[8px]">
+        <p className="max-w-4xl mx-auto px-[29px] md:px-4 text-center text-[12px] md:text-sm font-normal text-[#6B7280] italic pb-[8px]">
           {author.disclaimerNote}
         </p>
       )}
 
       {/* Profile freshness signal */}
       {author.lastUpdated && (
-        <p className="text-center text-[12px] md:text-sm font-normal text-[#999999] pb-[16px]">
+        <p className="text-center text-[12px] md:text-sm font-normal text-[#6B7280] pb-[16px]">
           Profile last updated on{" "}
           <time dateTime={toIsoDate(author.lastUpdated)}>{author.lastUpdated}</time>
         </p>

--- a/components/blog/TOCEnhancer.tsx
+++ b/components/blog/TOCEnhancer.tsx
@@ -50,14 +50,16 @@ export default function TOCEnhancer() {
 
       tocLinks.forEach(link => {
         link.addEventListener('click', (e) => {
-          e.preventDefault();
           const href = link.getAttribute('href');
           if (!href) return;
 
           const targetId = href.substring(1); // Remove the #
           const targetElement = document.getElementById(targetId);
 
+          // Only take over the click when we can actually scroll somewhere.
+          // Preventing the default on a dead anchor leaves the link doing nothing at all.
           if (targetElement) {
+            e.preventDefault();
             // Get the sticky header height
             const header = document.querySelector('header.sticky, header[class*="sticky"]');
             const headerHeight = header ? header.getBoundingClientRect().height : 0;

--- a/lib/content-processor.ts
+++ b/lib/content-processor.ts
@@ -170,27 +170,54 @@ export interface VideoItem {
 }
 
 /**
+ * Slugify heading text into an anchor id. Used on both ends of the TOC — the
+ * link href and the heading id — so the two must stay identical.
+ */
+function slugifyHeadingText(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+/**
+ * Normalise heading text for comparison only (never for ids). WordPress leaves
+ * entities like &#8217; in the markup, and they would otherwise leak digits
+ * into the comparison key.
+ */
+function headingMatchKey(text: string): string {
+  return text
+    .replace(/&#(\d+);/g, (_, code: string) => String.fromCharCode(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, code: string) => String.fromCharCode(parseInt(code, 16)))
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+/**
  * Helper function to extract only H2 headings from HTML (main sections for TOC)
  */
-function extractH2Headings(html: string): Array<{ id: string; text: string }> {
-  const headings: Array<{ id: string; text: string }> = [];
-  const headingRegex = /<h2[^>]*>([\s\S]*?)<\/h2>/gi;
+function extractH2Headings(html: string): Array<{ id: string; text: string; key: string }> {
+  const headings: Array<{ id: string; text: string; key: string }> = [];
+  const headingRegex = /<h2([^>]*)>([\s\S]*?)<\/h2>/gi;
   let match;
 
   while ((match = headingRegex.exec(html)) !== null) {
-    const text = match[1].replace(/<[^>]*>/g, '').trim();
-    // Skip TOC and FAQ headings
+    const attrs = match[1];
+    const text = match[2].replace(/<[^>]*>/g, '').trim();
+    // Skip the TOC heading itself and the sources block
     const textLower = text.toLowerCase();
     if (textLower === 'table of content' ||
         textLower === 'table of contents' ||
-        textLower === 'frequently asked questions' ||
         textLower.includes('sources') ||
         textLower.includes('references')) {
       continue;
     }
-    const id = text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    // Reuse an id the author set in WordPress. addHeadingIds() never overwrites
+    // an existing id, so the TOC has to link to that one rather than a slug the
+    // rendered heading will never carry.
+    const existingId = /\bid\s*=\s*"([^"]*)"/i.exec(attrs)?.[1].trim();
+    const id = existingId || slugifyHeadingText(text);
     if (id) {
-      headings.push({ id, text });
+      headings.push({ id, text, key: headingMatchKey(text) });
     }
   }
 
@@ -230,18 +257,27 @@ export function removeWordPressTOC(html: string): string {
       }
     }
 
-    // Build new list content with sequential heading matching
+    // Build new list content, matching each TOC item to its heading
+    const usedHeadings = new Set<number>();
     let newListContent = '';
     tocItems.forEach((text, index) => {
-      // Match TOC item to H2 heading by position (index)
-      const matchedHeading = h2Headings[index];
-      if (matchedHeading) {
-        newListContent += `<li><a href="#${matchedHeading.id}" class="toc-link">${text}</a></li>`;
-      } else {
-        // Fallback to generating ID from text if no heading at this index
-        const headingId = text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-        newListContent += `<li><a href="#${headingId}" class="toc-link">${text}</a></li>`;
+      // Match on heading text first — positional matching alone drifts whenever
+      // the post has an H2 that isn't listed in the TOC (CTA blocks, for example)
+      const key = headingMatchKey(text);
+      let headingIndex = h2Headings.findIndex((h, i) => !usedHeadings.has(i) && h.key === key);
+      if (headingIndex === -1 && h2Headings[index] && !usedHeadings.has(index)) {
+        headingIndex = index;
       }
+
+      let headingId: string;
+      if (headingIndex !== -1) {
+        usedHeadings.add(headingIndex);
+        headingId = h2Headings[headingIndex].id;
+      } else {
+        // Fallback to generating ID from text if no heading matched
+        headingId = slugifyHeadingText(text);
+      }
+      newListContent += `<li><a href="#${headingId}" class="toc-link">${text}</a></li>`;
     });
 
     return heading + newUlOpen + newListContent + ulClose;
@@ -336,20 +372,20 @@ export function addHeadingIds(html: string, headings: TOCItem[]): string {
   processed = processed.replace(/<(h[234])([^>]*)>([\s\S]*?)<\/\1>/gi, (match, tag, attrs, content) => {
     const text = content.replace(/<[^>]*>/g, '').trim();
 
-    // Skip TOC and FAQ headings
+    // Skip the TOC heading itself
     if (text.toLowerCase() === 'table of content' ||
-        text.toLowerCase() === 'table of contents' ||
-        text.toLowerCase() === 'frequently asked questions') {
+        text.toLowerCase() === 'table of contents') {
       return match;
     }
 
-    // Check if already has an id
+    // Check if already has an id. extractH2Headings() reads that same id back,
+    // so the TOC still resolves.
     if (/id=/.test(attrs)) {
       return match;
     }
 
     // Generate ID from text content (same logic as TOC link generation)
-    const headingId = text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    const headingId = slugifyHeadingText(text);
 
     if (headingId) {
       const newAttrs = attrs ? `${attrs} id="${headingId}"` : ` id="${headingId}"`;


### PR DESCRIPTION
The author profile read noticeably lighter than an article, and not by design -- body copy sat at 14/16px in #999999, which is 2.85:1 on white and fails WCAG AA. Seven greys were in use with no rule for which element got which, so the sections built to establish authority ended up the quietest thing on the page.

Body copy   14/16px #999999 -> 16/18px #6B7280 (4.8:1, passes AA)
H2          four different colours -> #333333 everywhere
Trust lists #999999 -> #374151, ticks now brand purple, so the career and
            certification lists read as the credibility signal they are
Padding     five section values (14/16/22/29/38px) -> px-[29px] md:px-4;
            the hero's nested px-[22px] became px-0 so it no longer
            compounds with the wrapper to 51px
Greys       seven -> four (#333333 #374151 #4B5563 #6B7280)

Also collapses three hardcoded #8134AF onto `text-primary`. That token is #8134a5, so the H1 name and the pull-quote had been rendering as two different purples; they now share one value. If #8134AF is the correct brand purple the fix belongs in tailwind.config, not here.

Metadata (dates, tags, disclaimer, last-updated) keeps its 12-14px sizes and takes the colour change only -- inflating a date row to 18px would read wrong.

AuthorCard gets the same scale, so the author block is consistent on the /blogs/authors hub and under every post.