### PR TITLE
fix(blog): bound trust-para H6 section to a single paragraph

### DIFF
--- a/components/blog/section-registry.ts
+++ b/components/blog/section-registry.ts
@@ -61,6 +61,7 @@ export const SECTION_REGISTRY: SectionConfig[] = [
     type: "trust-para",
     wrapperClass: "trust-para-section",
     allowMultiple: true,
+    maxElements: 1,
   },
   {
     markers: [


### PR DESCRIPTION
Without maxElements, H6SectionParser collected every sibling after the <h6>trust para</h6> marker until the second heading - on drafts with no TOC marker right after (e.g. preview post 1591) it swallowed the whole intro plus the first H2 section, rendering it at the 16px trust-para size instead of the 20px body size. A trust para is one paragraph by design (CheckmarkEnhancer only decorates the first paragraph), so cap it like highlight-box already does.