### PR TITLE
fix(blog): decode HTML entities in plain-text WordPress strings

### DIFF
--- a/app/api/blog-md/[slug]/route.ts
+++ b/app/api/blog-md/[slug]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import TurndownService from "turndown";
-import { getPostBySlug } from "@/lib/wordpress-improved";
+import { getPostBySlug, stripHtml } from "@/lib/wordpress-improved";
 
 export const revalidate = 3600;
 
@@ -21,7 +21,7 @@ export async function GET(
     });
     const body = td.turndown(post.content.rendered);
     const md =
-        `# ${post.title.rendered}\n\n` +
+        `# ${stripHtml(post.title.rendered)}\n\n` +
         `> Source: https://www.sparkonomy.com/blogs/${post.slug}\n` +
         `> Published: ${post.date}\n\n` +
         body +

--- a/app/blogs/[slug]/page.tsx
+++ b/app/blogs/[slug]/page.tsx
@@ -252,7 +252,7 @@ export default async function BlogPostPage({ params, searchParams }: BlogPostPag
   const processedContent = openLinksInNewTab(lazyLoadImages(contentWithoutDuplicate));
 
   // Get category for breadcrumb and related resources
-  const categoryName = post._embedded?.["wp:term"]?.[0]?.[0]?.name || "";
+  const categoryName = decodeHtmlEntities(post._embedded?.["wp:term"]?.[0]?.[0]?.name || "");
   const categorySlug = post._embedded?.["wp:term"]?.[0]?.[0]?.slug || "";
   const categoryId = post._embedded?.["wp:term"]?.[0]?.[0]?.id;
 

--- a/app/preview/[slug]/page.tsx
+++ b/app/preview/[slug]/page.tsx
@@ -199,7 +199,7 @@ export default async function PreviewPostPage({ params }: PreviewPostPageProps) 
   const processedContent = openLinksInNewTab(lazyLoadImages(contentWithoutLeadingImage));
 
   // Get category for breadcrumb and related resources
-  const categoryName = post._embedded?.["wp:term"]?.[0]?.[0]?.name || "";
+  const categoryName = decodeHtmlEntities(post._embedded?.["wp:term"]?.[0]?.[0]?.name || "");
   const categoryId = post._embedded?.["wp:term"]?.[0]?.[0]?.id;
 
   // Fetch related draft posts (more posts to have enough for both sections)

--- a/lib/content-processor.ts
+++ b/lib/content-processor.ts
@@ -3,6 +3,8 @@
  * Removes WordPress TOC and extracts headings for custom TOC
  */
 
+import { decodeEntities } from '@/lib/html-entities';
+
 /**
  * H6 marker keywords recognized server-side.
  * Must stay in sync with components/blog/section-registry.ts
@@ -183,11 +185,7 @@ function slugifyHeadingText(text: string): string {
  * into the comparison key.
  */
 function headingMatchKey(text: string): string {
-  return text
-    .replace(/&#(\d+);/g, (_, code: string) => String.fromCharCode(Number(code)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, code: string) => String.fromCharCode(parseInt(code, 16)))
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
+  return decodeEntities(text)
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '');
 }
@@ -432,7 +430,9 @@ export function extractFAQs(html: string): FAQItem[] {
   let questionMatch;
 
   while ((questionMatch = headingRegex.exec(faqSectionHtml)) !== null) {
-    const question = questionMatch[2].replace(/<[^>]*>/g, '').trim();
+    // Decoded: FAQ text goes straight into JSON-LD as plain text, so a raw
+    // &#8217; would ship to search engines verbatim.
+    const question = decodeEntities(questionMatch[2].replace(/<[^>]*>/g, '')).trim();
 
     // Find the answer (paragraph(s) following the question)
     const afterQuestion = faqSectionHtml.substring(questionMatch.index + questionMatch[0].length);
@@ -448,7 +448,7 @@ export function extractFAQs(html: string): FAQItem[] {
         break;
       }
 
-      const answerText = pMatch[1].replace(/<[^>]*>/g, '').trim();
+      const answerText = decodeEntities(pMatch[1].replace(/<[^>]*>/g, '')).trim();
       if (answerText) {
         answerParts.push(answerText);
       }
@@ -482,8 +482,8 @@ function extractGutenbergAccordionFAQs(html: string): FAQItem[] {
 
   let match;
   while ((match = itemRegex.exec(html)) !== null) {
-    const question = match[1].replace(/<[^>]*>/g, '').trim();
-    const answer = match[2].replace(/<[^>]*>/g, '').trim();
+    const question = decodeEntities(match[1].replace(/<[^>]*>/g, '')).trim();
+    const answer = decodeEntities(match[2].replace(/<[^>]*>/g, '')).trim();
 
     if (question && answer) {
       faqs.push({ question, answer });

--- a/lib/html-entities.ts
+++ b/lib/html-entities.ts
@@ -1,0 +1,98 @@
+/**
+ * HTML entity decoding for WordPress-sourced text.
+ *
+ * The WP REST API returns `title.rendered` / `excerpt.rendered` as HTML, so an
+ * apostrophe arrives as `&#8217;`. That is fine when the string is fed to
+ * `dangerouslySetInnerHTML`, but anywhere we render it as plain text (React
+ * text nodes, breadcrumbs, `metadata`, JSON-LD, `alt`/`title` attributes) the
+ * entity leaks through literally as "Creator&#8217;s".
+ */
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  // Plain space rather than U+00A0 — these strings end up in meta tags and
+  // truncated labels where a non-breaking space is more trouble than it's worth.
+  nbsp: " ",
+  ensp: " ",
+  emsp: " ",
+  thinsp: " ",
+  shy: "",
+  hellip: "…",
+  rsquo: "’",
+  lsquo: "‘",
+  sbquo: "‚",
+  rdquo: "”",
+  ldquo: "“",
+  bdquo: "„",
+  ndash: "–",
+  mdash: "—",
+  minus: "−",
+  bull: "•",
+  middot: "·",
+  copy: "©",
+  reg: "®",
+  trade: "™",
+  euro: "€",
+  pound: "£",
+  yen: "¥",
+  cent: "¢",
+  deg: "°",
+  laquo: "«",
+  raquo: "»",
+  times: "×",
+  divide: "÷",
+  plusmn: "±",
+  frac12: "½",
+  frac14: "¼",
+  frac34: "¾",
+  dagger: "†",
+  permil: "‰",
+  prime: "′",
+  Prime: "″",
+  larr: "←",
+  rarr: "→",
+  uarr: "↑",
+  darr: "↓",
+  harr: "↔",
+  infin: "∞",
+  ne: "≠",
+  le: "≤",
+  ge: "≥",
+};
+
+/**
+ * Decode HTML entities in a string. Handles every numeric/hex entity plus the
+ * named entities WordPress actually emits.
+ *
+ * Single pass on purpose: decoding `&amp;` and `&#38;` in separate passes would
+ * turn double-encoded input like `&amp;lt;` into a real `<`.
+ */
+export function decodeEntities(text: string): string {
+  return text.replace(
+    /&(#[Xx][0-9a-fA-F]+|#\d+|[a-zA-Z][a-zA-Z0-9]*);/g,
+    (match, body: string) => {
+      if (body[0] === "#") {
+        const isHex = body[1] === "x" || body[1] === "X";
+        const code = parseInt(isHex ? body.slice(2) : body.slice(1), isHex ? 16 : 10);
+        // Reject out-of-range and surrogate code points — String.fromCodePoint
+        // throws on those, and a malformed entity shouldn't crash a page render.
+        if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) return match;
+        if (code >= 0xd800 && code <= 0xdfff) return match;
+        return String.fromCodePoint(code);
+      }
+      return NAMED_ENTITIES[body] ?? match;
+    }
+  );
+}
+
+/**
+ * Strip HTML tags and decode entities, leaving plain text safe to render as a
+ * React text node or drop into `metadata`.
+ */
+export function htmlToText(html: string): string {
+  return decodeEntities(html.replace(/<[^>]*>/g, ""));
+}

--- a/lib/wordpress-improved.ts
+++ b/lib/wordpress-improved.ts
@@ -4,6 +4,7 @@
  */
 
 import type { WordPressPost, WordPressCategory, WordPressTag, WordPressAuthor } from "@/types/wordpress";
+import { htmlToText } from "@/lib/html-entities";
 
 const WORDPRESS_URL = process.env.NEXT_PUBLIC_WORDPRESS_API_URL || "https://blog.sparkonomy.com/wp-json/wp/v2";
 
@@ -332,39 +333,19 @@ export async function getAllPostSlugs(): Promise<string[]> {
 // ============================================================================
 
 /**
- * Strip HTML tags from content
+ * Strip HTML tags from content and decode HTML entities, so the result is safe
+ * to render as plain text (breadcrumbs, metadata, JSON-LD, alt/title attrs).
  */
 export function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, "");
+  return htmlToText(html);
 }
 
 /**
- * Strip HTML tags and decode HTML entities from text.
- * Handles all numeric/hex entities generically, plus common named entities.
+ * Strip HTML tags and decode HTML entities from text, and collapse WordPress'
+ * "[&hellip;]" excerpt marker into a plain ellipsis.
  */
 export function decodeHtmlEntities(text: string): string {
-  return text
-    .replace(/<[^>]*>/g, '')
-    // Generic numeric & hex entities (catches ALL numeric codes)
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
-    // Named entities
-    .replace(/&hellip;/g, '…')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&copy;/g, '©')
-    .replace(/&reg;/g, '®')
-    .replace(/&euro;/g, '€')
-    .replace(/&deg;/g, '°')
-    .replace(/&rsquo;/g, '\u2019')
-    .replace(/&lsquo;/g, '\u2018')
-    .replace(/&rdquo;/g, '\u201D')
-    .replace(/&ldquo;/g, '\u201C')
-    .replace(/&ndash;/g, '–')
-    .replace(/&mdash;/g, '—')
+  return htmlToText(text)
     .replace(/\[…\]/g, '…')
     .replace(/\[\.\.\.\]/g, '…')
     .trim();

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -1,4 +1,5 @@
 import type { WordPressPost, WordPressCategory, WordPressTag } from "@/types/wordpress";
+import { htmlToText } from "@/lib/html-entities";
 
 const WORDPRESS_API_URL = process.env.NEXT_PUBLIC_WORDPRESS_API_URL;
 
@@ -230,12 +231,12 @@ export async function searchPosts(
 }
 
 /**
- * Strip HTML tags from content
+ * Strip HTML tags from content and decode HTML entities
  * @param html - HTML string
- * @returns Plain text
+ * @returns Plain text (entities such as &#8217; decoded)
  */
 export function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, "");
+  return htmlToText(html);
 }
 
 /**


### PR DESCRIPTION
The WP REST API returns title.rendered / excerpt.rendered as HTML, so an apostrophe arrives as &#8217;. stripHtml() only removed tags, leaving the entity intact everywhere the string was rendered as plain text — the post breadcrumb ("A Creator&#8217;s Gover..."), page metadata, JSON-LD, share titles, image alt text, and the /api/blog-md output.

Add lib/html-entities.ts with a single-pass decoder covering all numeric/hex entities plus the named ones WordPress emits, and route stripHtml() (both WP clients) and decodeHtmlEntities() through it. A single pass matters: decoding &amp; and &#38; in separate passes turns double-encoded input like &amp;lt; into a real <.

Also decode FAQ question/answer text (goes straight into JSON-LD) and breadcrumb category names.