### PR TITLE
feat(authors): drop Recent Articles, relabel LinkedIn CTA

### DIFF
--- a/app/blogs/author/[slug]/page.tsx
+++ b/app/blogs/author/[slug]/page.tsx
@@ -5,10 +5,8 @@ import {
   getAuthorBySlug,
   getAllAuthorSlugs,
   FeaturedArticle,
-  RecentArticle,
 } from "@/data/authors";
 import {
-  getPosts,
   getPostsByAuthor,
   getPostsByAuthorSlug,
   getFeaturedImageUrl,
@@ -142,12 +140,10 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     notFound();
   }
 
-  // Fetch articles from WordPress. Prefer wordpressAuthorId for regular WP
-  // users; fall back to wordpressSlug (handles Co-Authors Plus guest authors
-  // whose slugs are not resolvable via /users?slug=). The two fetches run in
-  // parallel so the per-author call and the site-wide latest call overlap.
+  // Fetch this author's articles from WordPress. Prefer wordpressAuthorId for
+  // regular WP users; fall back to wordpressSlug (handles Co-Authors Plus guest
+  // authors whose slugs are not resolvable via /users?slug=).
   let featuredArticles: FeaturedArticle[] | undefined;
-  let recentArticles: RecentArticle[] | undefined;
 
   type AuthorPostsData = Awaited<ReturnType<typeof getPostsByAuthor>>["data"];
   const authorPostsPromise: Promise<AuthorPostsData> = author.wordpressAuthorId
@@ -156,18 +152,13 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
       ? getPostsByAuthorSlug(author.wordpressSlug, 10)
       : Promise.resolve([] as AuthorPostsData);
 
-  const [authorResult, latestResult] = await Promise.allSettled([
-    authorPostsPromise,
-    getPosts(1, 3),
-  ]);
-
   // Hoisted so the author's own posts are available both for display and for
-  // the authored-articles ItemList structured data built further below.
-  const authorPosts: AuthorPostsData =
-    authorResult.status === "fulfilled" ? authorResult.value : [];
-  if (authorResult.status === "rejected") {
-    console.error("Error fetching WordPress posts for author:", authorResult.reason);
-  }
+  // the authored-articles ItemList structured data built further below. A
+  // failed fetch degrades to an empty list rather than taking down the profile.
+  const authorPosts: AuthorPostsData = await authorPostsPromise.catch((err) => {
+    console.error("Error fetching WordPress posts for author:", err);
+    return [] as AuthorPostsData;
+  });
 
   if (authorPosts.length > 0) {
     // First 2-3 posts as featured articles
@@ -180,31 +171,6 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
       readingTime: `${getReadingTime(post)} min read`,
       href: `/blogs/${post.slug}`,
     }));
-
-    // Remaining posts as recent articles (fallback if the latest-posts
-    // fetch below fails — otherwise it gets overwritten).
-    recentArticles = authorPosts.slice(3).map((post) => ({
-      id: String(post.id),
-      title: decodeHtmlEntities(post.title.rendered),
-      date: formatDate(post.date),
-      imageSrc: getFeaturedImageUrl(post, "full") || "/blog/default-thumbnail.jpg",
-      href: `/blogs/${post.slug}`,
-    }));
-  }
-
-  if (latestResult.status === "fulfilled") {
-    const { data: latestPosts } = latestResult.value;
-    if (latestPosts.length > 0) {
-      recentArticles = latestPosts.map((post) => ({
-        id: String(post.id),
-        title: decodeHtmlEntities(post.title.rendered),
-        date: formatDate(post.date),
-        imageSrc: getFeaturedImageUrl(post, "full") || "/blog/default-thumbnail.jpg",
-        href: `/blogs/${post.slug}`,
-      }));
-    }
-  } else {
-    console.error("Error fetching latest WordPress posts:", latestResult.reason);
   }
 
   // Build social links array for structured data. sameAs is the dominant
@@ -376,7 +342,6 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
       <AuthorPageTemplate
         author={author}
         featuredArticles={featuredArticles}
-        recentArticles={recentArticles}
       />
     </>
   );

--- a/components/blog/AuthorPageTemplate.tsx
+++ b/components/blog/AuthorPageTemplate.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import { AuthorEntry, FeaturedArticle, RecentArticle } from "@/data/authors";
+import { AuthorEntry, FeaturedArticle } from "@/data/authors";
 import Breadcrumb from "@/components/blog/Breadcrumb";
 import RelatedPosts from "@/components/blog/RelatedPosts";
 import ImageWithFallback from "@/components/blog/ImageWithFallback";
@@ -102,18 +102,15 @@ interface AuthorPageTemplateProps {
   author: AuthorEntry;
   // Articles can be passed in (fetched from WordPress) or use author's hardcoded articles
   featuredArticles?: FeaturedArticle[];
-  recentArticles?: RecentArticle[];
 }
 
 export default function AuthorPageTemplate({
   author,
   featuredArticles,
-  recentArticles,
 }: AuthorPageTemplateProps) {
   // Use passed articles or fall back to author's hardcoded articles
   const displayFeaturedArticles =
     featuredArticles ?? author.featuredArticles ?? [];
-  const displayRecentArticles = recentArticles ?? author.recentArticles ?? [];
 
   return (
     // <article> (not <main>) — the blog layout already provides the <main> landmark.
@@ -561,64 +558,6 @@ export default function AuthorPageTemplate({
         </section>
       )}
 
-      {/* Recent Articles */}
-      {displayRecentArticles.length > 0 && (
-        <section className="max-w-4xl mx-auto px-[29px] md:px-4 py-[16px]">
-          <h2 className="text-[24px] md:text-[26px] font-semibold text-[#333333] mb-4">
-            Recent Articles
-          </h2>
-
-          <div className="flex flex-col gap-[12px]">
-            {displayRecentArticles.map((article) => (
-              <div
-                key={article.id}
-                className="flex items-center gap-4 max-h-[96px] pb-[12px] border-b border-[#F2F2F2]"
-              >
-                <div className="relative w-[80px] h-[80px] overflow-hidden flex-shrink-0">
-                  <Image
-                    src={article.imageSrc}
-                    alt={article.title}
-                    fill
-                    className="object-cover"
-                  />
-                </div>
-                <div className="flex-1 flex flex-col gap-[12px]">
-                  <Link href={article.href}>
-                    <h3 className="text-base md:text-lg text-[#6B7280] underline line-clamp-2">
-                      {article.title}
-                    </h3>
-                  </Link>
-                  <p className="text-[12px] md:text-sm font-normal text-[#6B7280]">
-                    {article.date}
-                  </p>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          <Link
-            href="/blogs"
-            className="inline-flex items-center gap-2 text-primary text-[16px] font-medium mt-6 hover:underline"
-          >
-            View All Articles
-            <svg
-              className="w-4 h-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M17 8l4 4m0 0l-4 4m4-4H3"
-              />
-            </svg>
-          </Link>
-        </section>
-      )}
-
       {/* Areas of Expertise */}
       {author.areasOfExpertise.length > 0 && (
         <section className="max-w-4xl mx-auto px-[29px] md:px-4 py-[16px]">
@@ -700,7 +639,7 @@ export default function AuthorPageTemplate({
                   className="flex items-center justify-center gap-2 text-[14px] md:text-base font-medium text-primary px-6 py-3 rounded-full bg-white"
                 >
                   {SocialIcons.linkedin}
-                  {author.ctaButtonLabel || "Subscribe Now"}
+                  {author.ctaButtonLabel || "Connect Now"}
                 </a>
               </div>
             )}

--- a/data/authors.ts
+++ b/data/authors.ts
@@ -44,14 +44,6 @@ export interface FeaturedArticle {
   href: string;
 }
 
-export interface RecentArticle {
-  id: string;
-  title: string;
-  date: string;
-  imageSrc: string;
-  href: string;
-}
-
 export interface Certification {
   name: string;
   issuer?: string; // issuing body / event (e.g., "SIGFEST")
@@ -101,7 +93,6 @@ export interface AuthorEntry {
 
   // Articles - fetched from WordPress automatically if wordpressSlug/wordpressAuthorId is set
   featuredArticles?: FeaturedArticle[]; // Optional hardcoded fallback
-  recentArticles?: RecentArticle[]; // Optional hardcoded fallback
 
   // Expertise tags
   areasOfExpertise: string[];
@@ -115,7 +106,7 @@ export interface AuthorEntry {
   speakingEmail?: string;
   responseTime?: string;
   linkedinSubscribe?: string;
-  ctaButtonLabel?: string; // overrides the default "Subscribe Now" label on the LinkedIn CTA
+  ctaButtonLabel?: string; // overrides the default "Connect Now" label on the LinkedIn CTA
 
   // Footer info
   lastUpdated: string;
@@ -260,7 +251,6 @@ export const authors: AuthorEntry[] = [
 
     // Articles fetched from WordPress - no hardcoded articles
     featuredArticles: [],
-    recentArticles: [],
 
     areasOfExpertise: [
       "Creator Economy",
@@ -340,7 +330,6 @@ export const authors: AuthorEntry[] = [
 
     // Articles fetched from WordPress - no hardcoded articles needed
     featuredArticles: [],
-    recentArticles: [],
 
     areasOfExpertise: [
       "Creator Payments",
@@ -433,7 +422,6 @@ export const authors: AuthorEntry[] = [
     mediaMentions: [],
 
     featuredArticles: [],
-    recentArticles: [],
 
     areasOfExpertise: [
       "Business for Creators",
@@ -524,7 +512,6 @@ export const authors: AuthorEntry[] = [
     mediaMentions: [],
 
     featuredArticles: [],
-    recentArticles: [],
 
     areasOfExpertise: [
       "Creator Invoicing",
@@ -638,7 +625,6 @@ export const authors: AuthorEntry[] = [
     ],
 
     featuredArticles: [],
-    recentArticles: [],
 
     areasOfExpertise: [
       "AI Strategy",
@@ -747,7 +733,6 @@ export const authors: AuthorEntry[] = [
     ],
 
     featuredArticles: [],
-    recentArticles: [],
 
     areasOfExpertise: [
       "Growth Strategy",
@@ -869,7 +854,6 @@ export const authors: AuthorEntry[] = [
 
     // Articles fetched from WordPress - no hardcoded articles
     featuredArticles: [],
-    recentArticles: [],
 
     areasOfExpertise: [
       "Creator Economy",
@@ -988,7 +972,6 @@ export const authors: AuthorEntry[] = [
     mediaMentions: [],
 
     featuredArticles: [],
-    recentArticles: [],
 
     areasOfExpertise: [
       "Multimodal Retrieval",
@@ -1119,7 +1102,6 @@ export const authors: AuthorEntry[] = [
     mediaMentions: [],
 
     featuredArticles: [],
-    recentArticles: [],
 
     areasOfExpertise: [
       "AI Agents",
@@ -1226,7 +1208,6 @@ export const authors: AuthorEntry[] = [
     mediaMentions: [],
 
     featuredArticles: [],
-    recentArticles: [],
 
     areasOfExpertise: [
       "Creator Economy",


### PR DESCRIPTION
Author profiles now surface only Featured Articles. Removing the section also removes the plumbing that existed solely to feed it: the `recentArticles` prop and local, the `RecentArticle` type, its optional field on AuthorEntry, and ten dead `recentArticles: []` entries.

Falls out of that: `getPosts(1, 3)` was fetching the site-wide latest posts purely to populate the section, so it was a dead WordPress round-trip on every author page. The two-fetch `Promise.allSettled` collapses to a single awaited call that still degrades to an empty list when the fetch fails.

The LinkedIn CTA default label becomes "Connect Now" -- the two authors setting `ctaButtonLabel` explicitly still override it, and the newsletter "Subscribe Now" buttons in BlogHeader are unrelated and untouched.

Note: the "View All Articles" link lived inside the removed section, so an author profile currently has no route back to /blogs. Featured is `slice(0, 3)`, so authors with more posts have the remainder unreachable from their profile -- worth restoring that link under Featured.