### PR TITLE
fix(blog): bound trust-para H6 section to a single paragraph

### DIFF
--- a/app/blogs/wordpress-content.css
+++ b/app/blogs/wordpress-content.css
@@ -2557,6 +2557,22 @@
   line-height: 1.5;
 }
 
+/* The gap below the section usually comes from a following heading's margin-top
+   (e.g. the TOC's h2) collapsing through its wrapper; the trust paragraph itself
+   contributes nothing because the p:last-child rule zeroes it. When plain body
+   copy follows instead (paragraphs have no margin-top), that gap vanishes — so
+   the wrapper carries its own bottom margin, sized to the h2 rhythm. Adjacent
+   margins collapse, so the heading case keeps its existing spacing. */
+.wordpress-content .trust-para-section {
+  margin-bottom: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .wordpress-content .trust-para-section {
+    margin-bottom: 1.75rem;
+  }
+}
+
 /* ====================
    CHECKMARK EMOJI STYLING
    Replace green ✅ emoji with primary purple checkmark

--- a/components/blog/section-registry.ts
+++ b/components/blog/section-registry.ts
@@ -61,6 +61,7 @@ export const SECTION_REGISTRY: SectionConfig[] = [
     type: "trust-para",
     wrapperClass: "trust-para-section",
     allowMultiple: true,
+    maxElements: 1,
   },
   {
     markers: [


### PR DESCRIPTION
Without maxElements, H6SectionParser collected every sibling after the <h6>trust para</h6> marker until the second heading - on drafts with no TOC marker right after (e.g. preview post 1591) it swallowed the whole intro plus the first H2 section, rendering it at the 16px trust-para size instead of the 20px body size. A trust para is one paragraph by design (CheckmarkEnhancer only decorates the first paragraph), so cap it like highlight-box already does.