### PR TITLE
docs(portfolio): replace TO CHECK notes with verified behaviour

### DIFF
--- a/app/creator/portfolio/PortfolioPage.tsx
+++ b/app/creator/portfolio/PortfolioPage.tsx
@@ -48,15 +48,10 @@ function CreatorPortfolioPageContent() {
   // null and HeroSection falls back to the bundled placeholder clip, which is
   // exactly the "want a portfolio like @X" version.
   //
-  // TO CHECK: the happy path here is unverified. What's been confirmed is the
-  // endpoint exists on both app-api-dev and app-api (unknown slug → 404), and
-  // that CORS allows dev.sparkonomy.com / www.sparkonomy.com respectively. What
-  // hasn't: an actual portfolio slug returning hero media, and that media
-  // rendering in the band. Open /creator/portfolio?portfolio_slug=<real-slug>
-  // and confirm the creator's own video plays instead of the placeholder.
-  // Note the failure mode is silent by design — every error becomes the
-  // placeholder clip, so a wrong field name or shape would look like a creator
-  // who simply has no video. Check the network tab, not just the page.
+  // Worth knowing when this looks broken: every failure path collapses to the
+  // placeholder clip, so a bad slug, a CORS rejection and a creator who simply
+  // has no hero video all render identically. Check the network tab, not the
+  // page. `?portfolio_slug=pandit_baller` is a known-good slug on dev.
   const portfolioSlug = searchParams.get("portfolio_slug");
   const { data: userDetails } = usePortfolioUserDetails(portfolioSlug);
 

--- a/lib/portfolio/api.ts
+++ b/lib/portfolio/api.ts
@@ -16,14 +16,10 @@ const TIMEOUT_MS = 10_000;
  *
  * Returns `null` rather than throwing when the portfolio doesn't exist, the
  * request times out, or the network fails — the hero has a placeholder for
- * every one of those cases, so there's nothing for a caller to handle.
- *
- * TO CHECK: only exercised against a 404 so far. The response shape below is
- * taken from the creator app's contract (SectionEnvelope<'user_details',
- * UserDetailsData>) rather than from an observed 200 on this host — verify a
- * real slug returns `{ data: { hero_video_url, ... } }` and that the field
- * names still match types/portfolio.ts. Because every failure collapses to
- * `null`, a shape mismatch degrades quietly to the placeholder clip.
+ * every one of those cases, so there's nothing for a caller to handle. Note the
+ * flip side: a shape mismatch degrades just as quietly, so if the backend ever
+ * renames a `hero_*` field the hero silently reverts to the placeholder rather
+ * than erroring. types/portfolio.ts is the contract to re-check first.
  */
 export async function fetchPortfolioUserDetails(
   slug: string,


### PR DESCRIPTION
Comment-only change to the portfolio hero `user_details` path. No runtime code touched.

The `TO CHECK` blocks in [PortfolioPage.tsx](app/creator/portfolio/PortfolioPage.tsx) and [lib/portfolio/api.ts](lib/portfolio/api.ts) flagged the happy path as unverified — only the 404 case had been exercised. That path has since been confirmed against a real slug, so those open questions are stale.

What replaces them is the part still worth knowing: every failure path collapses to the placeholder clip, so a bad slug, a CORS rejection, a shape mismatch, and a creator with no hero video all render identically. The notes now say to check the network tab rather than the page, point at `types/portfolio.ts` as the contract to re-check first, and record `?portfolio_slug=pandit_baller` as a known-good slug on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)